### PR TITLE
Add Browser Visit Logger Chrome extension

### DIFF
--- a/browser-visit-logger/extension/background.js
+++ b/browser-visit-logger/extension/background.js
@@ -1,0 +1,73 @@
+const NATIVE_HOST = 'com.browser.visit.logger';
+const TITLE_FLUSH_TIMEOUT_MS = 5000;
+
+// tabId -> { url, title, timestamp, timerId }
+const pendingVisits = new Map();
+
+function isTitleMeaningful(title, url) {
+  if (!title || title.trim() === '') return false;
+  try {
+    const u = new URL(url);
+    if (title === u.hostname) return false;
+    if (title === url) return false;
+  } catch (_) {}
+  return true;
+}
+
+function flushVisit(tabId) {
+  const entry = pendingVisits.get(tabId);
+  if (!entry) return;
+  pendingVisits.delete(tabId);
+  clearTimeout(entry.timerId);
+
+  const payload = {
+    timestamp: entry.timestamp,
+    url:       entry.url,
+    title:     entry.title || entry.url,
+  };
+
+  chrome.runtime.sendNativeMessage(NATIVE_HOST, payload, (response) => {
+    if (chrome.runtime.lastError) {
+      console.error('[BVL] Native message error:', chrome.runtime.lastError.message);
+    }
+  });
+}
+
+chrome.webNavigation.onCompleted.addListener((details) => {
+  // Only log main frame navigations, not iframes
+  if (details.frameId !== 0) return;
+
+  const timestamp = new Date().toISOString();
+
+  chrome.tabs.get(details.tabId, (tab) => {
+    if (chrome.runtime.lastError) return;
+
+    const title = (tab && tab.title) ? tab.title : '';
+
+    // If the title is already meaningful, send immediately
+    if (isTitleMeaningful(title, details.url)) {
+      chrome.runtime.sendNativeMessage(NATIVE_HOST, { timestamp, url: details.url, title }, (response) => {
+        if (chrome.runtime.lastError) {
+          console.error('[BVL] Native message error:', chrome.runtime.lastError.message);
+        }
+      });
+      return;
+    }
+
+    // Park the entry and wait for the title to arrive or the timeout to fire
+    if (pendingVisits.has(details.tabId)) {
+      clearTimeout(pendingVisits.get(details.tabId).timerId);
+    }
+
+    const timerId = setTimeout(() => flushVisit(details.tabId), TITLE_FLUSH_TIMEOUT_MS);
+    pendingVisits.set(details.tabId, { url: details.url, title, timestamp, timerId });
+  });
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  if (!changeInfo.title) return;
+  if (!pendingVisits.has(tabId)) return;
+
+  pendingVisits.get(tabId).title = changeInfo.title;
+  flushVisit(tabId);
+});

--- a/browser-visit-logger/extension/manifest.json
+++ b/browser-visit-logger/extension/manifest.json
@@ -1,0 +1,15 @@
+{
+  "manifest_version": 3,
+  "name": "Browser Visit Logger",
+  "version": "1.0.0",
+  "description": "Logs every page visit (URL, title, timestamp) to disk via native messaging.",
+  "permissions": [
+    "tabs",
+    "webNavigation",
+    "nativeMessaging"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "key": "__GENERATED_PUBLIC_KEY__"
+}

--- a/browser-visit-logger/install.sh
+++ b/browser-visit-logger/install.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# install.sh — Sets up the Browser Visit Logger native messaging host.
+#
+# What this script does:
+#   1. Generates a 2048-bit RSA key pair (once) so the Chrome extension gets a
+#      deterministic, stable ID based on the public key.
+#   2. Embeds the base64 public key into extension/manifest.json ("key" field).
+#   3. Computes the resulting Extension ID (SHA-256 of DER pubkey, nibble-mapped
+#      to letters a-p, first 32 chars).
+#   4. Makes native-host/host.py executable.
+#   5. Installs the native messaging host manifest (with real path + extension ID)
+#      to ~/.config/google-chrome/NativeMessagingHosts/ and/or
+#      ~/.config/chromium/NativeMessagingHosts/ depending on what's installed.
+#   6. Prints instructions for loading the unpacked extension in Chrome.
+#
+# Usage:
+#   bash install.sh
+#
+# Requirements: python3, openssl
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Resolve the repo root (directory containing this script)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTENSION_DIR="$SCRIPT_DIR/extension"
+NATIVE_DIR="$SCRIPT_DIR/native-host"
+MANIFEST_JSON="$EXTENSION_DIR/manifest.json"
+HOST_MANIFEST_TEMPLATE="$NATIVE_DIR/com.browser.visit.logger.json"
+HOST_PY="$NATIVE_DIR/host.py"
+KEY_PEM="$NATIVE_DIR/generated_key.pem"
+HOST_NAME="com.browser.visit.logger"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+info()  { echo "[install] $*"; }
+error() { echo "[install] ERROR: $*" >&2; exit 1; }
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || error "'$1' is required but not found in PATH."
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight checks
+# ---------------------------------------------------------------------------
+require_cmd python3
+require_cmd openssl
+
+# ---------------------------------------------------------------------------
+# Step 1: Generate RSA key pair (skip if already done)
+# ---------------------------------------------------------------------------
+if [[ ! -f "$KEY_PEM" ]]; then
+  info "Generating 2048-bit RSA key pair at $KEY_PEM ..."
+  openssl genrsa -out "$KEY_PEM" 2048 2>/dev/null
+  info "Key pair generated."
+else
+  info "RSA key already exists at $KEY_PEM, skipping generation."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: Extract DER-encoded public key and base64-encode it for manifest.json
+# ---------------------------------------------------------------------------
+DER_TMP="$(mktemp)"
+trap 'rm -f "$DER_TMP"' EXIT
+
+openssl rsa -in "$KEY_PEM" -pubout -outform DER -out "$DER_TMP" 2>/dev/null
+
+# Base64-encode the DER (no line breaks — Chrome wants a single long string)
+PUBLIC_KEY_B64="$(base64 < "$DER_TMP" | tr -d '\n')"
+
+# Patch the "key" field in manifest.json
+info "Embedding public key into $MANIFEST_JSON ..."
+python3 - "$MANIFEST_JSON" "$PUBLIC_KEY_B64" <<'PYEOF'
+import json, sys
+path, key_b64 = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    data = json.load(f)
+data['key'] = key_b64
+with open(path, 'w') as f:
+    json.dump(data, f, indent=2)
+    f.write('\n')
+PYEOF
+
+# ---------------------------------------------------------------------------
+# Step 3: Compute the Extension ID from the DER public key
+# ---------------------------------------------------------------------------
+EXTENSION_ID="$(python3 - "$DER_TMP" <<'PYEOF'
+import sys, hashlib
+with open(sys.argv[1], 'rb') as f:
+    der = f.read()
+digest = hashlib.sha256(der).digest()
+# Chrome maps each nibble to the letters a-p (a=0, b=1, ..., p=15)
+chars = ''.join(
+    chr(ord('a') + b)
+    for byte in digest[:16]
+    for b in (byte >> 4, byte & 0xf)
+)
+print(chars)
+PYEOF
+)"
+
+info "Extension ID: $EXTENSION_ID"
+
+# ---------------------------------------------------------------------------
+# Step 4: Make host.py executable
+# ---------------------------------------------------------------------------
+chmod +x "$HOST_PY"
+info "Made $HOST_PY executable."
+
+# Resolve the absolute real path to host.py (no symlinks)
+HOST_PY_ABS="$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$HOST_PY")"
+
+# ---------------------------------------------------------------------------
+# Step 5: Build the filled-in native host manifest and install it
+# ---------------------------------------------------------------------------
+FILLED_MANIFEST="$(python3 - "$HOST_MANIFEST_TEMPLATE" "$HOST_PY_ABS" "$EXTENSION_ID" <<'PYEOF'
+import json, sys
+template_path, host_path, ext_id = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(template_path) as f:
+    data = json.load(f)
+data['path'] = host_path
+data['allowed_origins'] = [f'chrome-extension://{ext_id}/']
+print(json.dumps(data, indent=2))
+PYEOF
+)"
+
+INSTALLED=0
+
+# Chrome (stable)
+CHROME_DIR="$HOME/.config/google-chrome/NativeMessagingHosts"
+if [[ -d "$HOME/.config/google-chrome" ]] || command -v google-chrome >/dev/null 2>&1 || command -v google-chrome-stable >/dev/null 2>&1; then
+  mkdir -p "$CHROME_DIR"
+  echo "$FILLED_MANIFEST" > "$CHROME_DIR/$HOST_NAME.json"
+  info "Installed native host manifest for Chrome at $CHROME_DIR/$HOST_NAME.json"
+  INSTALLED=1
+fi
+
+# Chromium
+CHROMIUM_DIR="$HOME/.config/chromium/NativeMessagingHosts"
+if [[ -d "$HOME/.config/chromium" ]] || command -v chromium >/dev/null 2>&1 || command -v chromium-browser >/dev/null 2>&1; then
+  mkdir -p "$CHROMIUM_DIR"
+  echo "$FILLED_MANIFEST" > "$CHROMIUM_DIR/$HOST_NAME.json"
+  info "Installed native host manifest for Chromium at $CHROMIUM_DIR/$HOST_NAME.json"
+  INSTALLED=1
+fi
+
+# Fallback: install for both if neither config dir was detected
+if [[ $INSTALLED -eq 0 ]]; then
+  mkdir -p "$CHROME_DIR" "$CHROMIUM_DIR"
+  echo "$FILLED_MANIFEST" > "$CHROME_DIR/$HOST_NAME.json"
+  echo "$FILLED_MANIFEST" > "$CHROMIUM_DIR/$HOST_NAME.json"
+  info "No browser config dir detected; installed manifest to both Chrome and Chromium locations."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 6: Print next-step instructions
+# ---------------------------------------------------------------------------
+cat <<EOF
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Browser Visit Logger — Installation complete
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Extension ID : $EXTENSION_ID
+Extension dir: $EXTENSION_DIR
+Native host  : $HOST_PY_ABS
+
+Next steps:
+  1. Open Chrome and go to: chrome://extensions
+  2. Enable "Developer mode" (top-right toggle).
+  3. Click "Load unpacked" and select:
+       $EXTENSION_DIR
+  4. Verify the extension ID shown in Chrome matches:
+       $EXTENSION_ID
+     (It should — the "key" field in manifest.json pins the ID.)
+  5. Navigate to any web page. Then check:
+       tail ~/browser-visits.log
+       sqlite3 ~/browser-visits.db "SELECT * FROM visits ORDER BY id DESC LIMIT 10;"
+
+If Chrome shows a different extension ID, re-run this script to regenerate.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+EOF

--- a/browser-visit-logger/native-host/com.browser.visit.logger.json
+++ b/browser-visit-logger/native-host/com.browser.visit.logger.json
@@ -1,0 +1,9 @@
+{
+  "name": "com.browser.visit.logger",
+  "description": "Writes browser visit records (URL, title, timestamp) to disk",
+  "path": "__HOST_PATH__",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://__EXTENSION_ID__/"
+  ]
+}

--- a/browser-visit-logger/native-host/host.py
+++ b/browser-visit-logger/native-host/host.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Native messaging host for Browser Visit Logger.
+
+Receives a single JSON visit record from Chrome via stdin (native messaging
+protocol: 4-byte LE length prefix + UTF-8 JSON), writes the record to a TSV
+log file and a SQLite database, then sends a JSON response to stdout.
+
+Chrome launches this script once per sendNativeMessage() call (MV3 one-shot
+semantics): read one message → write outputs → respond → exit.
+"""
+
+import json
+import logging
+import os
+import sqlite3
+import struct
+import sys
+from datetime import datetime, timezone
+from logging.handlers import RotatingFileHandler
+
+# ---------------------------------------------------------------------------
+# Paths (all in the user's home directory)
+# ---------------------------------------------------------------------------
+HOME     = os.path.expanduser('~')
+LOG_FILE = os.path.join(HOME, 'browser-visits.log')
+DB_FILE  = os.path.join(HOME, 'browser-visits.db')
+HOST_LOG = os.path.join(HOME, 'browser-visits-host.log')
+
+# ---------------------------------------------------------------------------
+# Host process logging (errors/debug — never written to stderr)
+# ---------------------------------------------------------------------------
+_handler = RotatingFileHandler(HOST_LOG, maxBytes=1_048_576, backupCount=3)
+_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(message)s'))
+logger = logging.getLogger('bvl')
+logger.setLevel(logging.DEBUG)
+logger.addHandler(_handler)
+
+# ---------------------------------------------------------------------------
+# Native messaging I/O
+# ---------------------------------------------------------------------------
+
+def read_message() -> dict:
+    """Read one native message from stdin (binary mode)."""
+    raw_length = sys.stdin.buffer.read(4)
+    if len(raw_length) < 4:
+        raise EOFError('stdin closed before length header was complete')
+    msg_length = struct.unpack('<I', raw_length)[0]
+    raw_message = sys.stdin.buffer.read(msg_length)
+    if len(raw_message) < msg_length:
+        raise EOFError('stdin closed mid-message')
+    return json.loads(raw_message.decode('utf-8'))
+
+
+def write_message(payload: dict) -> None:
+    """Write one native message to stdout (binary mode)."""
+    encoded = json.dumps(payload, ensure_ascii=False).encode('utf-8')
+    sys.stdout.buffer.write(struct.pack('<I', len(encoded)))
+    sys.stdout.buffer.write(encoded)
+    sys.stdout.buffer.flush()
+
+# ---------------------------------------------------------------------------
+# SQLite helpers
+# ---------------------------------------------------------------------------
+
+def ensure_db(conn: sqlite3.Connection) -> None:
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS visits (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT    NOT NULL,
+            url       TEXT    NOT NULL,
+            title     TEXT    NOT NULL DEFAULT ''
+        )
+    """)
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_visits_timestamp ON visits(timestamp)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_visits_url ON visits(url)"
+    )
+    conn.commit()
+
+
+def insert_visit(conn: sqlite3.Connection, timestamp: str, url: str, title: str) -> None:
+    conn.execute(
+        "INSERT INTO visits (timestamp, url, title) VALUES (?, ?, ?)",
+        (timestamp, url, title),
+    )
+    conn.commit()
+
+# ---------------------------------------------------------------------------
+# Log file helper
+# ---------------------------------------------------------------------------
+
+def append_log(timestamp: str, url: str, title: str) -> None:
+    """Append one TSV line. Tabs and newlines in field values are replaced."""
+    def sanitise(s: str) -> str:
+        return s.replace('\t', ' ').replace('\n', ' ').replace('\r', '')
+
+    line = f"{sanitise(timestamp)}\t{sanitise(url)}\t{sanitise(title)}\n"
+    with open(LOG_FILE, 'a', encoding='utf-8') as f:
+        f.write(line)
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    try:
+        message = read_message()
+        logger.debug('Received: %s', message)
+    except Exception as exc:
+        logger.error('Failed to read message: %s', exc)
+        write_message({'status': 'error', 'message': str(exc)})
+        return
+
+    timestamp = message.get('timestamp') or datetime.now(timezone.utc).isoformat()
+    url       = message.get('url', '')
+    title     = message.get('title', '')
+
+    errors = []
+
+    # Write to TSV log (independent of DB write)
+    try:
+        append_log(timestamp, url, title)
+    except Exception as exc:
+        logger.error('Log file write failed: %s', exc)
+        errors.append(f'log: {exc}')
+
+    # Write to SQLite (independent of log write)
+    try:
+        conn = sqlite3.connect(DB_FILE)
+        ensure_db(conn)
+        insert_visit(conn, timestamp, url, title)
+        conn.close()
+    except Exception as exc:
+        logger.error('SQLite write failed: %s', exc)
+        errors.append(f'db: {exc}')
+
+    if errors:
+        write_message({'status': 'error', 'errors': errors})
+    else:
+        write_message({'status': 'ok'})
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Captures every browser visit (URL, title, timestamp) via a Manifest V3
Chrome extension and logs records to both a TSV text file and a SQLite
database through a Python native messaging host.

Structure:
- extension/manifest.json   — MV3 manifest (key field for stable ID)
- extension/background.js   — Service worker: webNavigation + tabs listeners,
                              deferred title capture with 5 s timeout flush
- native-host/host.py       — One-shot native messaging host: TSV + SQLite
- native-host/com.browser.visit.logger.json  — Host manifest template
- install.sh                — Keygen, ID computation, manifest install,
                              Chrome/Chromium support, setup instructions

https://claude.ai/code/session_01TWz5R72jjZju3VYx2GBLNM