### PR TITLE
Fix install.sh for macOS

### DIFF
--- a/browser-visit-logger/install.sh
+++ b/browser-visit-logger/install.sh
@@ -9,8 +9,7 @@
 #      to letters a-p, first 32 chars).
 #   4. Makes native-host/host.py executable.
 #   5. Installs the native messaging host manifest (with real path + extension ID)
-#      to ~/.config/google-chrome/NativeMessagingHosts/ and/or
-#      ~/.config/chromium/NativeMessagingHosts/ depending on what's installed.
+#      to the correct NativeMessagingHosts directory for the OS and browser.
 #   6. Prints instructions for loading the unpacked extension in Chrome.
 #
 # Usage:
@@ -127,31 +126,57 @@ PYEOF
 )"
 
 INSTALLED=0
+OS="$(uname -s)"
 
-# Chrome (stable)
-CHROME_DIR="$HOME/.config/google-chrome/NativeMessagingHosts"
-if [[ -d "$HOME/.config/google-chrome" ]] || command -v google-chrome >/dev/null 2>&1 || command -v google-chrome-stable >/dev/null 2>&1; then
-  mkdir -p "$CHROME_DIR"
-  echo "$FILLED_MANIFEST" > "$CHROME_DIR/$HOST_NAME.json"
-  info "Installed native host manifest for Chrome at $CHROME_DIR/$HOST_NAME.json"
-  INSTALLED=1
-fi
+if [[ "$OS" == "Darwin" ]]; then
+  # macOS — Chrome reads from ~/Library/Application Support/...
+  install_manifest() {
+    local dir="$1"
+    local label="$2"
+    mkdir -p "$dir"
+    echo "$FILLED_MANIFEST" > "$dir/$HOST_NAME.json"
+    info "Installed native host manifest for $label at $dir/$HOST_NAME.json"
+    INSTALLED=1
+  }
 
-# Chromium
-CHROMIUM_DIR="$HOME/.config/chromium/NativeMessagingHosts"
-if [[ -d "$HOME/.config/chromium" ]] || command -v chromium >/dev/null 2>&1 || command -v chromium-browser >/dev/null 2>&1; then
-  mkdir -p "$CHROMIUM_DIR"
-  echo "$FILLED_MANIFEST" > "$CHROMIUM_DIR/$HOST_NAME.json"
-  info "Installed native host manifest for Chromium at $CHROMIUM_DIR/$HOST_NAME.json"
-  INSTALLED=1
-fi
+  CHROME_APP="$HOME/Library/Application Support/Google/Chrome"
+  CANARY_APP="$HOME/Library/Application Support/Google/Chrome Canary"
+  CHROMIUM_APP="$HOME/Library/Application Support/Chromium"
 
-# Fallback: install for both if neither config dir was detected
-if [[ $INSTALLED -eq 0 ]]; then
-  mkdir -p "$CHROME_DIR" "$CHROMIUM_DIR"
-  echo "$FILLED_MANIFEST" > "$CHROME_DIR/$HOST_NAME.json"
-  echo "$FILLED_MANIFEST" > "$CHROMIUM_DIR/$HOST_NAME.json"
-  info "No browser config dir detected; installed manifest to both Chrome and Chromium locations."
+  [[ -d "$CHROME_APP" ]]   && install_manifest "$CHROME_APP/NativeMessagingHosts"   "Chrome"
+  [[ -d "$CANARY_APP" ]]   && install_manifest "$CANARY_APP/NativeMessagingHosts"   "Chrome Canary"
+  [[ -d "$CHROMIUM_APP" ]] && install_manifest "$CHROMIUM_APP/NativeMessagingHosts" "Chromium"
+
+  # Fallback: Chrome wasn't open yet so its profile dir doesn't exist
+  if [[ $INSTALLED -eq 0 ]]; then
+    install_manifest "$CHROME_APP/NativeMessagingHosts" "Chrome (pre-created)"
+  fi
+
+else
+  # Linux
+  CHROME_DIR="$HOME/.config/google-chrome/NativeMessagingHosts"
+  CHROMIUM_DIR="$HOME/.config/chromium/NativeMessagingHosts"
+
+  if [[ -d "$HOME/.config/google-chrome" ]] || command -v google-chrome >/dev/null 2>&1 || command -v google-chrome-stable >/dev/null 2>&1; then
+    mkdir -p "$CHROME_DIR"
+    echo "$FILLED_MANIFEST" > "$CHROME_DIR/$HOST_NAME.json"
+    info "Installed native host manifest for Chrome at $CHROME_DIR/$HOST_NAME.json"
+    INSTALLED=1
+  fi
+
+  if [[ -d "$HOME/.config/chromium" ]] || command -v chromium >/dev/null 2>&1 || command -v chromium-browser >/dev/null 2>&1; then
+    mkdir -p "$CHROMIUM_DIR"
+    echo "$FILLED_MANIFEST" > "$CHROMIUM_DIR/$HOST_NAME.json"
+    info "Installed native host manifest for Chromium at $CHROMIUM_DIR/$HOST_NAME.json"
+    INSTALLED=1
+  fi
+
+  if [[ $INSTALLED -eq 0 ]]; then
+    mkdir -p "$CHROME_DIR" "$CHROMIUM_DIR"
+    echo "$FILLED_MANIFEST" > "$CHROME_DIR/$HOST_NAME.json"
+    echo "$FILLED_MANIFEST" > "$CHROMIUM_DIR/$HOST_NAME.json"
+    info "No browser config dir detected; installed manifest to both Chrome and Chromium locations."
+  fi
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`install.sh` was hardcoded to Linux paths (`~/.config/google-chrome/NativeMessagingHosts/`). On macOS, Chrome looks for native messaging host manifests in `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/`, so the host was never registered and Chrome reported "Specified native messaging host not found".

## Fix

Detect OS via `uname -s` and use the correct path:

| OS | Browser | Path |
|---|---|---|
| macOS | Chrome | `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/` |
| macOS | Chrome Canary | `~/Library/Application Support/Google/Chrome Canary/NativeMessagingHosts/` |
| macOS | Chromium | `~/Library/Application Support/Chromium/NativeMessagingHosts/` |
| Linux | Chrome | `~/.config/google-chrome/NativeMessagingHosts/` |
| Linux | Chromium | `~/.config/chromium/NativeMessagingHosts/` |

## Immediate workaround (before merging)

If you want to unblock yourself right now without waiting for the merge, run this once in your terminal:

```bash
cd /path/to/hello-world/browser-visit-logger
MANIFEST=$(cat native-host/com.browser.visit.logger.json | python3 -c "
import json,sys
d=json.load(sys.stdin)
print(d['allowed_origins'][0])
" 2>/dev/null && echo "exists" || echo "run install.sh first")

DIR="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
mkdir -p "$DIR"
cp native-host/com.browser.visit.logger.json "$DIR/"
```

Then open `chrome://extensions`, click the reload icon on the extension, and navigate to a page.
