### PR TITLE
Add popup to tag visits as memorable or read

### DIFF
--- a/browser-visit-logger/extension/manifest.json.template
+++ b/browser-visit-logger/extension/manifest.json.template
@@ -11,5 +11,9 @@
   "background": {
     "service_worker": "background.js"
   },
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Browser Visit Logger"
+  },
   "key": "__GENERATED_PUBLIC_KEY__"
 }

--- a/browser-visit-logger/extension/popup.html
+++ b/browser-visit-logger/extension/popup.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <style>
+    body {
+      width: 200px;
+      padding: 14px;
+      font-family: sans-serif;
+      margin: 0;
+    }
+    h3 {
+      margin: 0 0 12px;
+      font-size: 14px;
+      color: #333;
+    }
+    button {
+      display: block;
+      width: 100%;
+      padding: 8px 12px;
+      margin-bottom: 8px;
+      cursor: pointer;
+      font-size: 13px;
+      text-align: left;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      background: #f5f5f5;
+    }
+    button:hover:not(:disabled) { background: #e0e0e0; }
+    button:disabled { opacity: 0.5; cursor: default; }
+    #status {
+      font-size: 12px;
+      color: #555;
+      margin-top: 6px;
+      min-height: 16px;
+    }
+  </style>
+</head>
+<body>
+  <h3>Mark this page</h3>
+  <button data-tag="memorable">&#9733; Memorable</button>
+  <button data-tag="read">&#10003; Read</button>
+  <div id="status"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/browser-visit-logger/extension/popup.js
+++ b/browser-visit-logger/extension/popup.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const NATIVE_HOST = 'com.browser.visit.logger';
+
+function showStatus(text) {
+  document.getElementById('status').textContent = text;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-tag]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      btn.disabled = true;
+      document.querySelectorAll('[data-tag]').forEach(b => { b.disabled = true; });
+
+      chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
+        if (!tab) {
+          showStatus('No active tab found.');
+          return;
+        }
+        const message = {
+          timestamp: new Date().toISOString(),
+          url:       tab.url,
+          title:     tab.title || tab.url,
+          tag:       btn.dataset.tag,
+        };
+        chrome.runtime.sendNativeMessage(NATIVE_HOST, message, (response) => {
+          if (chrome.runtime.lastError) {
+            showStatus('Error: ' + chrome.runtime.lastError.message);
+            document.querySelectorAll('[data-tag]').forEach(b => { b.disabled = false; });
+          } else if (response && response.status === 'ok') {
+            showStatus('Marked as \u201c' + btn.dataset.tag + '\u201d.');
+          } else {
+            showStatus('Write failed — check host log.');
+            document.querySelectorAll('[data-tag]').forEach(b => { b.disabled = false; });
+          }
+        });
+      });
+    });
+  });
+});

--- a/browser-visit-logger/native-host/host.py
+++ b/browser-visit-logger/native-host/host.py
@@ -8,6 +8,16 @@ log file and a SQLite database, then sends a JSON response to stdout.
 
 Chrome launches this script once per sendNativeMessage() call (MV3 one-shot
 semantics): read one message → write outputs → respond → exit.
+
+Message types
+-------------
+Auto-log (from background.js):
+    { "timestamp": "...", "url": "...", "title": "..." }
+    → INSERT new row; append 3-field TSV line.
+
+Tag action (from popup.js):
+    { "timestamp": "...", "url": "...", "title": "...", "tag": "memorable"|"read" }
+    → UPDATE tag on most recent row for that URL; append 4-field TSV line.
 """
 
 import json
@@ -69,9 +79,15 @@ def ensure_db(conn: sqlite3.Connection) -> None:
             id        INTEGER PRIMARY KEY AUTOINCREMENT,
             timestamp TEXT    NOT NULL,
             url       TEXT    NOT NULL,
-            title     TEXT    NOT NULL DEFAULT ''
+            title     TEXT    NOT NULL DEFAULT '',
+            tag       TEXT    NOT NULL DEFAULT ''
         )
     """)
+    # Migrate databases created before the tag column was added
+    try:
+        conn.execute("ALTER TABLE visits ADD COLUMN tag TEXT NOT NULL DEFAULT ''")
+    except sqlite3.OperationalError:
+        pass  # column already exists
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_visits_timestamp ON visits(timestamp)"
     )
@@ -88,16 +104,29 @@ def insert_visit(conn: sqlite3.Connection, timestamp: str, url: str, title: str)
     )
     conn.commit()
 
+
+def tag_visit(conn: sqlite3.Connection, url: str, tag: str) -> None:
+    """Set tag on the most recent visit for the given URL."""
+    conn.execute(
+        "UPDATE visits SET tag = ? "
+        "WHERE id = (SELECT id FROM visits WHERE url = ? ORDER BY id DESC LIMIT 1)",
+        (tag, url),
+    )
+    conn.commit()
+
 # ---------------------------------------------------------------------------
 # Log file helper
 # ---------------------------------------------------------------------------
 
-def append_log(timestamp: str, url: str, title: str) -> None:
-    """Append one TSV line. Tabs and newlines in field values are replaced."""
+def append_log(timestamp: str, url: str, title: str, tag: str = '') -> None:
+    """Append one TSV line (3 fields for auto-log, 4 fields when tag is set)."""
     def sanitise(s: str) -> str:
         return s.replace('\t', ' ').replace('\n', ' ').replace('\r', '')
 
-    line = f"{sanitise(timestamp)}\t{sanitise(url)}\t{sanitise(title)}\n"
+    fields = [sanitise(timestamp), sanitise(url), sanitise(title)]
+    if tag:
+        fields.append(sanitise(tag))
+    line = '\t'.join(fields) + '\n'
     with open(LOG_FILE, 'a', encoding='utf-8') as f:
         f.write(line)
 
@@ -117,6 +146,7 @@ def main() -> None:
     url       = (message.get('url') or '').strip()
     timestamp = (message.get('timestamp') or '').strip()
     title     = message.get('title') or ''
+    tag       = (message.get('tag') or '').strip()
 
     if not url:
         write_message({'status': 'error', 'message': 'url is required'})
@@ -129,7 +159,7 @@ def main() -> None:
 
     # Write to TSV log (independent of DB write)
     try:
-        append_log(timestamp, url, title)
+        append_log(timestamp, url, title, tag)
     except Exception as exc:
         logger.error('Log file write failed: %s', exc)
         errors.append(f'log: {exc}')
@@ -138,7 +168,10 @@ def main() -> None:
     try:
         conn = sqlite3.connect(DB_FILE)
         ensure_db(conn)
-        insert_visit(conn, timestamp, url, title)
+        if tag:
+            tag_visit(conn, url, tag)
+        else:
+            insert_visit(conn, timestamp, url, title)
         conn.close()
     except Exception as exc:
         logger.error('SQLite write failed: %s', exc)

--- a/browser-visit-logger/tests/test_host.py
+++ b/browser-visit-logger/tests/test_host.py
@@ -109,12 +109,12 @@ class TestWriteMessage(unittest.TestCase):
 
 class TestAppendLog(unittest.TestCase):
 
-    def _run(self, timestamp, url, title) -> str:
+    def _run(self, timestamp, url, title, tag='') -> str:
         """Call append_log with a temp file and return its contents."""
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, 'visits.log')
             with patch.object(host, 'LOG_FILE', path):
-                host.append_log(timestamp, url, title)
+                host.append_log(timestamp, url, title, tag)
             return Path(path).read_text(encoding='utf-8')
 
     def test_tsv_format(self):
@@ -152,6 +152,22 @@ class TestAppendLog(unittest.TestCase):
         self.assertEqual(len(lines), 2)
         self.assertIn('https://a.com', lines[0])
         self.assertIn('https://b.com', lines[1])
+
+    def test_tag_produces_four_fields(self):
+        content = self._run('ts', 'https://example.com', 'Example', tag='memorable')
+        parts = content.rstrip('\n').split('\t')
+        self.assertEqual(len(parts), 4)
+        self.assertEqual(parts[3], 'memorable')
+
+    def test_no_tag_produces_three_fields(self):
+        content = self._run('ts', 'https://example.com', 'Example')
+        parts = content.rstrip('\n').split('\t')
+        self.assertEqual(len(parts), 3)
+
+    def test_tag_sanitised(self):
+        content = self._run('ts', 'https://example.com', 'Example', tag='mem\torable')
+        parts = content.rstrip('\n').split('\t')
+        self.assertEqual(parts[3], 'mem orable')
 
 
 # ---------------------------------------------------------------------------
@@ -223,6 +239,83 @@ class TestDatabase(unittest.TestCase):
         row = conn.execute('SELECT title FROM visits').fetchone()
         conn.close()
         self.assertEqual(row[0], '日本語タイトル')
+
+    def test_ensure_db_creates_tag_column(self):
+        conn = self._conn()
+        cols = {r[1] for r in conn.execute('PRAGMA table_info(visits)')}
+        conn.close()
+        self.assertIn('tag', cols)
+
+    def test_ensure_db_migrates_existing_table(self):
+        # Simulate a pre-tag database (no tag column)
+        conn = sqlite3.connect(':memory:')
+        conn.execute("""
+            CREATE TABLE visits (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                url TEXT NOT NULL,
+                title TEXT NOT NULL DEFAULT ''
+            )
+        """)
+        conn.commit()
+        host.ensure_db(conn)  # must add tag column without error
+        cols = {r[1] for r in conn.execute('PRAGMA table_info(visits)')}
+        conn.close()
+        self.assertIn('tag', cols)
+
+    def test_insert_visit_tag_defaults_to_empty(self):
+        conn = self._conn()
+        host.insert_visit(conn, 'ts', 'https://example.com', 'Title')
+        row = conn.execute('SELECT tag FROM visits').fetchone()
+        conn.close()
+        self.assertEqual(row[0], '')
+
+
+# ---------------------------------------------------------------------------
+# tag_visit
+# ---------------------------------------------------------------------------
+
+class TestTagVisit(unittest.TestCase):
+
+    def _conn(self):
+        conn = sqlite3.connect(':memory:')
+        host.ensure_db(conn)
+        return conn
+
+    def test_tag_visit_updates_tag_field(self):
+        conn = self._conn()
+        host.insert_visit(conn, 'ts', 'https://example.com', 'Example')
+        host.tag_visit(conn, 'https://example.com', 'memorable')
+        row = conn.execute('SELECT tag FROM visits').fetchone()
+        conn.close()
+        self.assertEqual(row[0], 'memorable')
+
+    def test_tag_visit_updates_most_recent_only(self):
+        conn = self._conn()
+        host.insert_visit(conn, 'ts1', 'https://example.com', 'Example')
+        host.insert_visit(conn, 'ts2', 'https://example.com', 'Example')
+        host.tag_visit(conn, 'https://example.com', 'read')
+        rows = conn.execute('SELECT tag FROM visits ORDER BY id').fetchall()
+        conn.close()
+        self.assertEqual(rows[0][0], '')       # first visit unchanged
+        self.assertEqual(rows[1][0], 'read')   # only the most recent updated
+
+    def test_tag_visit_no_existing_visit_is_noop(self):
+        conn = self._conn()
+        host.tag_visit(conn, 'https://example.com', 'memorable')  # must not raise
+        count = conn.execute('SELECT COUNT(*) FROM visits').fetchone()[0]
+        conn.close()
+        self.assertEqual(count, 0)
+
+    def test_tag_visit_does_not_affect_other_urls(self):
+        conn = self._conn()
+        host.insert_visit(conn, 'ts1', 'https://a.com', 'A')
+        host.insert_visit(conn, 'ts2', 'https://b.com', 'B')
+        host.tag_visit(conn, 'https://a.com', 'memorable')
+        rows = conn.execute('SELECT url, tag FROM visits ORDER BY id').fetchall()
+        conn.close()
+        self.assertEqual(rows[0], ('https://a.com', 'memorable'))
+        self.assertEqual(rows[1], ('https://b.com', ''))
 
 
 # ---------------------------------------------------------------------------
@@ -390,6 +483,72 @@ class TestIntegration(unittest.TestCase):
         self.assertTrue(any('db' in e for e in resp.get('errors', [])))
         # But the log write must have succeeded independently
         self.assertIn('https://example.com', log_content)
+
+    def test_tag_message_updates_db_record(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # Auto-log the visit first
+            self._invoke(
+                {'timestamp': 'ts', 'url': 'https://example.com', 'title': 'Example'},
+                tmp,
+            )
+            # Tag the visit
+            resp = self._invoke(
+                {'timestamp': 'ts2', 'url': 'https://example.com', 'title': 'Example', 'tag': 'memorable'},
+                tmp,
+            )
+            self.assertEqual(resp['status'], 'ok')
+            conn = sqlite3.connect(os.path.join(tmp, 'visits.db'))
+            row = conn.execute('SELECT tag FROM visits ORDER BY id DESC LIMIT 1').fetchone()
+            conn.close()
+        self.assertEqual(row[0], 'memorable')
+
+    def test_tag_message_appends_four_field_log_line(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._invoke(
+                {'timestamp': 'ts', 'url': 'https://example.com', 'title': 'Example', 'tag': 'read'},
+                tmp,
+            )
+            lines = Path(tmp, 'visits.log').read_text().splitlines()
+        self.assertEqual(len(lines), 1)
+        parts = lines[0].split('\t')
+        self.assertEqual(len(parts), 4)
+        self.assertEqual(parts[3], 'read')
+
+    def test_auto_log_appends_three_field_log_line(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._invoke(
+                {'timestamp': 'ts', 'url': 'https://example.com', 'title': 'Example'},
+                tmp,
+            )
+            lines = Path(tmp, 'visits.log').read_text().splitlines()
+        self.assertEqual(len(lines[0].split('\t')), 3)
+
+    def test_tag_without_prior_visit_succeeds(self):
+        # tag_visit is a no-op UPDATE when the URL has no prior visit
+        with tempfile.TemporaryDirectory() as tmp:
+            resp = self._invoke(
+                {'timestamp': 'ts', 'url': 'https://example.com', 'title': 'Example', 'tag': 'memorable'},
+                tmp,
+            )
+            self.assertEqual(resp['status'], 'ok')
+            # Log line still written
+            self.assertIn('memorable', Path(tmp, 'visits.log').read_text())
+            # DB exists but has no rows (UPDATE on empty table is a no-op)
+            conn = sqlite3.connect(os.path.join(tmp, 'visits.db'))
+            count = conn.execute('SELECT COUNT(*) FROM visits').fetchone()[0]
+            conn.close()
+        self.assertEqual(count, 0)
+
+    def test_auto_log_tag_column_defaults_to_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._invoke(
+                {'timestamp': 'ts', 'url': 'https://example.com', 'title': 'Example'},
+                tmp,
+            )
+            conn = sqlite3.connect(os.path.join(tmp, 'visits.db'))
+            row = conn.execute('SELECT tag FROM visits').fetchone()
+            conn.close()
+        self.assertEqual(row[0], '')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- **New popup UI** (`extension/popup.html` + `popup.js`): clicking the extension icon shows two buttons — ⭐ Memorable and ✓ Read
- **manifest.json.template**: adds `"action": {"default_popup": "popup.html"}` to wire up the popup
- **host.py**: adds a `tag` column to the `visits` table (with automatic migration for existing databases), a new `tag_visit()` function that updates the most recent row for a given URL, and updates `append_log()` to write a 4-field TSV line when a tag is present
- **test_host.py**: 14 new tests covering schema migration, `tag_visit` behaviour, and tag integration paths (50 passing total)

## How it works

1. User navigates to a page → visit is auto-logged as before (3-field TSV line, INSERT into DB with empty tag)
2. User clicks the extension icon → popup opens
3. User clicks **Memorable** or **Read** → popup sends a native message with `{timestamp, url, title, tag}`
4. `host.py` appends a 4-field TSV line to `browser-visits.log` and UPDATEs the `tag` column on the most recent row for that URL in `browser-visits.db`

## After merging

Re-run `bash install.sh` to regenerate `extension/manifest.json` from the updated template, then reload the extension in Chrome (`chrome://extensions` → click the reload icon).

## Test plan

- [ ] Run `pytest tests/test_host.py -v` — all 50 tests pass
- [ ] Load the unpacked extension in Chrome
- [ ] Navigate to a page, click the extension icon, verify the popup appears with both buttons
- [ ] Click **Memorable** — verify the status message updates and `browser-visits.log` gains a 4-field line
- [ ] Query the DB: `sqlite3 ~/browser-visits.db "SELECT url, tag FROM visits ORDER BY id DESC LIMIT 5;"` — confirm the tag column is set

https://claude.ai/code/session_01TWz5R72jjZju3VYx2GBLNM