### PR TITLE
Add Skimmed tag

### DIFF
--- a/browser-visit-logger/extension/popup.html
+++ b/browser-visit-logger/extension/popup.html
@@ -40,6 +40,7 @@
   <h3>Mark this page</h3>
   <button data-tag="memorable">&#9733; Memorable</button>
   <button data-tag="read">&#10003; Read</button>
+  <button data-tag="skimmed">&#126; Skimmed</button>
   <div id="status"></div>
   <script src="popup.js"></script>
 </body>

--- a/browser-visit-logger/native-host/host.py
+++ b/browser-visit-logger/native-host/host.py
@@ -16,9 +16,9 @@ Auto-log (from background.js):
     → INSERT OR IGNORE new row (first visit wins); append 3-field TSV line.
 
 Tag action (from popup.js):
-    { "timestamp": "...", "url": "...", "title": "...", "tag": "memorable"|"read" }
-    → UPDATE memorable or read column on the row for that URL using the
-      message timestamp; append 4-field TSV line.
+    { "timestamp": "...", "url": "...", "title": "...", "tag": "memorable"|"read"|"skimmed" }
+    → UPDATE memorable, read, or skimmed column on the row for that URL using
+      the message timestamp; append 4-field TSV line.
 
 Schema
 ------
@@ -27,7 +27,8 @@ Schema
         timestamp TEXT NOT NULL,        -- set on first visit, never updated
         title     TEXT NOT NULL DEFAULT '',
         memorable TEXT,                 -- ISO timestamp, NULL until tagged
-        read      TEXT                  -- ISO timestamp, NULL until tagged
+        read      TEXT,                 -- ISO timestamp, NULL until tagged
+        skimmed   TEXT                  -- ISO timestamp, NULL until tagged
     )
 """
 
@@ -95,7 +96,8 @@ def ensure_db(conn: sqlite3.Connection) -> None:
                 timestamp TEXT NOT NULL,
                 title     TEXT NOT NULL DEFAULT '',
                 memorable TEXT,
-                read      TEXT
+                read      TEXT,
+                skimmed   TEXT
             )
         """)
     elif 'id' in cols:
@@ -106,7 +108,8 @@ def ensure_db(conn: sqlite3.Connection) -> None:
                 timestamp TEXT NOT NULL,
                 title     TEXT NOT NULL DEFAULT '',
                 memorable TEXT,
-                read      TEXT
+                read      TEXT,
+                skimmed   TEXT
             )
         """)
         conn.execute("""
@@ -115,6 +118,11 @@ def ensure_db(conn: sqlite3.Connection) -> None:
         """)
         conn.execute("DROP TABLE visits")
         conn.execute("ALTER TABLE visits_new RENAME TO visits")
+
+    else:
+        # Add skimmed column to existing url-PK schema if missing
+        if 'skimmed' not in cols:
+            conn.execute("ALTER TABLE visits ADD COLUMN skimmed TEXT")
 
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_visits_timestamp ON visits(timestamp)"
@@ -132,7 +140,7 @@ def insert_visit(conn: sqlite3.Connection, timestamp: str, url: str, title: str)
 
 
 def tag_visit(conn: sqlite3.Connection, url: str, tag: str, tag_timestamp: str) -> None:
-    """Set the memorable or read timestamp on the visit record for url."""
+    """Set the memorable, read, or skimmed timestamp on the visit record for url."""
     if tag == 'memorable':
         conn.execute(
             "UPDATE visits SET memorable = ? WHERE url = ?",
@@ -141,6 +149,11 @@ def tag_visit(conn: sqlite3.Connection, url: str, tag: str, tag_timestamp: str) 
     elif tag == 'read':
         conn.execute(
             "UPDATE visits SET read = ? WHERE url = ?",
+            (tag_timestamp, url),
+        )
+    elif tag == 'skimmed':
+        conn.execute(
+            "UPDATE visits SET skimmed = ? WHERE url = ?",
             (tag_timestamp, url),
         )
     conn.commit()
@@ -165,7 +178,7 @@ def append_log(timestamp: str, url: str, title: str, tag: str = '') -> None:
 # Main
 # ---------------------------------------------------------------------------
 
-VALID_TAGS = {'memorable', 'read'}
+VALID_TAGS = {'memorable', 'read', 'skimmed'}
 
 
 def main() -> None:

--- a/browser-visit-logger/tests/test_host.py
+++ b/browser-visit-logger/tests/test_host.py
@@ -209,6 +209,27 @@ class TestDatabase(unittest.TestCase):
         self.assertIn('read', self._cols(conn))
         conn.close()
 
+    def test_ensure_db_creates_skimmed_column(self):
+        conn = self._conn()
+        self.assertIn('skimmed', self._cols(conn))
+        conn.close()
+
+    def test_ensure_db_adds_skimmed_column_to_existing_schema(self):
+        conn = sqlite3.connect(':memory:')
+        conn.execute("""
+            CREATE TABLE visits (
+                url       TEXT PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                title     TEXT NOT NULL DEFAULT '',
+                memorable TEXT,
+                read      TEXT
+            )
+        """)
+        conn.commit()
+        host.ensure_db(conn)
+        self.assertIn('skimmed', self._cols(conn))
+        conn.close()
+
     def test_ensure_db_url_is_primary_key(self):
         conn = self._conn()
         pk_cols = {r[1] for r in conn.execute('PRAGMA table_info(visits)') if r[5] == 1}
@@ -260,10 +281,11 @@ class TestDatabase(unittest.TestCase):
     def test_insert_visit_memorable_and_read_default_to_null(self):
         conn = self._conn()
         host.insert_visit(conn, 'ts', 'https://example.com', 'Title')
-        row = conn.execute('SELECT memorable, read FROM visits').fetchone()
+        row = conn.execute('SELECT memorable, read, skimmed FROM visits').fetchone()
         conn.close()
         self.assertIsNone(row[0])
         self.assertIsNone(row[1])
+        self.assertIsNone(row[2])
 
     def test_insert_visit_empty_title(self):
         conn = self._conn()
@@ -338,6 +360,23 @@ class TestTagVisit(unittest.TestCase):
         row = conn.execute('SELECT read FROM visits').fetchone()
         conn.close()
         self.assertIsNone(row[0])
+
+    def test_tag_visit_sets_skimmed(self):
+        conn = self._conn()
+        host.insert_visit(conn, 'ts', 'https://example.com', 'Example')
+        host.tag_visit(conn, 'https://example.com', 'skimmed', '2026-01-01T12:00:00Z')
+        row = conn.execute('SELECT skimmed FROM visits').fetchone()
+        conn.close()
+        self.assertEqual(row[0], '2026-01-01T12:00:00Z')
+
+    def test_tag_visit_skimmed_does_not_set_memorable_or_read(self):
+        conn = self._conn()
+        host.insert_visit(conn, 'ts', 'https://example.com', 'Example')
+        host.tag_visit(conn, 'https://example.com', 'skimmed', '2026-01-01T12:00:00Z')
+        row = conn.execute('SELECT memorable, read FROM visits').fetchone()
+        conn.close()
+        self.assertIsNone(row[0])
+        self.assertIsNone(row[1])
 
     def test_tag_visit_no_existing_visit_is_noop(self):
         conn = self._conn()
@@ -580,10 +619,11 @@ class TestIntegration(unittest.TestCase):
             )
             self.assertEqual(resp['status'], 'ok')
             conn = sqlite3.connect(os.path.join(tmp, 'visits.db'))
-            row = conn.execute('SELECT memorable, read FROM visits').fetchone()
+            row = conn.execute('SELECT memorable, read, skimmed FROM visits').fetchone()
             conn.close()
         self.assertEqual(row[0], 'ts-tag')
         self.assertIsNone(row[1])
+        self.assertIsNone(row[2])
 
     def test_tag_message_sets_read_column(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -597,10 +637,29 @@ class TestIntegration(unittest.TestCase):
             )
             self.assertEqual(resp['status'], 'ok')
             conn = sqlite3.connect(os.path.join(tmp, 'visits.db'))
-            row = conn.execute('SELECT memorable, read FROM visits').fetchone()
+            row = conn.execute('SELECT memorable, read, skimmed FROM visits').fetchone()
             conn.close()
         self.assertIsNone(row[0])
         self.assertEqual(row[1], 'ts-tag')
+        self.assertIsNone(row[2])
+
+    def test_tag_message_sets_skimmed_column(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._invoke(
+                {'timestamp': 'ts-visit', 'url': 'https://example.com', 'title': 'Example'},
+                tmp,
+            )
+            resp = self._invoke(
+                {'timestamp': 'ts-tag', 'url': 'https://example.com', 'title': 'Example', 'tag': 'skimmed'},
+                tmp,
+            )
+            self.assertEqual(resp['status'], 'ok')
+            conn = sqlite3.connect(os.path.join(tmp, 'visits.db'))
+            row = conn.execute('SELECT memorable, read, skimmed FROM visits').fetchone()
+            conn.close()
+        self.assertIsNone(row[0])
+        self.assertIsNone(row[1])
+        self.assertEqual(row[2], 'ts-tag')
 
     def test_tag_message_appends_four_field_log_line(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- Adds a `skimmed` column to the DB schema with a migration path for existing databases
- Adds `'skimmed'` to `VALID_TAGS` in the native host and handles it in `tag_visit`
- Adds a "~ Skimmed" button to the extension popup
- 5 new tests covering schema creation, DB migration, tag isolation, and end-to-end integration

## Test plan

- [ ] Run `pytest tests/ -v` — all 63 tests pass
- [ ] Load the extension in Chrome and verify three buttons appear in the popup
- [ ] Click "Skimmed" on a visited page and confirm the `skimmed` column is set in the DB
- [ ] Confirm an existing DB without the `skimmed` column is migrated automatically on first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)