### PR TITLE
Error when tagging a URL with no existing DB record

### DIFF
--- a/browser-visit-logger/extension/popup.js
+++ b/browser-visit-logger/extension/popup.js
@@ -30,7 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
           } else if (response && response.status === 'ok') {
             window.close();
           } else {
-            showStatus('Write failed — check host log.');
+            showStatus(response && response.message ? response.message : 'Write failed — check host log.');
             document.querySelectorAll('[data-tag]').forEach(b => { b.disabled = false; });
           }
         });

--- a/browser-visit-logger/native-host/host.py
+++ b/browser-visit-logger/native-host/host.py
@@ -139,24 +139,30 @@ def insert_visit(conn: sqlite3.Connection, timestamp: str, url: str, title: str)
     conn.commit()
 
 
-def tag_visit(conn: sqlite3.Connection, url: str, tag: str, tag_timestamp: str) -> None:
-    """Set the memorable, read, or skimmed timestamp on the visit record for url."""
+def tag_visit(conn: sqlite3.Connection, url: str, tag: str, tag_timestamp: str) -> bool:
+    """Set the memorable, read, or skimmed timestamp on the visit record for url.
+
+    Returns True if a row was found and updated, False if no record exists for url.
+    """
     if tag == 'memorable':
-        conn.execute(
+        cursor = conn.execute(
             "UPDATE visits SET memorable = ? WHERE url = ?",
             (tag_timestamp, url),
         )
     elif tag == 'read':
-        conn.execute(
+        cursor = conn.execute(
             "UPDATE visits SET read = ? WHERE url = ?",
             (tag_timestamp, url),
         )
     elif tag == 'skimmed':
-        conn.execute(
+        cursor = conn.execute(
             "UPDATE visits SET skimmed = ? WHERE url = ?",
             (tag_timestamp, url),
         )
+    else:
+        return False
     conn.commit()
+    return cursor.rowcount > 0
 
 # ---------------------------------------------------------------------------
 # Log file helper
@@ -219,10 +225,14 @@ def main() -> None:
         conn = sqlite3.connect(DB_FILE)
         ensure_db(conn)
         if tag:
-            tag_visit(conn, url, tag, timestamp)
+            found = tag_visit(conn, url, tag, timestamp)
         else:
             insert_visit(conn, timestamp, url, title)
+            found = True
         conn.close()
+        if tag and not found:
+            write_message({'status': 'error', 'message': 'No record found for this URL — visit the page before tagging'})
+            return
     except Exception as exc:
         logger.error('SQLite write failed: %s', exc)
         errors.append(f'db: {exc}')

--- a/browser-visit-logger/tests/test_host.py
+++ b/browser-visit-logger/tests/test_host.py
@@ -378,12 +378,20 @@ class TestTagVisit(unittest.TestCase):
         self.assertIsNone(row[0])
         self.assertIsNone(row[1])
 
-    def test_tag_visit_no_existing_visit_is_noop(self):
+    def test_tag_visit_no_existing_visit_returns_false(self):
         conn = self._conn()
-        host.tag_visit(conn, 'https://example.com', 'memorable', 'ts')  # must not raise
+        found = host.tag_visit(conn, 'https://example.com', 'memorable', 'ts')
         count = conn.execute('SELECT COUNT(*) FROM visits').fetchone()[0]
         conn.close()
+        self.assertFalse(found)
         self.assertEqual(count, 0)
+
+    def test_tag_visit_existing_visit_returns_true(self):
+        conn = self._conn()
+        host.insert_visit(conn, 'ts', 'https://example.com', 'Example')
+        found = host.tag_visit(conn, 'https://example.com', 'memorable', 'ts-tag')
+        conn.close()
+        self.assertTrue(found)
 
     def test_tag_visit_does_not_affect_other_urls(self):
         conn = self._conn()
@@ -682,18 +690,14 @@ class TestIntegration(unittest.TestCase):
             lines = Path(tmp, 'visits.log').read_text().splitlines()
         self.assertEqual(len(lines[0].split('\t')), 3)
 
-    def test_tag_without_prior_visit_succeeds(self):
+    def test_tag_without_prior_visit_returns_error(self):
         with tempfile.TemporaryDirectory() as tmp:
             resp = self._invoke(
                 {'timestamp': 'ts', 'url': 'https://example.com', 'title': 'Example', 'tag': 'memorable'},
                 tmp,
             )
-            self.assertEqual(resp['status'], 'ok')
-            self.assertIn('memorable', Path(tmp, 'visits.log').read_text())
-            conn = sqlite3.connect(os.path.join(tmp, 'visits.db'))
-            count = conn.execute('SELECT COUNT(*) FROM visits').fetchone()[0]
-            conn.close()
-        self.assertEqual(count, 0)
+            self.assertEqual(resp['status'], 'error')
+            self.assertIn('No record found', resp.get('message', ''))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- `tag_visit` in `host.py` now returns `True`/`False` based on whether a row was found and updated (via `cursor.rowcount`)
- `main` treats a missed tag as an error, returning `{"status": "error", "message": "No record found for this URL — visit the page before tagging"}`
- `popup.js` now shows the error `message` from the response instead of the generic fallback string
- Updated two tests that previously asserted the silent-noop behavior; added one new test for the true-on-hit case

## Test plan

- [ ] All 64 tests pass
- [ ] Reset the DB, then try to tag a page — popup should display "No record found for this URL — visit the page before tagging"
- [ ] Tag a normally-visited page — should still close the popup immediately on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)