### PR TITLE
Write two log lines per action: intended action then success/error result

### DIFF
--- a/browser-visit-logger/native-host/host.py
+++ b/browser-visit-logger/native-host/host.py
@@ -168,14 +168,16 @@ def tag_visit(conn: sqlite3.Connection, url: str, tag: str, tag_timestamp: str) 
 # Log file helper
 # ---------------------------------------------------------------------------
 
-def append_log(timestamp: str, url: str, title: str, tag: str = '') -> None:
-    """Append one TSV line (3 fields for auto-log, 4 fields when tag is set)."""
+def append_log(timestamp: str, url: str, title: str, tag: str = '', error: str = '') -> None:
+    """Append one TSV line (3 fields for auto-log, 4 with tag, 5 with tag + error)."""
     def sanitise(s: str) -> str:
         return s.replace('\t', ' ').replace('\n', ' ').replace('\r', '')
 
     fields = [sanitise(timestamp), sanitise(url), sanitise(title)]
     if tag:
         fields.append(sanitise(tag))
+    if error:
+        fields.append(sanitise(error))
     line = '\t'.join(fields) + '\n'
     with open(LOG_FILE, 'a', encoding='utf-8') as f:
         f.write(line)
@@ -212,32 +214,35 @@ def main() -> None:
         return
 
     errors = []
+    no_record = False
 
-    # Write to TSV log (independent of DB write)
-    try:
-        append_log(timestamp, url, title, tag)
-    except Exception as exc:
-        logger.error('Log file write failed: %s', exc)
-        errors.append(f'log: {exc}')
-
-    # Write to SQLite (independent of log write)
+    # Write to SQLite first so we know whether to append an error to the log line
     try:
         conn = sqlite3.connect(DB_FILE)
         ensure_db(conn)
         if tag:
             found = tag_visit(conn, url, tag, timestamp)
+            if not found:
+                no_record = True
         else:
             insert_visit(conn, timestamp, url, title)
-            found = True
         conn.close()
-        if tag and not found:
-            write_message({'status': 'error', 'message': 'No record found for this URL — visit the page before tagging'})
-            return
     except Exception as exc:
         logger.error('SQLite write failed: %s', exc)
         errors.append(f'db: {exc}')
 
-    if errors:
+    # Write to TSV log, appending the error message when no record was found
+    no_record_msg = 'No record found for this URL — visit the page before tagging'
+    log_error = no_record_msg if no_record else ''
+    try:
+        append_log(timestamp, url, title, tag, log_error)
+    except Exception as exc:
+        logger.error('Log file write failed: %s', exc)
+        errors.append(f'log: {exc}')
+
+    if no_record:
+        write_message({'status': 'error', 'message': no_record_msg})
+    elif errors:
         write_message({'status': 'error', 'errors': errors})
     else:
         write_message({'status': 'ok'})

--- a/browser-visit-logger/native-host/host.py
+++ b/browser-visit-logger/native-host/host.py
@@ -168,19 +168,26 @@ def tag_visit(conn: sqlite3.Connection, url: str, tag: str, tag_timestamp: str) 
 # Log file helper
 # ---------------------------------------------------------------------------
 
-def append_log(timestamp: str, url: str, title: str, tag: str = '', result: str = '') -> None:
-    """Append one TSV line (3 fields for auto-log, 4 with tag, 5 with tag + result)."""
+def append_log(timestamp: str, url: str, title: str, tag: str = '') -> None:
+    """Append one TSV line (3 fields for auto-log, 4 fields when tag is set)."""
     def sanitise(s: str) -> str:
         return s.replace('\t', ' ').replace('\n', ' ').replace('\r', '')
 
     fields = [sanitise(timestamp), sanitise(url), sanitise(title)]
     if tag:
         fields.append(sanitise(tag))
-    if result:
-        fields.append(sanitise(result))
     line = '\t'.join(fields) + '\n'
     with open(LOG_FILE, 'a', encoding='utf-8') as f:
         f.write(line)
+
+
+def append_result_log(result: str) -> None:
+    """Append a single-field result line: 'success' or 'error: <message>'."""
+    def sanitise(s: str) -> str:
+        return s.replace('\t', ' ').replace('\n', ' ').replace('\r', '')
+
+    with open(LOG_FILE, 'a', encoding='utf-8') as f:
+        f.write(sanitise(result) + '\n')
 
 # ---------------------------------------------------------------------------
 # Main
@@ -247,7 +254,7 @@ def main() -> None:
     else:
         log_result = 'success'
     try:
-        append_log(timestamp, url, title, tag, log_result)
+        append_result_log(log_result)
     except Exception as exc:
         logger.error('Log file result write failed: %s', exc)
 

--- a/browser-visit-logger/native-host/host.py
+++ b/browser-visit-logger/native-host/host.py
@@ -168,16 +168,16 @@ def tag_visit(conn: sqlite3.Connection, url: str, tag: str, tag_timestamp: str) 
 # Log file helper
 # ---------------------------------------------------------------------------
 
-def append_log(timestamp: str, url: str, title: str, tag: str = '', error: str = '') -> None:
-    """Append one TSV line (3 fields for auto-log, 4 with tag, 5 with tag + error)."""
+def append_log(timestamp: str, url: str, title: str, tag: str = '', result: str = '') -> None:
+    """Append one TSV line (3 fields for auto-log, 4 with tag, 5 with tag + result)."""
     def sanitise(s: str) -> str:
         return s.replace('\t', ' ').replace('\n', ' ').replace('\r', '')
 
     fields = [sanitise(timestamp), sanitise(url), sanitise(title)]
     if tag:
         fields.append(sanitise(tag))
-    if error:
-        fields.append(sanitise(error))
+    if result:
+        fields.append(sanitise(result))
     line = '\t'.join(fields) + '\n'
     with open(LOG_FILE, 'a', encoding='utf-8') as f:
         f.write(line)
@@ -215,8 +215,16 @@ def main() -> None:
 
     errors = []
     no_record = False
+    no_record_msg = 'No record found for this URL — visit the page before tagging'
 
-    # Write to SQLite first so we know whether to append an error to the log line
+    # First write: record the intended action
+    try:
+        append_log(timestamp, url, title, tag)
+    except Exception as exc:
+        logger.error('Log file write failed: %s', exc)
+        errors.append(f'log: {exc}')
+
+    # Write to SQLite
     try:
         conn = sqlite3.connect(DB_FILE)
         ensure_db(conn)
@@ -231,14 +239,17 @@ def main() -> None:
         logger.error('SQLite write failed: %s', exc)
         errors.append(f'db: {exc}')
 
-    # Write to TSV log, appending the error message when no record was found
-    no_record_msg = 'No record found for this URL — visit the page before tagging'
-    log_error = no_record_msg if no_record else ''
+    # Second write: record the result
+    if no_record:
+        log_result = f'error: {no_record_msg}'
+    elif errors:
+        log_result = f'error: {"; ".join(errors)}'
+    else:
+        log_result = 'success'
     try:
-        append_log(timestamp, url, title, tag, log_error)
+        append_log(timestamp, url, title, tag, log_result)
     except Exception as exc:
-        logger.error('Log file write failed: %s', exc)
-        errors.append(f'log: {exc}')
+        logger.error('Log file result write failed: %s', exc)
 
     if no_record:
         write_message({'status': 'error', 'message': no_record_msg})

--- a/browser-visit-logger/tests/test_host.py
+++ b/browser-visit-logger/tests/test_host.py
@@ -158,6 +158,17 @@ class TestAppendLog(unittest.TestCase):
         self.assertEqual(len(parts), 4)
         self.assertEqual(parts[3], 'memorable')
 
+    def test_tag_with_error_produces_five_fields(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'visits.log')
+            with patch.object(host, 'LOG_FILE', path):
+                host.append_log('ts', 'https://example.com', 'Example', tag='memorable', error='No record found')
+            content = Path(path).read_text(encoding='utf-8')
+        parts = content.rstrip('\n').split('\t')
+        self.assertEqual(len(parts), 5)
+        self.assertEqual(parts[3], 'memorable')
+        self.assertEqual(parts[4], 'No record found')
+
     def test_no_tag_produces_three_fields(self):
         content = self._run('ts', 'https://example.com', 'Example')
         parts = content.rstrip('\n').split('\t')
@@ -672,12 +683,16 @@ class TestIntegration(unittest.TestCase):
     def test_tag_message_appends_four_field_log_line(self):
         with tempfile.TemporaryDirectory() as tmp:
             self._invoke(
-                {'timestamp': 'ts', 'url': 'https://example.com', 'title': 'Example', 'tag': 'read'},
+                {'timestamp': 'ts-visit', 'url': 'https://example.com', 'title': 'Example'},
+                tmp,
+            )
+            self._invoke(
+                {'timestamp': 'ts-tag', 'url': 'https://example.com', 'title': 'Example', 'tag': 'read'},
                 tmp,
             )
             lines = Path(tmp, 'visits.log').read_text().splitlines()
-        self.assertEqual(len(lines), 1)
-        parts = lines[0].split('\t')
+        tag_line = lines[1]
+        parts = tag_line.split('\t')
         self.assertEqual(len(parts), 4)
         self.assertEqual(parts[3], 'read')
 
@@ -698,6 +713,12 @@ class TestIntegration(unittest.TestCase):
             )
             self.assertEqual(resp['status'], 'error')
             self.assertIn('No record found', resp.get('message', ''))
+            lines = Path(tmp, 'visits.log').read_text().splitlines()
+            self.assertEqual(len(lines), 1)
+            parts = lines[0].split('\t')
+            self.assertEqual(len(parts), 5)
+            self.assertEqual(parts[3], 'memorable')
+            self.assertIn('No record found', parts[4])
 
 
 if __name__ == '__main__':

--- a/browser-visit-logger/tests/test_host.py
+++ b/browser-visit-logger/tests/test_host.py
@@ -158,16 +158,16 @@ class TestAppendLog(unittest.TestCase):
         self.assertEqual(len(parts), 4)
         self.assertEqual(parts[3], 'memorable')
 
-    def test_tag_with_error_produces_five_fields(self):
+    def test_tag_with_result_produces_five_fields(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, 'visits.log')
             with patch.object(host, 'LOG_FILE', path):
-                host.append_log('ts', 'https://example.com', 'Example', tag='memorable', error='No record found')
+                host.append_log('ts', 'https://example.com', 'Example', tag='memorable', result='success')
             content = Path(path).read_text(encoding='utf-8')
         parts = content.rstrip('\n').split('\t')
         self.assertEqual(len(parts), 5)
         self.assertEqual(parts[3], 'memorable')
-        self.assertEqual(parts[4], 'No record found')
+        self.assertEqual(parts[4], 'success')
 
     def test_no_tag_produces_three_fields(self):
         content = self._run('ts', 'https://example.com', 'Example')
@@ -453,8 +453,9 @@ class TestIntegration(unittest.TestCase):
                 {'timestamp': '2026-01-01T00:00:00Z', 'url': 'https://example.com', 'title': 'Example Domain'},
                 tmp,
             )
-            content = Path(tmp, 'visits.log').read_text()
-        self.assertEqual(content, '2026-01-01T00:00:00Z\thttps://example.com\tExample Domain\n')
+            lines = Path(tmp, 'visits.log').read_text().splitlines()
+        self.assertEqual(lines[0], '2026-01-01T00:00:00Z\thttps://example.com\tExample Domain')
+        self.assertEqual(lines[1], '2026-01-01T00:00:00Z\thttps://example.com\tExample Domain\tsuccess')
 
     def test_sqlite_record(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -496,7 +497,7 @@ class TestIntegration(unittest.TestCase):
                     tmp,
                 )
             log_lines = Path(tmp, 'visits.log').read_text().splitlines()
-            self.assertEqual(len(log_lines), 3)
+            self.assertEqual(len(log_lines), 6)  # 2 lines per invocation
 
             conn = sqlite3.connect(os.path.join(tmp, 'visits.db'))
             count = conn.execute('SELECT COUNT(*) FROM visits').fetchone()[0]
@@ -523,7 +524,7 @@ class TestIntegration(unittest.TestCase):
                     tmp,
                 )
             lines = Path(tmp, 'visits.log').read_text().splitlines()
-        self.assertEqual(len(lines), 3)
+        self.assertEqual(len(lines), 6)  # 2 lines per invocation
 
     def test_duplicate_url_preserves_original_timestamp(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -691,10 +692,13 @@ class TestIntegration(unittest.TestCase):
                 tmp,
             )
             lines = Path(tmp, 'visits.log').read_text().splitlines()
-        tag_line = lines[1]
-        parts = tag_line.split('\t')
-        self.assertEqual(len(parts), 4)
-        self.assertEqual(parts[3], 'read')
+        # lines[0]=visit action, lines[1]=visit result, lines[2]=tag action, lines[3]=tag result
+        self.assertEqual(len(lines), 4)
+        tag_action = lines[2].split('\t')
+        self.assertEqual(len(tag_action), 4)
+        self.assertEqual(tag_action[3], 'read')
+        tag_result = lines[3].split('\t')
+        self.assertEqual(tag_result[-1], 'success')
 
     def test_auto_log_appends_three_field_log_line(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -703,7 +707,9 @@ class TestIntegration(unittest.TestCase):
                 tmp,
             )
             lines = Path(tmp, 'visits.log').read_text().splitlines()
-        self.assertEqual(len(lines[0].split('\t')), 3)
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(len(lines[0].split('\t')), 3)   # action: 3 fields
+        self.assertEqual(lines[1].split('\t')[-1], 'success')  # result: ends with success
 
     def test_tag_without_prior_visit_returns_error(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -714,11 +720,14 @@ class TestIntegration(unittest.TestCase):
             self.assertEqual(resp['status'], 'error')
             self.assertIn('No record found', resp.get('message', ''))
             lines = Path(tmp, 'visits.log').read_text().splitlines()
-            self.assertEqual(len(lines), 1)
-            parts = lines[0].split('\t')
-            self.assertEqual(len(parts), 5)
-            self.assertEqual(parts[3], 'memorable')
-            self.assertIn('No record found', parts[4])
+            self.assertEqual(len(lines), 2)
+            action = lines[0].split('\t')
+            self.assertEqual(len(action), 4)
+            self.assertEqual(action[3], 'memorable')
+            result = lines[1].split('\t')
+            self.assertEqual(len(result), 5)
+            self.assertEqual(result[3], 'memorable')
+            self.assertIn('No record found', result[4])
 
 
 if __name__ == '__main__':

--- a/browser-visit-logger/tests/test_host.py
+++ b/browser-visit-logger/tests/test_host.py
@@ -158,16 +158,21 @@ class TestAppendLog(unittest.TestCase):
         self.assertEqual(len(parts), 4)
         self.assertEqual(parts[3], 'memorable')
 
-    def test_tag_with_result_produces_five_fields(self):
+    def test_append_result_log_writes_single_field(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, 'visits.log')
             with patch.object(host, 'LOG_FILE', path):
-                host.append_log('ts', 'https://example.com', 'Example', tag='memorable', result='success')
+                host.append_result_log('success')
             content = Path(path).read_text(encoding='utf-8')
-        parts = content.rstrip('\n').split('\t')
-        self.assertEqual(len(parts), 5)
-        self.assertEqual(parts[3], 'memorable')
-        self.assertEqual(parts[4], 'success')
+        self.assertEqual(content, 'success\n')
+
+    def test_append_result_log_sanitises_tabs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'visits.log')
+            with patch.object(host, 'LOG_FILE', path):
+                host.append_result_log('error: foo\tbar')
+            content = Path(path).read_text(encoding='utf-8').rstrip('\n')
+        self.assertEqual(content, 'error: foo bar')
 
     def test_no_tag_produces_three_fields(self):
         content = self._run('ts', 'https://example.com', 'Example')
@@ -455,7 +460,7 @@ class TestIntegration(unittest.TestCase):
             )
             lines = Path(tmp, 'visits.log').read_text().splitlines()
         self.assertEqual(lines[0], '2026-01-01T00:00:00Z\thttps://example.com\tExample Domain')
-        self.assertEqual(lines[1], '2026-01-01T00:00:00Z\thttps://example.com\tExample Domain\tsuccess')
+        self.assertEqual(lines[1], 'success')
 
     def test_sqlite_record(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -697,8 +702,7 @@ class TestIntegration(unittest.TestCase):
         tag_action = lines[2].split('\t')
         self.assertEqual(len(tag_action), 4)
         self.assertEqual(tag_action[3], 'read')
-        tag_result = lines[3].split('\t')
-        self.assertEqual(tag_result[-1], 'success')
+        self.assertEqual(lines[3], 'success')
 
     def test_auto_log_appends_three_field_log_line(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -708,8 +712,8 @@ class TestIntegration(unittest.TestCase):
             )
             lines = Path(tmp, 'visits.log').read_text().splitlines()
         self.assertEqual(len(lines), 2)
-        self.assertEqual(len(lines[0].split('\t')), 3)   # action: 3 fields
-        self.assertEqual(lines[1].split('\t')[-1], 'success')  # result: ends with success
+        self.assertEqual(len(lines[0].split('\t')), 3)  # action: 3 fields
+        self.assertEqual(lines[1], 'success')
 
     def test_tag_without_prior_visit_returns_error(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -724,10 +728,7 @@ class TestIntegration(unittest.TestCase):
             action = lines[0].split('\t')
             self.assertEqual(len(action), 4)
             self.assertEqual(action[3], 'memorable')
-            result = lines[1].split('\t')
-            self.assertEqual(len(result), 5)
-            self.assertEqual(result[3], 'memorable')
-            self.assertIn('No record found', result[4])
+            self.assertIn('No record found', lines[1])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Every action now writes two TSV lines to the log file instead of one
- **First line**: the intended action (unchanged format — 3 fields for auto-log, 4 for a tag action)
- **Second line**: the result — `success` on the happy path, `error: <message>` on any failure (no DB record, DB exception, etc.)
- `append_log` gains an optional `result` parameter for the second field
- Closes #13 (superseded by this design)

## Example log output

Successful visit:
```
2026-04-21T10:00:00Z\thttps://example.com\tExample
2026-04-21T10:00:00Z\thttps://example.com\tExample\tsuccess
```

Tag with no DB record:
```
2026-04-21T10:01:00Z\thttps://example.com\tExample\tmemorable
2026-04-21T10:01:00Z\thttps://example.com\tExample\tmemorable\terror: No record found for this URL — visit the page before tagging
```

## Test plan

- [ ] All 65 tests pass
- [ ] Visit a page; confirm 2 log lines appear, second ends with `success`
- [ ] Reset DB, tag a page; confirm 2 log lines appear, second ends with `error: No record found...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)