### PR TITLE
Fix garbled snapshot when marking a PDF tab as 'read'

### DIFF
--- a/browser-visit-logger/extension/background.js
+++ b/browser-visit-logger/extension/background.js
@@ -77,12 +77,22 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   flushVisit(tabId);
 });
 
-// Handle "read" tag from popup: capture MHTML snapshot, save it to
-// ~/Downloads/browser-visit-snapshots/<sha256(url)>.mhtml, then tag via native host.
+// Handle "read" tag from popup: save a snapshot of the tab to
+// ~/Downloads/browser-visit-snapshots/<sha256(url)>.<ext>, then tag via native host.
+//
+// For PDF URLs the original file is downloaded directly (MHTML capture of the
+// PDF viewer produces garbled output). For all other pages, chrome.pageCapture
+// saves a complete offline-capable MHTML bundle.
 //
 // Chrome's downloads API can only write within the Downloads directory, so the
 // snapshot lives there. The native host never touches the file; it only records
 // the read timestamp in the database.
+
+function isPdfUrl(url) {
+  // Match .pdf at end of path, before query string or fragment.
+  return /\.pdf([?#]|$)/i.test(url);
+}
+
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.type !== 'read-and-snapshot') return false;
 
@@ -97,67 +107,70 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         .join('')
     );
 
-  chrome.pageCapture.saveAsMHTML({ tabId }, (mhtmlData) => {
-    if (chrome.runtime.lastError || !mhtmlData) {
-      sendResponse({
-        status: 'error',
-        message: 'Snapshot capture failed: ' + (chrome.runtime.lastError?.message || 'no data'),
-      });
-      return;
-    }
+  // For PDFs: download the original URL directly (avoids the garbled-viewer
+  // problem). For everything else: capture MHTML via pageCapture and convert
+  // the blob to a data URL (URL.createObjectURL is unavailable in MV3 workers).
+  const isPdf = isPdfUrl(url);
+  const ext   = isPdf ? 'pdf' : 'mhtml';
 
-    // URL.createObjectURL is not available in MV3 service workers; convert
-    // the blob to a data URL so chrome.downloads can read it.
-    const dataUrlPromise = new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.addEventListener('loadend', () => {
-        if (reader.error) reject(reader.error);
-        else resolve(reader.result);
-      });
-      reader.readAsDataURL(mhtmlData);
-    });
-
-    Promise.all([hashPromise, dataUrlPromise])
-      .then(([hexHash, dataUrl]) => {
-        const filename = `browser-visit-snapshots/${hexHash}.mhtml`;
-
-        chrome.downloads.download({ url: dataUrl, filename, saveAs: false }, (downloadId) => {
-          if (chrome.runtime.lastError || downloadId === undefined) {
-            sendResponse({
-              status: 'error',
-              message: 'Snapshot download failed: ' + (chrome.runtime.lastError?.message || 'unknown'),
-            });
+  const contentPromise = isPdf
+    ? Promise.resolve(url)
+    : new Promise((resolve, reject) => {
+        chrome.pageCapture.saveAsMHTML({ tabId }, (mhtmlData) => {
+          if (chrome.runtime.lastError || !mhtmlData) {
+            reject(new Error('Snapshot capture failed: ' +
+              (chrome.runtime.lastError?.message || 'no data')));
             return;
           }
-
-          const onChanged = (delta) => {
-            if (delta.id !== downloadId) return;
-
-            if (delta.state?.current === 'complete') {
-              chrome.downloads.onChanged.removeListener(onChanged);
-              chrome.runtime.sendNativeMessage(NATIVE_HOST, {
-                timestamp, url, title,
-                tag: 'read',
-              }, (response) => {
-                if (chrome.runtime.lastError) {
-                  sendResponse({ status: 'error', message: chrome.runtime.lastError.message });
-                } else {
-                  sendResponse(response);
-                }
-              });
-            } else if (delta.state?.current === 'interrupted') {
-              chrome.downloads.onChanged.removeListener(onChanged);
-              sendResponse({ status: 'error', message: 'Snapshot download was interrupted' });
-            }
-          };
-
-          chrome.downloads.onChanged.addListener(onChanged);
+          const reader = new FileReader();
+          reader.addEventListener('loadend', () => {
+            if (reader.error) reject(reader.error);
+            else resolve(reader.result);
+          });
+          reader.readAsDataURL(mhtmlData);
         });
-      })
-      .catch((err) => {
-        sendResponse({ status: 'error', message: 'Snapshot preparation failed: ' + err });
       });
-  });
+
+  Promise.all([hashPromise, contentPromise])
+    .then(([hexHash, downloadUrl]) => {
+      const filename = `browser-visit-snapshots/${hexHash}.${ext}`;
+
+      chrome.downloads.download({ url: downloadUrl, filename, saveAs: false }, (downloadId) => {
+        if (chrome.runtime.lastError || downloadId === undefined) {
+          sendResponse({
+            status: 'error',
+            message: 'Snapshot download failed: ' + (chrome.runtime.lastError?.message || 'unknown'),
+          });
+          return;
+        }
+
+        const onChanged = (delta) => {
+          if (delta.id !== downloadId) return;
+
+          if (delta.state?.current === 'complete') {
+            chrome.downloads.onChanged.removeListener(onChanged);
+            chrome.runtime.sendNativeMessage(NATIVE_HOST, {
+              timestamp, url, title,
+              tag: 'read',
+            }, (response) => {
+              if (chrome.runtime.lastError) {
+                sendResponse({ status: 'error', message: chrome.runtime.lastError.message });
+              } else {
+                sendResponse(response);
+              }
+            });
+          } else if (delta.state?.current === 'interrupted') {
+            chrome.downloads.onChanged.removeListener(onChanged);
+            sendResponse({ status: 'error', message: 'Snapshot download was interrupted' });
+          }
+        };
+
+        chrome.downloads.onChanged.addListener(onChanged);
+      });
+    })
+    .catch((err) => {
+      sendResponse({ status: 'error', message: String(err) });
+    });
 
   return true; // Keep message channel open for async response
 });

--- a/browser-visit-logger/tests/background.test.js
+++ b/browser-visit-logger/tests/background.test.js
@@ -401,13 +401,15 @@ describe('read-and-snapshot message handler', () => {
     expect(mockSaveAsMHTML).not.toHaveBeenCalled();
   });
 
-  test('calls pageCapture.saveAsMHTML with the tabId', () => {
+  // --- HTML page path (saveAsMHTML) ---
+
+  test('calls pageCapture.saveAsMHTML with the tabId for non-PDF pages', () => {
     setupSuccessFlow();
     messageHandler(baseMsg, {}, jest.fn());
     expect(mockSaveAsMHTML).toHaveBeenCalledWith({ tabId: 1 }, expect.any(Function));
   });
 
-  test('on pageCapture error, calls sendResponse with error', () => {
+  test('on pageCapture error, calls sendResponse with error', async () => {
     mockSaveAsMHTML.mockImplementation(({ tabId }, cb) => {
       global.chrome.runtime.lastError = { message: 'Tab not found' };
       cb(null);
@@ -415,11 +417,12 @@ describe('read-and-snapshot message handler', () => {
     });
     const sendResponse = jest.fn();
     messageHandler(baseMsg, {}, sendResponse);
+    await flushPromises();
     expect(sendResponse).toHaveBeenCalledWith(expect.objectContaining({ status: 'error' }));
     expect(mockDownloadsDownload).not.toHaveBeenCalled();
   });
 
-  test('on successful capture, downloads to browser-visit-snapshots/<sha256>.mhtml', async () => {
+  test('HTML page: downloads to browser-visit-snapshots/<sha256>.mhtml', async () => {
     setupSuccessFlow();
     messageHandler(baseMsg, {}, jest.fn());
     await flushPromises();
@@ -432,7 +435,7 @@ describe('read-and-snapshot message handler', () => {
     );
   });
 
-  test('reads blob as data URL and passes it to downloads.download', async () => {
+  test('HTML page: reads blob as data URL and passes it to downloads.download', async () => {
     setupSuccessFlow();
     messageHandler(baseMsg, {}, jest.fn());
     await flushPromises();
@@ -441,6 +444,70 @@ describe('read-and-snapshot message handler', () => {
       expect.objectContaining({ url: 'data:message/rfc822;base64,MOCKED_DATA' }),
       expect.any(Function),
     );
+  });
+
+  // --- PDF path (direct URL download) ---
+
+  describe('PDF URL handling', () => {
+    const pdfUrls = [
+      'https://example.com/paper.pdf',
+      'https://example.com/paper.PDF',
+      'https://example.com/paper.pdf?v=2',
+      'https://example.com/paper.pdf#page=3',
+    ];
+    const nonPdfUrls = [
+      'https://example.com/',
+      'https://example.com/page.html',
+      'https://example.com/pdf-viewer',
+    ];
+
+    pdfUrls.forEach((url) => {
+      test(`treats "${url}" as PDF`, async () => {
+        mockDownloadsDownload.mockImplementation((opts, cb) => cb(42));
+        mockSendNativeMessage.mockImplementation((host, msg, cb) => cb({ status: 'ok' }));
+        const pdfMsg = { ...baseMsg, url };
+        messageHandler(pdfMsg, {}, jest.fn());
+        await flushPromises();
+        // Should NOT call saveAsMHTML
+        expect(mockSaveAsMHTML).not.toHaveBeenCalled();
+        // Should download the original URL directly with .pdf extension
+        expect(mockDownloadsDownload).toHaveBeenCalledWith(
+          expect.objectContaining({ url, filename: expect.stringMatching(/\.pdf$/) }),
+          expect.any(Function),
+        );
+      });
+    });
+
+    nonPdfUrls.forEach((url) => {
+      test(`treats "${url}" as HTML (uses saveAsMHTML)`, () => {
+        setupSuccessFlow();
+        messageHandler({ ...baseMsg, url }, {}, jest.fn());
+        expect(mockSaveAsMHTML).toHaveBeenCalled();
+      });
+    });
+
+    test('PDF: filename uses sha256 hash with .pdf extension', async () => {
+      mockDownloadsDownload.mockImplementation((opts, cb) => cb(42));
+      mockSendNativeMessage.mockImplementation((host, msg, cb) => cb({ status: 'ok' }));
+      const pdfMsg = { ...baseMsg, url: 'https://example.com/paper.pdf' };
+      messageHandler(pdfMsg, {}, jest.fn());
+      await flushPromises();
+      expect(mockDownloadsDownload).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filename: `browser-visit-snapshots/${MOCK_HEX_HASH}.pdf`,
+          saveAs: false,
+        }),
+        expect.any(Function),
+      );
+    });
+
+    test('PDF: does not call FileReader', async () => {
+      mockDownloadsDownload.mockImplementation((opts, cb) => cb(42));
+      mockSendNativeMessage.mockImplementation((host, msg, cb) => cb({ status: 'ok' }));
+      messageHandler({ ...baseMsg, url: 'https://example.com/doc.pdf' }, {}, jest.fn());
+      await flushPromises();
+      expect(mockFileReaderInstance.readAsDataURL).not.toHaveBeenCalled();
+    });
   });
 
   test('on download error, calls sendResponse with error', async () => {


### PR DESCRIPTION
## Summary

- `chrome.pageCapture.saveAsMHTML` on a PDF tab captures Chrome's PDF viewer shell rather than the PDF content, producing a snapshot that displays as garbled HTML when reopened
- Detect PDF URLs (path ends with `.pdf` before any `?` or `#`) and download the original file directly via `chrome.downloads`, saving it as `browser-visit-snapshots/<sha256>.pdf` instead of `.mhtml`
- Non-PDF pages continue to use the existing `saveAsMHTML` → FileReader → data URL path
- The two paths converge on the same download-and-notify logic, so there's no code duplication

## Test plan

- [ ] 46 JS tests pass (`npm test`)
- [ ] Visit an HTML page, click Read — `browser-visit-snapshots/<hash>.mhtml` appears in Downloads and loads correctly offline
- [ ] Visit a PDF URL (e.g. any `*.pdf` link), click Read — `browser-visit-snapshots/<hash>.pdf` appears in Downloads and opens as a proper PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)