### PR TITLE
Show visit history in popup

### DIFF
--- a/browser-visit-logger/extension/popup.html
+++ b/browser-visit-logger/extension/popup.html
@@ -4,16 +4,44 @@
   <meta charset="utf-8">
   <style>
     body {
-      width: 200px;
+      width: 220px;
       padding: 14px;
       font-family: sans-serif;
       margin: 0;
     }
     h3 {
-      margin: 0 0 12px;
+      margin: 0 0 10px;
       font-size: 14px;
       color: #333;
     }
+    /* Visit history */
+    #visit-info {
+      display: none;
+      margin-bottom: 10px;
+    }
+    .info-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: 8px;
+      margin-bottom: 4px;
+      font-size: 12px;
+      color: #444;
+    }
+    .info-label {
+      white-space: nowrap;
+      color: #666;
+    }
+    .info-value {
+      text-align: right;
+      color: #222;
+    }
+    hr {
+      border: none;
+      border-top: 1px solid #ddd;
+      margin: 10px 0;
+    }
+    /* Tag buttons */
     button {
       display: block;
       width: 100%;
@@ -37,6 +65,10 @@
   </style>
 </head>
 <body>
+  <div id="visit-info">
+    <div id="visit-rows"></div>
+    <hr>
+  </div>
   <h3>Mark this page</h3>
   <button data-tag="memorable">&#9733; Memorable</button>
   <button data-tag="read">&#10003; Read</button>

--- a/browser-visit-logger/extension/popup.js
+++ b/browser-visit-logger/extension/popup.js
@@ -6,51 +6,106 @@ function showStatus(text) {
   document.getElementById('status').textContent = text;
 }
 
+/**
+ * Format an ISO timestamp into a short human-readable string, e.g.
+ * "Apr 23, 2026, 10:04 AM".  Returns null for falsy input.
+ */
+function formatTs(iso) {
+  if (!iso) return null;
+  return new Date(iso).toLocaleString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+/**
+ * Render the visit history section from the record returned by the host.
+ * Does nothing if record is null (URL not yet in the database).
+ */
+function showVisitInfo(record) {
+  if (!record) return;
+
+  const rows = [
+    { label: 'Visited',     value: formatTs(record.timestamp) },
+    { label: '★ Memorable', value: formatTs(record.memorable) },
+    { label: '✓ Read',      value: formatTs(record.read) },
+    { label: '~ Skimmed',   value: formatTs(record.skimmed) },
+  ].filter((r) => r.value !== null);
+
+  if (rows.length === 0) return;
+
+  document.getElementById('visit-rows').innerHTML = rows
+    .map((r) =>
+      `<div class="info-row">` +
+        `<span class="info-label">${r.label}</span>` +
+        `<span class="info-value">${r.value}</span>` +
+      `</div>`
+    )
+    .join('');
+
+  document.getElementById('visit-info').style.display = '';
+}
+
 document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('[data-tag]').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      btn.disabled = true;
-      document.querySelectorAll('[data-tag]').forEach(b => { b.disabled = true; });
+  chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
+    if (!tab) {
+      showStatus('No active tab found.');
+      return;
+    }
 
-      chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
-        if (!tab) {
-          showStatus('No active tab found.');
-          return;
+    // Query the native host for any existing record for this URL.
+    chrome.runtime.sendNativeMessage(NATIVE_HOST, { action: 'query', url: tab.url },
+      (response) => {
+        // Ignore errors — the history section simply stays hidden.
+        if (!chrome.runtime.lastError && response && response.status === 'ok') {
+          showVisitInfo(response.record);
         }
 
-        const timestamp = new Date().toISOString();
-        const tag       = btn.dataset.tag;
-
-        function handleResponse(response) {
-          if (chrome.runtime.lastError) {
-            showStatus('Error: ' + chrome.runtime.lastError.message);
-            document.querySelectorAll('[data-tag]').forEach(b => { b.disabled = false; });
-          } else if (response && response.status === 'ok') {
-            window.close();
-          } else {
-            showStatus(response && response.message ? response.message : 'Write failed — check host log.');
-            document.querySelectorAll('[data-tag]').forEach(b => { b.disabled = false; });
-          }
-        }
-
-        if (tag === 'read') {
-          showStatus('Saving snapshot\u2026');
-          chrome.runtime.sendMessage({
-            type:      'read-and-snapshot',
-            tabId:     tab.id,
-            timestamp,
-            url:       tab.url,
-            title:     tab.title || tab.url,
-          }, handleResponse);
-        } else {
-          chrome.runtime.sendNativeMessage(NATIVE_HOST, {
-            timestamp,
-            url:   tab.url,
-            title: tab.title || tab.url,
-            tag,
-          }, handleResponse);
-        }
-      });
-    });
+        // Set up tag buttons after the query returns (so the popup doesn't
+        // flash in if the query is fast).
+        setupButtons(tab);
+      }
+    );
   });
 });
+
+function setupButtons(tab) {
+  document.querySelectorAll('[data-tag]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('[data-tag]').forEach(b => { b.disabled = true; });
+
+      const timestamp = new Date().toISOString();
+      const tag       = btn.dataset.tag;
+
+      function handleResponse(response) {
+        if (chrome.runtime.lastError) {
+          showStatus('Error: ' + chrome.runtime.lastError.message);
+          document.querySelectorAll('[data-tag]').forEach(b => { b.disabled = false; });
+        } else if (response && response.status === 'ok') {
+          window.close();
+        } else {
+          showStatus(response && response.message ? response.message : 'Write failed — check host log.');
+          document.querySelectorAll('[data-tag]').forEach(b => { b.disabled = false; });
+        }
+      }
+
+      if (tag === 'read') {
+        showStatus('Saving snapshot\u2026');
+        chrome.runtime.sendMessage({
+          type:      'read-and-snapshot',
+          tabId:     tab.id,
+          timestamp,
+          url:       tab.url,
+          title:     tab.title || tab.url,
+        }, handleResponse);
+      } else {
+        chrome.runtime.sendNativeMessage(NATIVE_HOST, {
+          timestamp,
+          url:   tab.url,
+          title: tab.title || tab.url,
+          tag,
+        }, handleResponse);
+      }
+    });
+  });
+}

--- a/browser-visit-logger/native-host/host.py
+++ b/browser-visit-logger/native-host/host.py
@@ -142,6 +142,23 @@ def insert_visit(conn: sqlite3.Connection, timestamp: str, url: str, title: str)
     conn.commit()
 
 
+def query_visit(conn: sqlite3.Connection, url: str) -> 'dict | None':
+    """Return the visit record for url as a dict, or None if no record exists."""
+    row = conn.execute(
+        "SELECT timestamp, title, memorable, read, skimmed FROM visits WHERE url = ?",
+        (url,),
+    ).fetchone()
+    if row is None:
+        return None
+    return {
+        'timestamp': row[0],
+        'title':     row[1],
+        'memorable': row[2],
+        'read':      row[3],
+        'skimmed':   row[4],
+    }
+
+
 def tag_visit(conn: sqlite3.Connection, url: str, tag: str, tag_timestamp: str) -> bool:
     """Set the memorable, read, or skimmed timestamp on the visit record for url.
 
@@ -208,7 +225,26 @@ def main() -> None:
         write_message({'status': 'error', 'message': str(exc)})
         return
 
-    url       = (message.get('url') or '').strip()
+    url    = (message.get('url') or '').strip()
+    action = (message.get('action') or '').strip()
+
+    # Query action: read-only lookup, no log writes.
+    if action == 'query':
+        if not url:
+            write_message({'status': 'error', 'message': 'url is required'})
+            return
+        try:
+            conn = sqlite3.connect(DB_FILE)
+            ensure_db(conn)
+            record = query_visit(conn, url)
+            conn.close()
+        except Exception as exc:
+            logger.error('SQLite query failed: %s', exc)
+            write_message({'status': 'error', 'message': str(exc)})
+            return
+        write_message({'status': 'ok', 'record': record})
+        return
+
     timestamp = (message.get('timestamp') or '').strip()
     title     = message.get('title') or ''
     tag       = (message.get('tag') or '').strip()

--- a/browser-visit-logger/tests/test_host.py
+++ b/browser-visit-logger/tests/test_host.py
@@ -426,6 +426,60 @@ class TestTagVisit(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# query_visit
+# ---------------------------------------------------------------------------
+
+class TestQueryVisit(unittest.TestCase):
+
+    def _conn(self):
+        conn = sqlite3.connect(':memory:')
+        host.ensure_db(conn)
+        return conn
+
+    def test_returns_none_for_unknown_url(self):
+        conn = self._conn()
+        result = host.query_visit(conn, 'https://unknown.com')
+        conn.close()
+        self.assertIsNone(result)
+
+    def test_returns_record_for_known_url(self):
+        conn = self._conn()
+        host.insert_visit(conn, '2026-01-01T00:00:00Z', 'https://example.com', 'Example')
+        result = host.query_visit(conn, 'https://example.com')
+        conn.close()
+        self.assertIsNotNone(result)
+        self.assertEqual(result['timestamp'], '2026-01-01T00:00:00Z')
+        self.assertEqual(result['title'], 'Example')
+
+    def test_tag_fields_are_none_before_tagging(self):
+        conn = self._conn()
+        host.insert_visit(conn, 'ts', 'https://example.com', 'Example')
+        result = host.query_visit(conn, 'https://example.com')
+        conn.close()
+        self.assertIsNone(result['memorable'])
+        self.assertIsNone(result['read'])
+        self.assertIsNone(result['skimmed'])
+
+    def test_tag_fields_reflect_applied_tags(self):
+        conn = self._conn()
+        host.insert_visit(conn, 'ts-visit', 'https://example.com', 'Example')
+        host.tag_visit(conn, 'https://example.com', 'memorable', 'ts-mem')
+        host.tag_visit(conn, 'https://example.com', 'read', 'ts-read')
+        result = host.query_visit(conn, 'https://example.com')
+        conn.close()
+        self.assertEqual(result['memorable'], 'ts-mem')
+        self.assertEqual(result['read'], 'ts-read')
+        self.assertIsNone(result['skimmed'])
+
+    def test_does_not_return_record_for_different_url(self):
+        conn = self._conn()
+        host.insert_visit(conn, 'ts', 'https://a.com', 'A')
+        result = host.query_visit(conn, 'https://b.com')
+        conn.close()
+        self.assertIsNone(result)
+
+
+# ---------------------------------------------------------------------------
 # Integration: run host.py as a subprocess (mirrors Chrome's usage)
 # ---------------------------------------------------------------------------
 
@@ -736,10 +790,49 @@ class TestIntegration(unittest.TestCase):
             self.assertIn('No record found', lines[1])
 
 
-# ---------------------------------------------------------------------------
-# save_snapshot
-# ---------------------------------------------------------------------------
+    def test_query_unknown_url_returns_null_record(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            resp = self._invoke({'action': 'query', 'url': 'https://example.com'}, tmp)
+            self.assertEqual(resp['status'], 'ok')
+            self.assertIsNone(resp['record'])
 
+    def test_query_known_url_returns_record(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._invoke(
+                {'timestamp': 'ts-visit', 'url': 'https://example.com', 'title': 'Example'},
+                tmp,
+            )
+            resp = self._invoke({'action': 'query', 'url': 'https://example.com'}, tmp)
+            self.assertEqual(resp['status'], 'ok')
+            self.assertIsNotNone(resp['record'])
+            self.assertEqual(resp['record']['timestamp'], 'ts-visit')
+            self.assertEqual(resp['record']['title'], 'Example')
+
+    def test_query_reflects_applied_tags(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._invoke(
+                {'timestamp': 'ts-visit', 'url': 'https://example.com', 'title': 'Example'},
+                tmp,
+            )
+            self._invoke(
+                {'timestamp': 'ts-mem', 'url': 'https://example.com', 'title': 'Example', 'tag': 'memorable'},
+                tmp,
+            )
+            resp = self._invoke({'action': 'query', 'url': 'https://example.com'}, tmp)
+            self.assertEqual(resp['record']['memorable'], 'ts-mem')
+            self.assertIsNone(resp['record']['read'])
+            self.assertIsNone(resp['record']['skimmed'])
+
+    def test_query_does_not_write_log(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self._invoke({'action': 'query', 'url': 'https://example.com'}, tmp)
+            self.assertFalse(Path(tmp, 'visits.log').exists())
+
+    def test_query_missing_url_returns_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            resp = self._invoke({'action': 'query'}, tmp)
+            self.assertEqual(resp['status'], 'error')
+            self.assertIn('url', resp.get('message', ''))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- The popup now opens with a query to the native host for the current URL's record
- If a record exists, a history section is shown above the tag buttons, displaying:
  - **Visited** — when the URL was first recorded
  - **★ Memorable** / **✓ Read** / **~ Skimmed** — timestamp for each tag that has been applied (tags not yet applied are omitted)
- For URLs not yet in the database the history section stays hidden and the popup looks exactly as before

## Implementation

- **`host.py`**: new `query_visit()` function; new `action: 'query'` message path that reads from the DB without writing to the log or modifying any data
- **`popup.js`**: on `DOMContentLoaded`, sends a query message and calls `showVisitInfo()` with the result before setting up button handlers
- **`popup.html`**: added `#visit-info` / `#visit-rows` section with a divider; widened to 220 px to accommodate timestamps

## Tests

- 5 new unit tests in `TestQueryVisit`
- 5 new integration tests in `TestIntegration` covering: unknown URL returns null, known URL returns record, tags are reflected, query does not write log, missing URL returns error
- 76 Python tests pass total

🤖 Generated with [Claude Code](https://claude.com/claude-code)