### PR TITLE
Add visits_rebuilder to recreate DB from log + iCloud archive

### DIFF
--- a/browser-visit-logger/README.md
+++ b/browser-visit-logger/README.md
@@ -184,7 +184,7 @@ All scripts live at the repo root or under `native-host/`. They share
 the same `BVL_*` env-var conventions and accept overriding flags so
 they're safe to point at test data.
 
-The four user-facing Python scripts each have an executable Bash
+The five user-facing Python scripts each have an executable Bash
 wrapper at the repo root for convenience — e.g. `./move_snapshot
 --show-errors` instead of `python3 native-host/snapshot_mover.py
 --show-errors`. Each wrapper forwards all arguments verbatim and
@@ -197,6 +197,7 @@ delegating to the Python script's own argparse `--help`.
 | `./seal_snapshot_directory` | `native-host/snapshot_sealer.py` |
 | `./verify_snapshot_directory` | `native-host/snapshot_verifier.py` |
 | `./reset_visits_data` | `reset.py` |
+| `./rebuild_visits_data` | `native-host/visits_rebuilder.py` |
 
 ### `install.sh`
 
@@ -434,6 +435,66 @@ Respects the same `BVL_*` env vars as the host, so custom paths Just
 Work. Safe to run with no targets present — missing files/dirs are
 reported and skipped.
 
+### `native-host/visits_rebuilder.py`
+
+Reconstructs `~/browser-visits.db` from two side-channels that survive
+DB loss: the on-disk log (`~/browser-visits.log`) and the iCloud
+snapshot archive.  Two phases run by default:
+
+1. **Log replay** — every host invocation writes a UUID-prefixed
+   action line followed by a result line; the rebuilder pairs them by
+   UUID and re-applies each *successful* action via the same
+   `host.py` helpers used at write-time.  Error pairs are skipped
+   (the DB write didn't happen).  Orphan / malformed lines are
+   counted and trip a non-zero exit.
+2. **Filesystem rehydration** — iterates every `YYYY-MM-DD`
+   subdirectory under the iCloud root, upserts a `snapshots` row
+   (`sealed = 1` if `MANIFEST.tsv` exists), and updates each event
+   row's `directory` column from Downloads to the date subdir for
+   files that have already been moved.
+
+```bash
+# Rebuild against the configured paths (DROPs and recreates
+# visits / read_events / skimmed_events / snapshots first)
+./rebuild_visits_data
+
+# Skip the wipe; rely on idempotency
+./rebuild_visits_data --no-truncate
+
+# Phase 1 only (e.g. log present, iCloud unreachable)
+./rebuild_visits_data --log-only
+
+# Phase 2 only (log lost, iCloud archive intact)
+./rebuild_visits_data --rehydrate-only
+
+# Operate on isolated paths (useful in tests / experiments)
+./rebuild_visits_data \
+    --log /tmp/visits.log --db /tmp/test.db \
+    --source /tmp/dl --dest /tmp/icloud
+```
+
+Flags:
+
+| Flag | Effect |
+|------|--------|
+| `--truncate` (default) / `--no-truncate` | DROP and recreate the four rebuildable tables before phase 1.  `mover_errors` is left alone in either case. |
+| `--log-only` / `--rehydrate-only` | Skip phase 2 / phase 1 (mutually exclusive). |
+| `--log FILE` | Override `BVL_LOG_FILE` |
+| `--db FILE` | Override `BVL_DB_FILE` |
+| `--source DIR` | Override `BVL_DOWNLOADS_SNAPSHOTS_DIR` |
+| `--dest DIR` | Override `BVL_ICLOUD_SNAPSHOTS_DIR` |
+| `-v`, `--verbose` | DEBUG log level |
+
+`mover_errors` is intentionally not log-recoverable; the rebuild
+leaves it alone.  Filesystem-derived rows (`orphan_file`,
+`invalid_filename`, `missing_directory`, `manifest_invalid`)
+repopulate naturally on the next mover/sealer/verifier pass.
+
+Exit codes: 0 on success, 1 on input errors (missing log/DB path,
+orphan or malformed lines skipped during phase 1), 2 on an
+unexpected exception.  See [docs/rebuild-visits-from-log.md](docs/rebuild-visits-from-log.md)
+for the full design.
+
 ### `point-to-worktree.py`
 
 Developer convenience. Repoints the installed native-host manifest at
@@ -576,6 +637,7 @@ browser-visit-logger/
 │   ├── snapshot_mover.py                   # Periodic archiver (mover + seal)
 │   ├── snapshot_sealer.py                  # Manual sealer CLI
 │   ├── snapshot_verifier.py                # Manifest verifier CLI
+│   ├── visits_rebuilder.py                 # DB rebuilder (log replay + FS rehydrate)
 │   ├── com.browser.visit.logger.json       # Host manifest (template-installed)
 │   ├── com.browser.visit.logger.snapshot_mover.plist.template
 │   └── com.browser.visit.logger.snapshot_verifier.plist.template
@@ -587,6 +649,7 @@ browser-visit-logger/
 ├── seal_snapshot_directory                 # Bash wrapper → snapshot_sealer.py
 ├── verify_snapshot_directory               # Bash wrapper → snapshot_verifier.py
 ├── reset_visits_data                       # Bash wrapper → reset.py
+├── rebuild_visits_data                     # Bash wrapper → visits_rebuilder.py
 ├── package.json                            # JS test deps + jest config
 └── requirements-test.txt                   # Python test deps
 ```

--- a/browser-visit-logger/native-host/host.py
+++ b/browser-visit-logger/native-host/host.py
@@ -62,6 +62,7 @@ import os
 import sqlite3
 import struct
 import sys
+import uuid
 from logging.handlers import RotatingFileHandler
 
 
@@ -189,15 +190,16 @@ def _insert_event(
     exists = conn.execute("SELECT 1 FROM visits WHERE url = ?", (url,)).fetchone()
     if exists:
         basename = os.path.basename(filename)
-        conn.execute(
+        cursor = conn.execute(
             f"INSERT OR IGNORE INTO {table} (url, timestamp, filename, directory) "
             f"VALUES (?, ?, ?, ?)",
             (url, timestamp, basename, DOWNLOADS_SNAPSHOTS_DIR),
         )
-        conn.execute(
-            f"UPDATE visits SET {visits_col} = {visits_col} + 1 WHERE url = ?",
-            (url,),
-        )
+        if cursor.rowcount > 0:
+            conn.execute(
+                f"UPDATE visits SET {visits_col} = {visits_col} + 1 WHERE url = ?",
+                (url,),
+            )
     conn.commit()
     return exists is not None
 
@@ -273,26 +275,42 @@ def tag_visit(
 # Log file helper
 # ---------------------------------------------------------------------------
 
-def append_log(timestamp: str, url: str, title: str, tag: str = '') -> None:
-    """Append one TSV line (3 fields for auto-log, 4 fields when tag is set)."""
+def append_log(
+    record_id: str, timestamp: str, url: str, title: str,
+    tag: str = '', filename: str = '',
+) -> None:
+    """Append one TSV action line, prefixed with record_id.
+
+    Field layout:
+        <record_id>\\t<timestamp>\\t<url>\\t<title>                          # auto-log
+        <record_id>\\t<timestamp>\\t<url>\\t<title>\\t<tag>                   # of_interest
+        <record_id>\\t<timestamp>\\t<url>\\t<title>\\t<tag>\\t<filename>      # read / skimmed
+
+    record_id correlates this line with its later result line so a replay
+    tool can pair them safely even under concurrent host invocations.
+    filename is included only for read / skimmed tags.
+    """
     def sanitise(s: str) -> str:
         return s.replace('\t', ' ').replace('\n', ' ').replace('\r', '')
 
-    fields = [sanitise(timestamp), sanitise(url), sanitise(title)]
+    fields = [sanitise(record_id), sanitise(timestamp), sanitise(url), sanitise(title)]
     if tag:
         fields.append(sanitise(tag))
+        if tag in ('read', 'skimmed'):
+            fields.append(sanitise(filename))
     line = '\t'.join(fields) + '\n'
     with open(LOG_FILE, 'a', encoding='utf-8') as f:
         f.write(line)
 
 
-def append_result_log(result: str) -> None:
-    """Append a single-field result line: 'success' or 'error: <message>'."""
+def append_result_log(record_id: str, result: str) -> None:
+    """Append a result line prefixed with record_id: 'success' or 'error: <message>'."""
     def sanitise(s: str) -> str:
         return s.replace('\t', ' ').replace('\n', ' ').replace('\r', '')
 
+    line = sanitise(record_id) + '\t' + sanitise(result) + '\n'
     with open(LOG_FILE, 'a', encoding='utf-8') as f:
-        f.write(sanitise(result) + '\n')
+        f.write(line)
 
 # ---------------------------------------------------------------------------
 # Main
@@ -309,6 +327,8 @@ def main() -> None:
         logger.error('Failed to read message: %s', exc)
         write_message({'status': 'error', 'message': str(exc)})
         return
+
+    record_id = uuid.uuid4().hex
 
     url    = (message.get('url') or '').strip()
     action = (message.get('action') or '').strip()
@@ -349,7 +369,7 @@ def main() -> None:
 
     # First write: record the intended action
     try:
-        append_log(timestamp, url, title, tag)
+        append_log(record_id, timestamp, url, title, tag, filename)
     except Exception as exc:
         logger.error('Log file write failed: %s', exc)
         errors.append(f'log: {exc}')
@@ -372,7 +392,7 @@ def main() -> None:
     # Second write: record the result
     log_result = f'error: {"; ".join(errors)}' if errors else 'success'
     try:
-        append_result_log(log_result)
+        append_result_log(record_id, log_result)
     except Exception as exc:
         logger.error('Log file result write failed: %s', exc)
 

--- a/browser-visit-logger/native-host/visits_rebuilder.py
+++ b/browser-visit-logger/native-host/visits_rebuilder.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""
+visits_rebuilder.py — rebuild ``browser-visits.db`` from the on-disk log
+and the iCloud snapshot archive.
+
+The DB is normally the source of truth.  When it's lost or corrupt, this
+tool restores it from two side-channels that *are* still durable:
+
+  1. ``browser-visits.log`` — append-only TSV every host.py invocation
+     writes.  Each invocation produces an action line followed by a
+     result line, both prefixed with the same record_id (UUID hex).
+     Phase 1 ("log replay") parses this file and re-applies every
+     successful action via the existing host.py helpers.
+
+  2. The iCloud snapshot archive — daily ``YYYY-MM-DD`` subdirectories
+     under ICLOUD_SNAPSHOTS_DIR, optionally containing a MANIFEST.tsv
+     once the directory has been sealed.  Phase 2 ("filesystem
+     rehydration") repopulates the ``snapshots`` table and updates the
+     ``directory`` column on event rows whose snapshot file has since
+     been moved out of Downloads.
+
+``mover_errors`` is intentionally *not* recovered.  Filesystem-derived
+rows (orphan_file, invalid_filename, missing_directory,
+manifest_invalid) repopulate naturally on the next mover/sealer/
+verifier pass.  Transient failures that have since healed are
+correctly dropped.
+"""
+
+import argparse
+import logging
+import os
+import re
+import sqlite3
+import sys
+from dataclasses import dataclass, field
+from typing import Optional
+
+import host
+import snapshot_mover
+
+logger = logging.getLogger('visits_rebuilder')
+
+# A record_id is uuid.uuid4().hex — exactly 32 lowercase hex chars.
+_UUID_RE = re.compile(r'^[0-9a-f]{32}$')
+
+# Tags that include a trailing filename column on the action line.
+_FILENAME_TAGS = ('read', 'skimmed')
+
+
+# ---------------------------------------------------------------------------
+# Stats
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ReplayStats:
+    visits_inserted:    int = 0
+    of_interest_set:    int = 0
+    read_events:        int = 0
+    skimmed_events:     int = 0
+    success_records:    int = 0
+    error_records:      int = 0    # action+error pair: counted, not applied
+    orphan_actions:     int = 0    # action with no matching result
+    orphan_results:     int = 0    # result with no matching action
+    malformed_lines:    int = 0    # bad UUID prefix, wrong field count, etc.
+
+    @property
+    def has_skipped_lines(self) -> bool:
+        """True if any action/result line was skipped (excluding error pairs)."""
+        return bool(self.orphan_actions or self.orphan_results or self.malformed_lines)
+
+
+@dataclass
+class RehydrateStats:
+    snapshots_upserted:    int = 0
+    sealed_dirs:           int = 0
+    unsealed_dirs:         int = 0
+    events_relocated:      int = 0
+    files_without_events:  int = 0
+
+
+@dataclass
+class RebuildStats:
+    replay:    Optional[ReplayStats]    = None
+    rehydrate: Optional[RehydrateStats] = None
+    truncated: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — log replay
+# ---------------------------------------------------------------------------
+
+def _looks_like_uuid(field_str: str) -> bool:
+    return bool(_UUID_RE.fullmatch(field_str))
+
+
+def _parse_action_fields(parts: list) -> Optional[dict]:
+    """Parse an action line's fields (excluding the leading record_id).
+
+    parts has the record_id already stripped.  Returns a dict on success
+    or None if the field count is wrong.
+    """
+    # auto-log: timestamp, url, title  → 3 fields
+    # of_interest: timestamp, url, title, tag  → 4 fields
+    # read/skimmed: timestamp, url, title, tag, filename  → 5 fields
+    if len(parts) == 3:
+        return {'timestamp': parts[0], 'url': parts[1], 'title': parts[2],
+                'tag': '', 'filename': ''}
+    if len(parts) == 4:
+        return {'timestamp': parts[0], 'url': parts[1], 'title': parts[2],
+                'tag': parts[3], 'filename': ''}
+    if len(parts) == 5:
+        return {'timestamp': parts[0], 'url': parts[1], 'title': parts[2],
+                'tag': parts[3], 'filename': parts[4]}
+    return None
+
+
+def _is_result_payload(payload: str) -> bool:
+    return payload == 'success' or payload.startswith('error: ')
+
+
+def replay_log(conn: sqlite3.Connection, log_path: str) -> ReplayStats:
+    """Phase 1: replay a UUID-prefixed TSV log into the DB.
+
+    Action lines are buffered in a dict keyed by record_id; each result
+    line pops its matching action.  Successful pairs are applied via
+    host.py's helpers.  Error pairs are counted but skipped (the DB
+    write didn't happen, so there's nothing to replay).  Orphans on
+    either side are counted and logged.
+    """
+    stats = ReplayStats()
+    pending: dict = {}  # record_id -> parsed action fields
+
+    with open(log_path, 'r', encoding='utf-8') as f:
+        for raw in f:
+            line = raw.rstrip('\n')
+            if not line:
+                continue
+            parts = line.split('\t')
+            if not _looks_like_uuid(parts[0]):
+                logger.warning('Skipping malformed log line (non-UUID prefix): %r', raw)
+                stats.malformed_lines += 1
+                continue
+            record_id = parts[0]
+            rest = parts[1:]
+
+            # Result lines have exactly one field after the record_id, and
+            # that field is either 'success' or starts with 'error: '.
+            if len(rest) == 1 and _is_result_payload(rest[0]):
+                action = pending.pop(record_id, None)
+                if action is None:
+                    logger.warning(
+                        'Result line for %s has no matching action — skipping', record_id)
+                    stats.orphan_results += 1
+                    continue
+                if rest[0] == 'success':
+                    _apply_action(conn, action, stats)
+                    stats.success_records += 1
+                else:
+                    stats.error_records += 1
+                continue
+
+            # Otherwise it's an action line.
+            action = _parse_action_fields(rest)
+            if action is None:
+                logger.warning('Skipping malformed action line: %r', raw)
+                stats.malformed_lines += 1
+                continue
+            if record_id in pending:
+                # Duplicate UUID for a pending action — the host should
+                # never emit this.  Drop the prior, count the new one.
+                logger.warning(
+                    'Duplicate record_id %s while a prior action is pending — '
+                    'dropping the prior orphan', record_id)
+                stats.orphan_actions += 1
+            pending[record_id] = action
+
+    # Anything still pending after EOF is an orphan action.
+    if pending:
+        for record_id in pending:
+            logger.warning('Action %s has no matching result line', record_id)
+        stats.orphan_actions += len(pending)
+
+    conn.commit()
+    return stats
+
+
+def _apply_action(conn: sqlite3.Connection, action: dict, stats: ReplayStats) -> None:
+    """Apply a (parsed action, success) pair against the DB."""
+    timestamp = action['timestamp']
+    url       = action['url']
+    title     = action['title']
+    tag       = action['tag']
+    filename  = action['filename']
+
+    host.insert_visit(conn, timestamp, url, title)
+    stats.visits_inserted += 1
+
+    if tag == 'of_interest':
+        conn.execute(
+            "UPDATE visits SET of_interest = 1 WHERE url = ?", (url,)
+        )
+        stats.of_interest_set += 1
+    elif tag in ('read', 'skimmed'):
+        host.tag_visit(conn, url, tag, timestamp, filename)
+        if tag == 'read':
+            stats.read_events += 1
+        else:
+            stats.skimmed_events += 1
+    elif tag:
+        # Unknown tag — should have been rejected by host.py at write time.
+        logger.warning('Unknown tag %r in record for %s — ignoring', tag, url)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — filesystem rehydration
+# ---------------------------------------------------------------------------
+
+def rehydrate_filesystem(
+    conn: sqlite3.Connection, icloud_dir: str, downloads_dir: str,
+) -> RehydrateStats:
+    """Phase 2: walk the iCloud archive, repopulate snapshots, relocate events.
+
+    Files matching the snapshot filename pattern have any matching event
+    rows updated to point at the date subdirectory (only rows whose
+    ``directory`` column still says Downloads — already-relocated rows
+    are left alone).  Orphan files are *not* deleted; the next
+    snapshot_verifier pass will flag them.
+    """
+    stats = RehydrateStats()
+    if not os.path.isdir(icloud_dir):
+        logger.warning('iCloud snapshots dir %s does not exist — phase 2 noop',
+                       icloud_dir)
+        return stats
+
+    snapshot_mover._ensure_snapshots_table(conn)
+
+    for entry in sorted(os.listdir(icloud_dir)):
+        if not snapshot_mover._DATE_DIR_RE.match(entry):
+            continue
+        date_dir = os.path.join(icloud_dir, entry)
+        if not os.path.isdir(date_dir):
+            continue
+        manifest_path = os.path.join(date_dir, 'MANIFEST.tsv')
+        sealed = 1 if os.path.exists(manifest_path) else 0
+        conn.execute(
+            "INSERT INTO snapshots (date, sealed) VALUES (?, ?) "
+            "ON CONFLICT(date) DO UPDATE SET sealed = excluded.sealed",
+            (entry, sealed),
+        )
+        stats.snapshots_upserted += 1
+        if sealed:
+            stats.sealed_dirs += 1
+        else:
+            stats.unsealed_dirs += 1
+
+        for fname in sorted(os.listdir(date_dir)):
+            if fname == 'MANIFEST.tsv':
+                continue
+            if not snapshot_mover._SNAPSHOT_FILENAME_RE.match(fname):
+                continue
+            relocated_here = 0
+            for table in ('read_events', 'skimmed_events'):
+                cur = conn.execute(
+                    f"UPDATE {table} SET directory = ? "
+                    f"WHERE filename = ? AND directory = ?",
+                    (date_dir, fname, downloads_dir),
+                )
+                relocated_here += cur.rowcount
+            if relocated_here > 0:
+                stats.events_relocated += relocated_here
+            else:
+                # No matching events row in either table.  This file will
+                # be flagged as an orphan by the next snapshot_verifier
+                # pass; the rebuild tool itself does not delete or record.
+                logger.info(
+                    'No event row for %s in %s — snapshot_verifier will flag it',
+                    fname, date_dir)
+                stats.files_without_events += 1
+
+    conn.commit()
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+_REBUILDABLE_TABLES = ('visits', 'read_events', 'skimmed_events', 'snapshots')
+
+
+def _truncate_rebuildable_tables(conn: sqlite3.Connection) -> None:
+    """DROP the four log/FS-recoverable tables.  ``mover_errors`` is left alone."""
+    for table in _REBUILDABLE_TABLES:
+        conn.execute(f"DROP TABLE IF EXISTS {table}")
+    conn.commit()
+
+
+def rebuild(
+    conn: sqlite3.Connection, *,
+    log_path: str, icloud_dir: str, downloads_dir: str,
+    do_log: bool = True, do_rehydrate: bool = True, truncate: bool = True,
+) -> RebuildStats:
+    stats = RebuildStats(truncated=truncate)
+    if truncate:
+        _truncate_rebuildable_tables(conn)
+    host.ensure_db(conn)
+    snapshot_mover._ensure_snapshots_table(conn)
+
+    if do_log:
+        stats.replay = replay_log(conn, log_path)
+    if do_rehydrate:
+        stats.rehydrate = rehydrate_filesystem(conn, icloud_dir, downloads_dir)
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+# Exit codes
+_EXIT_OK              = 0
+_EXIT_INPUT_ERROR     = 1   # log/DB unreachable, orphans/malformed lines, bad args
+_EXIT_UNEXPECTED      = 2   # unhandled exception
+
+
+def _parse_args(argv=None):
+    p = argparse.ArgumentParser(
+        prog='visits_rebuilder.py',
+        description='Rebuild browser-visits.db by replaying browser-visits.log '
+                    'and rehydrating directory state from the iCloud snapshot '
+                    'archive.',
+    )
+    truncate_group = p.add_mutually_exclusive_group()
+    truncate_group.add_argument(
+        '--truncate', dest='truncate', action='store_true', default=True,
+        help='DROP and recreate visits / read_events / skimmed_events / '
+             'snapshots before rebuilding (default).  mover_errors is left '
+             'alone.')
+    truncate_group.add_argument(
+        '--no-truncate', dest='truncate', action='store_false',
+        help='skip the wipe; rely on idempotency of replay + rehydrate')
+    p.add_argument('--log-only', action='store_true',
+                   help='skip phase 2 (filesystem rehydration)')
+    p.add_argument('--rehydrate-only', action='store_true',
+                   help='skip phase 1 (log replay)')
+    p.add_argument('--log', metavar='FILE', dest='log_path',
+                   help=f'override the log file path (default {host.LOG_FILE})')
+    p.add_argument('--db', metavar='FILE', dest='db_path',
+                   help=f'override the SQLite database path (default {host.DB_FILE})')
+    p.add_argument('--source', metavar='DIR',
+                   help=f'override the Downloads snapshots root '
+                        f'(default {host.DOWNLOADS_SNAPSHOTS_DIR})')
+    p.add_argument('--dest', metavar='DIR',
+                   help=f'override the iCloud snapshots root '
+                        f'(default {snapshot_mover.ICLOUD_SNAPSHOTS_DIR})')
+    p.add_argument('-v', '--verbose', action='store_true',
+                   help='enable DEBUG logging')
+
+    args = p.parse_args(argv)
+    if args.log_only and args.rehydrate_only:
+        p.error('cannot combine --log-only with --rehydrate-only')
+    return args
+
+
+def cli(argv=None) -> int:
+    args = _parse_args(argv)
+
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        stream=sys.stderr, level=log_level,
+        format='%(asctime)s %(levelname)s [visits_rebuilder] %(message)s',
+    )
+    logger.setLevel(log_level)
+
+    log_path      = args.log_path or host.LOG_FILE
+    db_path       = args.db_path  or host.DB_FILE
+    downloads_dir = args.source   or host.DOWNLOADS_SNAPSHOTS_DIR
+    icloud_dir    = args.dest     or snapshot_mover.ICLOUD_SNAPSHOTS_DIR
+
+    do_log       = not args.rehydrate_only
+    do_rehydrate = not args.log_only
+
+    # Apply overrides to the imported modules so helpers downstream (e.g.
+    # _ensure_events_table's directory DEFAULT, tag_visit's recorded
+    # directory) use the same values the user passed on the CLI.
+    host.DOWNLOADS_SNAPSHOTS_DIR = downloads_dir
+    host.DB_FILE                 = db_path
+    snapshot_mover.ICLOUD_SNAPSHOTS_DIR = icloud_dir
+
+    if do_log and not os.path.exists(log_path):
+        print(f'No log file at {log_path}', file=sys.stderr)
+        return _EXIT_INPUT_ERROR
+
+    db_dir = os.path.dirname(db_path) or '.'
+    if not os.path.isdir(db_dir):
+        print(f'DB parent directory {db_dir} does not exist', file=sys.stderr)
+        return _EXIT_INPUT_ERROR
+
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            stats = rebuild(
+                conn,
+                log_path=log_path,
+                icloud_dir=icloud_dir,
+                downloads_dir=downloads_dir,
+                do_log=do_log, do_rehydrate=do_rehydrate,
+                truncate=args.truncate,
+            )
+        finally:
+            conn.close()
+    except Exception as exc:
+        logger.exception('Rebuild failed: %s', exc)
+        return _EXIT_UNEXPECTED
+
+    _print_summary(stats)
+    if stats.replay is not None and stats.replay.has_skipped_lines:
+        return _EXIT_INPUT_ERROR
+    return _EXIT_OK
+
+
+def _print_summary(stats: RebuildStats) -> None:
+    parts = []
+    if stats.replay is not None:
+        r = stats.replay
+        parts.append(
+            f'replay: visits={r.visits_inserted} of_interest={r.of_interest_set} '
+            f'read={r.read_events} skimmed={r.skimmed_events} '
+            f'errors={r.error_records} orphan_actions={r.orphan_actions} '
+            f'orphan_results={r.orphan_results} malformed={r.malformed_lines}'
+        )
+    if stats.rehydrate is not None:
+        h = stats.rehydrate
+        parts.append(
+            f'rehydrate: snapshots={h.snapshots_upserted} '
+            f'sealed={h.sealed_dirs} unsealed={h.unsealed_dirs} '
+            f'relocated={h.events_relocated} '
+            f'files_without_events={h.files_without_events}'
+        )
+    print('\n'.join(parts))
+
+
+if __name__ == '__main__':  # pragma: no cover
+    sys.exit(cli())

--- a/browser-visit-logger/rebuild_visits_data
+++ b/browser-visit-logger/rebuild_visits_data
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# rebuild_visits_data — convenience wrapper around native-host/visits_rebuilder.py.
+#
+# Rebuilds browser-visits.db by replaying browser-visits.log and
+# rehydrating directory state from the iCloud snapshot archive.  All
+# arguments are forwarded verbatim to the underlying Python script;
+# --help is supported and produces both a brief wrapper note and the
+# script's full --help output.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="$SCRIPT_DIR/native-host/visits_rebuilder.py"
+
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help)
+      cat <<'EOF'
+rebuild_visits_data — wrapper around native-host/visits_rebuilder.py
+
+Rebuilds browser-visits.db from the on-disk log (phase 1: log replay)
+and the iCloud snapshot archive (phase 2: filesystem rehydration).
+By default both phases run and the rebuildable tables are wiped and
+recreated first; use --no-truncate, --log-only, or --rehydrate-only
+to scope the operation.  All arguments are forwarded verbatim to the
+Python script.
+
+The remainder of this help is from the Python script:
+
+EOF
+      exec python3 "$TARGET" --help
+      ;;
+  esac
+done
+
+exec python3 "$TARGET" "$@"

--- a/browser-visit-logger/tests/test_host.py
+++ b/browser-visit-logger/tests/test_host.py
@@ -108,24 +108,31 @@ class TestWriteMessage(unittest.TestCase):
 # Log file (append_log)
 # ---------------------------------------------------------------------------
 
+FIXED_REC_ID = '0' * 32  # placeholder UUID hex; tests assert on field positions
+
+
 class TestAppendLog(unittest.TestCase):
 
-    def _run(self, timestamp, url, title, tag='') -> str:
+    def _run(self, timestamp, url, title, tag='', filename='',
+             record_id=FIXED_REC_ID) -> str:
         """Call append_log with a temp file and return its contents."""
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, 'visits.log')
             with patch.object(host, 'LOG_FILE', path):
-                host.append_log(timestamp, url, title, tag)
+                host.append_log(record_id, timestamp, url, title, tag, filename)
             return Path(path).read_text(encoding='utf-8')
 
     def test_tsv_format(self):
         content = self._run('2026-01-01T00:00:00Z', 'https://example.com', 'Example Domain')
-        self.assertEqual(content, '2026-01-01T00:00:00Z\thttps://example.com\tExample Domain\n')
+        self.assertEqual(
+            content,
+            f'{FIXED_REC_ID}\t2026-01-01T00:00:00Z\thttps://example.com\tExample Domain\n',
+        )
 
     def test_tab_in_title_replaced(self):
         content = self._run('ts', 'https://a.com', 'Part1\tPart2').rstrip('\n')
         parts = content.split('\t')
-        self.assertEqual(parts[2], 'Part1 Part2')
+        self.assertEqual(parts[3], 'Part1 Part2')
 
     def test_newline_in_title_replaced(self):
         content = self._run('ts', 'https://a.com', 'Line1\nLine2')
@@ -136,7 +143,7 @@ class TestAppendLog(unittest.TestCase):
         # \r is removed entirely (not replaced with a space), collapsing the surrounding text
         content = self._run('ts', 'https://a.com', 'Title\rStuff').rstrip('\n')
         parts = content.split('\t')
-        self.assertEqual(parts[2], 'TitleStuff')
+        self.assertEqual(parts[3], 'TitleStuff')
 
     def test_unicode_preserved(self):
         content = self._run('ts', 'https://a.com', '日本語タイトル')
@@ -146,44 +153,83 @@ class TestAppendLog(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, 'visits.log')
             with patch.object(host, 'LOG_FILE', path):
-                host.append_log('ts1', 'https://a.com', 'A')
-                host.append_log('ts2', 'https://b.com', 'B')
+                host.append_log(FIXED_REC_ID, 'ts1', 'https://a.com', 'A')
+                host.append_log(FIXED_REC_ID, 'ts2', 'https://b.com', 'B')
             lines = Path(path).read_text().splitlines()
         self.assertEqual(len(lines), 2)
         self.assertIn('https://a.com', lines[0])
         self.assertIn('https://b.com', lines[1])
 
-    def test_tag_produces_four_fields(self):
-        content = self._run('ts', 'https://example.com', 'Example', tag='of_interest')
+    def test_no_tag_produces_four_fields(self):
+        content = self._run('ts', 'https://example.com', 'Example')
         parts = content.rstrip('\n').split('\t')
         self.assertEqual(len(parts), 4)
-        self.assertEqual(parts[3], 'of_interest')
+        self.assertEqual(parts[0], FIXED_REC_ID)
 
-    def test_append_result_log_writes_single_field(self):
+    def test_of_interest_tag_produces_five_fields_no_filename(self):
+        content = self._run('ts', 'https://example.com', 'Example', tag='of_interest')
+        parts = content.rstrip('\n').split('\t')
+        self.assertEqual(len(parts), 5)
+        self.assertEqual(parts[4], 'of_interest')
+
+    def test_read_tag_produces_six_fields_with_filename(self):
+        content = self._run('ts', 'https://example.com', 'Example',
+                            tag='read', filename='abc.mhtml')
+        parts = content.rstrip('\n').split('\t')
+        self.assertEqual(len(parts), 6)
+        self.assertEqual(parts[4], 'read')
+        self.assertEqual(parts[5], 'abc.mhtml')
+
+    def test_skimmed_tag_produces_six_fields_with_filename(self):
+        content = self._run('ts', 'https://example.com', 'Example',
+                            tag='skimmed', filename='def.mhtml')
+        parts = content.rstrip('\n').split('\t')
+        self.assertEqual(len(parts), 6)
+        self.assertEqual(parts[4], 'skimmed')
+        self.assertEqual(parts[5], 'def.mhtml')
+
+    def test_read_tag_with_empty_filename_still_writes_field(self):
+        # When the message arrives without a filename (defensive), the column
+        # is still emitted so field-count parsing in replay stays uniform.
+        content = self._run('ts', 'https://example.com', 'Example', tag='read')
+        parts = content.rstrip('\n').split('\t')
+        self.assertEqual(len(parts), 6)
+        self.assertEqual(parts[5], '')
+
+    def test_filename_sanitised(self):
+        content = self._run('ts', 'https://a.com', 'Example',
+                            tag='read', filename='nasty\tname.mhtml')
+        parts = content.rstrip('\n').split('\t')
+        self.assertEqual(parts[5], 'nasty name.mhtml')
+
+    def test_record_id_sanitised(self):
+        # Defensive: even though uuid4().hex never contains tabs, the helper
+        # sanitises every field so a corrupted caller can't break the format.
+        content = self._run('ts', 'https://a.com', 'Example',
+                            record_id='broken\tid')
+        parts = content.rstrip('\n').split('\t')
+        self.assertEqual(parts[0], 'broken id')
+
+    def test_append_result_log_writes_two_fields(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, 'visits.log')
             with patch.object(host, 'LOG_FILE', path):
-                host.append_result_log('success')
+                host.append_result_log(FIXED_REC_ID, 'success')
             content = Path(path).read_text(encoding='utf-8')
-        self.assertEqual(content, 'success\n')
+        self.assertEqual(content, f'{FIXED_REC_ID}\tsuccess\n')
 
     def test_append_result_log_sanitises_tabs(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, 'visits.log')
             with patch.object(host, 'LOG_FILE', path):
-                host.append_result_log('error: foo\tbar')
+                host.append_result_log(FIXED_REC_ID, 'error: foo\tbar')
             content = Path(path).read_text(encoding='utf-8').rstrip('\n')
-        self.assertEqual(content, 'error: foo bar')
-
-    def test_no_tag_produces_three_fields(self):
-        content = self._run('ts', 'https://example.com', 'Example')
-        parts = content.rstrip('\n').split('\t')
-        self.assertEqual(len(parts), 3)
+        self.assertEqual(content, f'{FIXED_REC_ID}\terror: foo bar')
 
     def test_tag_sanitised(self):
         content = self._run('ts', 'https://example.com', 'Example', tag='mem\torable')
         parts = content.rstrip('\n').split('\t')
-        self.assertEqual(parts[3], 'mem orable')
+        self.assertEqual(parts[4], 'mem orable')
 
 
 # ---------------------------------------------------------------------------
@@ -444,6 +490,22 @@ class TestTagVisit(unittest.TestCase):
         conn.close()
         self.assertEqual(count, 2)
 
+    def test_tag_visit_read_duplicate_timestamp_does_not_increment_counter(self):
+        # Regression test for the rowcount-gated counter increment: a duplicate
+        # (url, timestamp) pair is dropped by INSERT OR IGNORE, so the visits.read
+        # counter must not advance.  Replay safety hinges on this.
+        conn = self._conn()
+        host.insert_visit(conn, 'ts', 'https://example.com', 'Example')
+        host.tag_visit(conn, 'https://example.com', 'read', '2026-01-01T12:00:00Z')
+        host.tag_visit(conn, 'https://example.com', 'read', '2026-01-01T12:00:00Z')
+        count = conn.execute('SELECT read FROM visits').fetchone()[0]
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM read_events WHERE url = ?", ('https://example.com',)
+        ).fetchone()[0]
+        conn.close()
+        self.assertEqual(count, 1)
+        self.assertEqual(rows, 1)
+
     def test_tag_visit_of_interest_does_not_touch_read_or_skimmed(self):
         conn = self._conn()
         host.insert_visit(conn, 'ts', 'https://example.com', 'Example')
@@ -514,6 +576,21 @@ class TestTagVisit(unittest.TestCase):
         count = conn.execute('SELECT skimmed FROM visits').fetchone()[0]
         conn.close()
         self.assertEqual(count, 2)
+
+    def test_tag_visit_skimmed_duplicate_timestamp_does_not_increment_counter(self):
+        # Mirror of the read-side regression test: duplicate (url, timestamp) is
+        # dropped by INSERT OR IGNORE, so visits.skimmed must not advance.
+        conn = self._conn()
+        host.insert_visit(conn, 'ts', 'https://example.com', 'Example')
+        host.tag_visit(conn, 'https://example.com', 'skimmed', '2026-01-01T12:00:00Z')
+        host.tag_visit(conn, 'https://example.com', 'skimmed', '2026-01-01T12:00:00Z')
+        count = conn.execute('SELECT skimmed FROM visits').fetchone()[0]
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM skimmed_events WHERE url = ?", ('https://example.com',)
+        ).fetchone()[0]
+        conn.close()
+        self.assertEqual(count, 1)
+        self.assertEqual(rows, 1)
 
     def test_tag_visit_skimmed_does_not_set_of_interest_or_read(self):
         conn = self._conn()
@@ -841,8 +918,13 @@ class TestMain(unittest.TestCase):
                 {'timestamp': 'ts', 'url': 'https://example.com', 'title': 'Title'}, tmp)
             lines = Path(tmp, 'visits.log').read_text().splitlines()
         self.assertEqual(len(lines), 2)
+        action_parts = lines[0].split('\t')
+        result_parts = lines[1].split('\t')
+        # Action and result must share the same record_id (UUID hex prefix).
+        self.assertEqual(action_parts[0], result_parts[0])
+        self.assertRegex(action_parts[0], r'^[0-9a-f]{32}$')
         self.assertIn('https://example.com', lines[0])
-        self.assertEqual(lines[1], 'success')
+        self.assertEqual(result_parts[1], 'success')
 
     def test_auto_log_inserts_db_record(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1002,8 +1084,12 @@ class TestIntegration(unittest.TestCase):
                 tmp,
             )
             lines = Path(tmp, 'visits.log').read_text().splitlines()
-        self.assertEqual(lines[0], '2026-01-01T00:00:00Z\thttps://example.com\tExample Domain')
-        self.assertEqual(lines[1], 'success')
+        action_parts = lines[0].split('\t')
+        result_parts = lines[1].split('\t')
+        self.assertRegex(action_parts[0], r'^[0-9a-f]{32}$')
+        self.assertEqual(action_parts[1:], ['2026-01-01T00:00:00Z',
+                                            'https://example.com', 'Example Domain'])
+        self.assertEqual(result_parts, [action_parts[0], 'success'])
 
     def test_sqlite_record(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1278,31 +1364,42 @@ class TestIntegration(unittest.TestCase):
         self.assertEqual([e[0] for e in events], ['ts-skim-1', 'ts-skim-2'])
         self.assertEqual(skim_counter, 2)  # counter incremented twice
 
-    def test_tag_message_appends_four_field_log_line(self):
+    def test_tag_message_appends_six_field_log_line(self):
         url = 'https://example.com'
         with tempfile.TemporaryDirectory() as tmp:
             self._invoke(
                 {'timestamp': 'ts-visit', 'url': url, 'title': 'Example'}, tmp)
             self._invoke(
-                {'timestamp': 'ts-tag', 'url': url, 'title': 'Example', 'tag': 'read'}, tmp)
+                {'timestamp': 'ts-tag', 'url': url, 'title': 'Example',
+                 'tag': 'read', 'filename': 'browser-visit-snapshots/abc.mhtml'},
+                tmp)
             lines = Path(tmp, 'visits.log').read_text().splitlines()
         # lines[0]=visit action, lines[1]=visit result, lines[2]=tag action, lines[3]=tag result
         self.assertEqual(len(lines), 4)
         tag_action = lines[2].split('\t')
-        self.assertEqual(len(tag_action), 4)
-        self.assertEqual(tag_action[3], 'read')
-        self.assertEqual(lines[3], 'success')
+        tag_result = lines[3].split('\t')
+        # 6 fields: record_id, timestamp, url, title, tag, filename
+        self.assertEqual(len(tag_action), 6)
+        self.assertRegex(tag_action[0], r'^[0-9a-f]{32}$')
+        self.assertEqual(tag_action[4], 'read')
+        # filename is logged as Chrome reports it (Downloads-relative); host
+        # normalises to basename only when writing the DB row.
+        self.assertEqual(tag_action[5], 'browser-visit-snapshots/abc.mhtml')
+        self.assertEqual(tag_result, [tag_action[0], 'success'])
 
-    def test_auto_log_appends_three_field_log_line(self):
+    def test_auto_log_appends_four_field_log_line(self):
         with tempfile.TemporaryDirectory() as tmp:
             self._invoke(
                 {'timestamp': 'ts', 'url': 'https://example.com', 'title': 'Example'},
                 tmp,
             )
             lines = Path(tmp, 'visits.log').read_text().splitlines()
+        action_parts = lines[0].split('\t')
         self.assertEqual(len(lines), 2)
-        self.assertEqual(len(lines[0].split('\t')), 3)  # action: 3 fields
-        self.assertEqual(lines[1], 'success')
+        # 4 fields: record_id, timestamp, url, title
+        self.assertEqual(len(action_parts), 4)
+        self.assertRegex(action_parts[0], r'^[0-9a-f]{32}$')
+        self.assertEqual(lines[1].split('\t'), [action_parts[0], 'success'])
 
     def test_tag_without_prior_visit_succeeds_and_creates_visit(self):
         # Tagging a URL with no prior auto-log entry must now succeed: the host
@@ -1326,7 +1423,23 @@ class TestIntegration(unittest.TestCase):
         self.assertEqual(row[0], 'ts')       # timestamp from tag message
         self.assertEqual(row[1], '1')        # of_interest applied
         self.assertEqual(len(lines), 2)
-        self.assertEqual(lines[1], 'success')
+        self.assertEqual(lines[1].split('\t')[1], 'success')
+
+    def test_two_invocations_use_distinct_record_ids(self):
+        # Each main() call generates its own UUID; concurrent hosts can
+        # interleave safely because the replay tool joins by record_id.
+        with tempfile.TemporaryDirectory() as tmp:
+            self._invoke(
+                {'timestamp': 'ts1', 'url': 'https://a.com', 'title': 'A'}, tmp)
+            self._invoke(
+                {'timestamp': 'ts2', 'url': 'https://b.com', 'title': 'B'}, tmp)
+            lines = Path(tmp, 'visits.log').read_text().splitlines()
+        first_id  = lines[0].split('\t')[0]
+        second_id = lines[2].split('\t')[0]
+        self.assertNotEqual(first_id, second_id)
+        # Each invocation's action and result share their own record_id
+        self.assertEqual(lines[1].split('\t')[0], first_id)
+        self.assertEqual(lines[3].split('\t')[0], second_id)
 
     def test_query_unknown_url_returns_null_record(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/browser-visit-logger/tests/test_shell_wrappers.py
+++ b/browser-visit-logger/tests/test_shell_wrappers.py
@@ -32,6 +32,7 @@ WRAPPERS = [
     ('seal_snapshot_directory',   'snapshot_sealer.py'),
     ('verify_snapshot_directory', 'snapshot_verifier.py'),
     ('reset_visits_data',         'reset.py'),
+    ('rebuild_visits_data',       'visits_rebuilder.py'),
 ]
 
 
@@ -167,6 +168,26 @@ class TestWrapperForwarding(unittest.TestCase):
             )
             self.assertEqual(result.returncode, 0,
                              f'stderr: {result.stderr}')
+
+    def test_rebuild_visits_data_forwards_overrides_against_empty_log(self):
+        # rebuild_visits_data --log <empty file> --db <new path> --source/--dest
+        # against an empty log should reach the rebuilder, exit 0, and print
+        # the per-phase summary lines.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = os.path.join(tmp, 'visits.log')
+            Path(log).touch()
+            db   = os.path.join(tmp, 'visits.db')
+            src  = os.path.join(tmp, 'dl');     os.makedirs(src)
+            dest = os.path.join(tmp, 'icloud'); os.makedirs(dest)
+            result = subprocess.run(
+                [str(REPO_ROOT / 'rebuild_visits_data'),
+                 '--log', log, '--db', db, '--source', src, '--dest', dest],
+                capture_output=True, text=True, timeout=10,
+            )
+            self.assertEqual(result.returncode, 0,
+                             f'stderr: {result.stderr}')
+            self.assertIn('replay:',    result.stdout)
+            self.assertIn('rehydrate:', result.stdout)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/browser-visit-logger/tests/test_visits_rebuilder.py
+++ b/browser-visit-logger/tests/test_visits_rebuilder.py
@@ -1,0 +1,909 @@
+"""
+Tests for native-host/visits_rebuilder.py.
+
+Covers:
+
+- Phase 1 ("log replay"): hand-built logs exercise the happy path
+  (auto-log / of_interest / read / skimmed), error result skipping,
+  orphan handling, malformed-line handling, and idempotency.
+- Phase 2 ("filesystem rehydration"): an iCloud-archive layout with
+  sealed and unsealed daily dirs and conforming + non-conforming files
+  produces the expected snapshots rows and events.directory updates.
+- CLI: --truncate / --no-truncate / --log-only / --rehydrate-only
+  override flags, exit codes, mover_errors preservation, and a full
+  end-to-end round-trip via the host.py + snapshot_mover pipeline.
+"""
+import io
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import host
+import snapshot_mover
+import visits_rebuilder as vr
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+REC_A = '0' * 32
+REC_B = '1' * 32
+REC_C = '2' * 32
+REC_D = '3' * 32
+
+
+def _write_log(path, *lines):
+    """Write a log file from a list of TSV-pre-joined strings."""
+    with open(path, 'w', encoding='utf-8') as f:
+        for line in lines:
+            f.write(line + '\n')
+
+
+def _action(rec, ts, url, title, tag='', filename=None):
+    """Compose an action line.  filename=None omits the field; '' includes empty."""
+    fields = [rec, ts, url, title]
+    if tag:
+        fields.append(tag)
+        if filename is not None:
+            fields.append(filename)
+    return '\t'.join(fields)
+
+
+def _result(rec, payload):
+    return rec + '\t' + payload
+
+
+def _fresh_db(tmp):
+    """Fresh DB with all four rebuildable tables created."""
+    db = os.path.join(tmp, 'visits.db')
+    conn = sqlite3.connect(db)
+    host.ensure_db(conn)
+    snapshot_mover._ensure_snapshots_table(conn)
+    conn.close()
+    return db
+
+
+def _row_count(db, table):
+    conn = sqlite3.connect(db)
+    try:
+        return conn.execute(f'SELECT COUNT(*) FROM {table}').fetchone()[0]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — log replay
+# ---------------------------------------------------------------------------
+
+class TestReplayLog(unittest.TestCase):
+
+    def setUp(self):
+        self._tmpdirs = []
+
+    def tearDown(self):
+        import shutil
+        for d in self._tmpdirs:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def _replay(self, *lines):
+        """Common harness: write the lines, replay against a fresh DB,
+        return (db_path, stats).  The temp dir lives until tearDown."""
+        tmp = tempfile.mkdtemp()
+        self._tmpdirs.append(tmp)
+        log = os.path.join(tmp, 'visits.log')
+        _write_log(log, *lines)
+        db = _fresh_db(tmp)
+        conn = sqlite3.connect(db)
+        try:
+            stats = vr.replay_log(conn, log)
+        finally:
+            conn.close()
+        return db, stats
+
+    def test_round_trips_visits(self):
+        db, stats = self._replay(
+            _action(REC_A, '2026-01-01T00:00:00Z', 'https://a.com', 'A'),
+            _result(REC_A, 'success'),
+            _action(REC_B, '2026-01-02T00:00:00Z', 'https://b.com', 'B'),
+            _result(REC_B, 'success'),
+        )
+        conn = sqlite3.connect(db)
+        rows = conn.execute(
+            'SELECT url, timestamp, title FROM visits ORDER BY url'
+        ).fetchall()
+        conn.close()
+        self.assertEqual(rows, [
+            ('https://a.com', '2026-01-01T00:00:00Z', 'A'),
+            ('https://b.com', '2026-01-02T00:00:00Z', 'B'),
+        ])
+        self.assertEqual(stats.visits_inserted, 2)
+        self.assertEqual(stats.success_records, 2)
+        self.assertFalse(stats.has_skipped_lines)
+
+    def test_applies_of_interest(self):
+        db, _ = self._replay(
+            _action(REC_A, 'ts', 'https://a.com', 'A'),
+            _result(REC_A, 'success'),
+            _action(REC_B, 'ts', 'https://a.com', 'A', tag='of_interest'),
+            _result(REC_B, 'success'),
+        )
+        conn = sqlite3.connect(db)
+        of_interest = conn.execute(
+            'SELECT of_interest FROM visits WHERE url = ?', ('https://a.com',)
+        ).fetchone()[0]
+        conn.close()
+        # Stored as TEXT '1' per the schema.
+        self.assertEqual(of_interest, '1')
+
+    def test_applies_read_with_filename(self):
+        db, stats = self._replay(
+            _action(REC_A, 'ts0', 'https://a.com', 'A'),
+            _result(REC_A, 'success'),
+            _action(REC_B, 'ts1', 'https://a.com', 'A',
+                    tag='read', filename='2026-01-01T00-00-00Z-abc.mhtml'),
+            _result(REC_B, 'success'),
+        )
+        conn = sqlite3.connect(db)
+        events = conn.execute(
+            'SELECT timestamp, filename FROM read_events WHERE url = ?',
+            ('https://a.com',),
+        ).fetchall()
+        counter = conn.execute('SELECT read FROM visits').fetchone()[0]
+        conn.close()
+        self.assertEqual(events, [('ts1', '2026-01-01T00-00-00Z-abc.mhtml')])
+        self.assertEqual(counter, 1)
+        self.assertEqual(stats.read_events, 1)
+
+    def test_applies_skimmed_with_filename(self):
+        db, stats = self._replay(
+            _action(REC_A, 'ts0', 'https://a.com', 'A'),
+            _result(REC_A, 'success'),
+            _action(REC_B, 'ts1', 'https://a.com', 'A',
+                    tag='skimmed', filename='2026-01-02T00-00-00Z-def.mhtml'),
+            _result(REC_B, 'success'),
+        )
+        conn = sqlite3.connect(db)
+        events = conn.execute(
+            'SELECT timestamp, filename FROM skimmed_events WHERE url = ?',
+            ('https://a.com',),
+        ).fetchall()
+        conn.close()
+        self.assertEqual(events, [('ts1', '2026-01-02T00-00-00Z-def.mhtml')])
+        self.assertEqual(stats.skimmed_events, 1)
+
+    def test_skips_error_results(self):
+        db, stats = self._replay(
+            _action(REC_A, 'ts', 'https://a.com', 'A'),
+            _result(REC_A, 'error: log: permission denied; db: disk full'),
+            _action(REC_B, 'ts', 'https://b.com', 'B'),
+            _result(REC_B, 'success'),
+        )
+        conn = sqlite3.connect(db)
+        urls = [r[0] for r in conn.execute(
+            'SELECT url FROM visits ORDER BY url').fetchall()]
+        conn.close()
+        # Only B should have made it in; A was a recorded failure.
+        self.assertEqual(urls, ['https://b.com'])
+        self.assertEqual(stats.error_records, 1)
+        # An error pair is NOT an orphan — the host correctly emitted both lines.
+        self.assertEqual(stats.orphan_actions, 0)
+        self.assertEqual(stats.orphan_results, 0)
+        self.assertFalse(stats.has_skipped_lines)
+
+    def test_skips_orphan_action(self):
+        db, stats = self._replay(
+            _action(REC_A, 'ts', 'https://a.com', 'A'),
+            # No matching result — orphan action.
+            _action(REC_B, 'ts', 'https://b.com', 'B'),
+            _result(REC_B, 'success'),
+        )
+        conn = sqlite3.connect(db)
+        urls = [r[0] for r in conn.execute('SELECT url FROM visits').fetchall()]
+        conn.close()
+        self.assertEqual(urls, ['https://b.com'])
+        self.assertEqual(stats.orphan_actions, 1)
+        self.assertTrue(stats.has_skipped_lines)
+
+    def test_skips_orphan_result(self):
+        db, stats = self._replay(
+            _result(REC_A, 'success'),  # no matching action
+            _action(REC_B, 'ts', 'https://b.com', 'B'),
+            _result(REC_B, 'success'),
+        )
+        conn = sqlite3.connect(db)
+        urls = [r[0] for r in conn.execute('SELECT url FROM visits').fetchall()]
+        conn.close()
+        self.assertEqual(urls, ['https://b.com'])
+        self.assertEqual(stats.orphan_results, 1)
+        self.assertTrue(stats.has_skipped_lines)
+
+    def test_skips_malformed_lines(self):
+        db, stats = self._replay(
+            'this is not a uuid line at all',
+            _action(REC_A, 'ts', 'https://a.com', 'A'),
+            _result(REC_A, 'success'),
+        )
+        conn = sqlite3.connect(db)
+        n = conn.execute('SELECT COUNT(*) FROM visits').fetchone()[0]
+        conn.close()
+        self.assertEqual(n, 1)
+        self.assertEqual(stats.malformed_lines, 1)
+        self.assertTrue(stats.has_skipped_lines)
+
+    def test_skips_action_with_wrong_field_count(self):
+        # Right UUID prefix, wrong number of trailing fields → malformed.
+        db, stats = self._replay(
+            REC_A + '\textra1\textra2\textra3\textra4\textra5\textra6',
+            _action(REC_B, 'ts', 'https://b.com', 'B'),
+            _result(REC_B, 'success'),
+        )
+        conn = sqlite3.connect(db)
+        n = conn.execute('SELECT COUNT(*) FROM visits').fetchone()[0]
+        conn.close()
+        self.assertEqual(n, 1)
+        self.assertEqual(stats.malformed_lines, 1)
+
+    def test_idempotent_with_no_truncate(self):
+        # Replay the same log twice against the same DB — the second pass
+        # must produce no additional rows or counter increments.  This is
+        # the regression test for the rowcount-gated _insert_event fix.
+        with tempfile.TemporaryDirectory() as tmp:
+            log = os.path.join(tmp, 'visits.log')
+            _write_log(
+                log,
+                _action(REC_A, 'ts0', 'https://a.com', 'A'),
+                _result(REC_A, 'success'),
+                _action(REC_B, 'ts1', 'https://a.com', 'A',
+                        tag='read', filename='abc.mhtml'),
+                _result(REC_B, 'success'),
+                _action(REC_C, 'ts2', 'https://a.com', 'A',
+                        tag='skimmed', filename='def.mhtml'),
+                _result(REC_C, 'success'),
+                _action(REC_D, 'ts3', 'https://a.com', 'A', tag='of_interest'),
+                _result(REC_D, 'success'),
+            )
+            db = _fresh_db(tmp)
+            conn = sqlite3.connect(db)
+            try:
+                vr.replay_log(conn, log)
+                first = conn.execute(
+                    'SELECT url, timestamp, title, of_interest, read, skimmed '
+                    'FROM visits'
+                ).fetchall()
+                first_re = conn.execute(
+                    'SELECT timestamp, filename FROM read_events'
+                ).fetchall()
+                first_se = conn.execute(
+                    'SELECT timestamp, filename FROM skimmed_events'
+                ).fetchall()
+
+                vr.replay_log(conn, log)
+                second = conn.execute(
+                    'SELECT url, timestamp, title, of_interest, read, skimmed '
+                    'FROM visits'
+                ).fetchall()
+                second_re = conn.execute(
+                    'SELECT timestamp, filename FROM read_events'
+                ).fetchall()
+                second_se = conn.execute(
+                    'SELECT timestamp, filename FROM skimmed_events'
+                ).fetchall()
+            finally:
+                conn.close()
+        self.assertEqual(first, second)
+        self.assertEqual(first_re, second_re)
+        self.assertEqual(first_se, second_se)
+        # Counters must remain 1, not 2.
+        self.assertEqual(second[0][4], 1)  # read
+        self.assertEqual(second[0][5], 1)  # skimmed
+
+    def test_blank_lines_are_silently_skipped(self):
+        # Empty lines in the middle of the log should not count as malformed —
+        # they're a no-op (matches generic-text-log conventions).
+        db, stats = self._replay(
+            '',
+            _action(REC_A, 'ts', 'https://a.com', 'A'),
+            '',
+            _result(REC_A, 'success'),
+            '',
+        )
+        conn = sqlite3.connect(db)
+        n = conn.execute('SELECT COUNT(*) FROM visits').fetchone()[0]
+        conn.close()
+        self.assertEqual(n, 1)
+        self.assertEqual(stats.malformed_lines, 0)
+
+    def test_duplicate_record_id_for_pending_action_drops_prior(self):
+        # Defensive: should never happen with uuid4, but if a host process
+        # somehow emits two action lines with the same record_id before any
+        # result, the prior one is treated as orphan and the newer wins.
+        db, stats = self._replay(
+            _action(REC_A, 'ts0', 'https://a.com', 'A'),
+            _action(REC_A, 'ts1', 'https://b.com', 'B'),  # collision
+            _result(REC_A, 'success'),
+        )
+        conn = sqlite3.connect(db)
+        urls = [r[0] for r in conn.execute('SELECT url FROM visits').fetchall()]
+        conn.close()
+        # The second action wins (it owns the result).
+        self.assertEqual(urls, ['https://b.com'])
+        self.assertEqual(stats.orphan_actions, 1)
+
+    def test_unknown_tag_is_logged_but_does_not_crash(self):
+        # Forward-compatibility: a future tag in the log shouldn't crash
+        # the rebuild.  The visit row is still created; the tag itself is
+        # ignored — counters stay 0, of_interest stays NULL, and no event
+        # rows are created in either events table.
+        db, stats = self._replay(
+            _action(REC_A, 'ts', 'https://a.com', 'A', tag='wat'),
+            _result(REC_A, 'success'),
+        )
+        conn = sqlite3.connect(db)
+        row = conn.execute(
+            'SELECT of_interest, read, skimmed FROM visits WHERE url = ?',
+            ('https://a.com',),
+        ).fetchone()
+        n_read = conn.execute('SELECT COUNT(*) FROM read_events').fetchone()[0]
+        n_skim = conn.execute('SELECT COUNT(*) FROM skimmed_events').fetchone()[0]
+        conn.close()
+        self.assertIsNotNone(row)
+        self.assertIsNone(row[0])     # of_interest untouched
+        self.assertEqual(row[1], 0)   # read counter untouched
+        self.assertEqual(row[2], 0)   # skimmed counter untouched
+        self.assertEqual(n_read, 0)
+        self.assertEqual(n_skim, 0)
+        self.assertEqual(stats.success_records, 1)
+        self.assertEqual(stats.read_events, 0)
+        self.assertEqual(stats.skimmed_events, 0)
+        self.assertEqual(stats.of_interest_set, 0)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — filesystem rehydration
+# ---------------------------------------------------------------------------
+
+class TestRehydrateFilesystem(unittest.TestCase):
+
+    def _setup_archive(self, tmp):
+        """Build a minimal iCloud archive with one sealed + one unsealed dir,
+        plus one non-conforming file, plus one conforming-but-orphan file."""
+        icloud = os.path.join(tmp, 'icloud')
+        sealed_date   = '2026-04-29'
+        unsealed_date = '2026-04-30'
+        os.makedirs(os.path.join(icloud, sealed_date))
+        os.makedirs(os.path.join(icloud, unsealed_date))
+        # MANIFEST present → sealed
+        Path(os.path.join(icloud, sealed_date, 'MANIFEST.tsv')).write_text(
+            'filename\ttag\ttimestamp\turl\ttitle\n')
+        # Conforming snapshot files
+        good_sealed   = '2026-04-29T10-00-00Z-aaa.mhtml'
+        good_unsealed = '2026-04-30T11-00-00Z-bbb.mhtml'
+        orphan_file   = '2026-04-30T12-00-00Z-ccc.mhtml'
+        Path(os.path.join(icloud, sealed_date,   good_sealed)).touch()
+        Path(os.path.join(icloud, unsealed_date, good_unsealed)).touch()
+        Path(os.path.join(icloud, unsealed_date, orphan_file)).touch()
+        # A non-conforming filename that should be silently ignored.
+        Path(os.path.join(icloud, unsealed_date, 'README.txt')).touch()
+        return icloud, good_sealed, good_unsealed, orphan_file, sealed_date, unsealed_date
+
+    def test_upserts_snapshots_with_sealed_flag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            icloud, *_, sealed_date, unsealed_date = self._setup_archive(tmp)
+            db = _fresh_db(tmp)
+            conn = sqlite3.connect(db)
+            try:
+                stats = vr.rehydrate_filesystem(
+                    conn, icloud, host.DOWNLOADS_SNAPSHOTS_DIR)
+                rows = dict(conn.execute(
+                    'SELECT date, sealed FROM snapshots ORDER BY date'
+                ).fetchall())
+            finally:
+                conn.close()
+        self.assertEqual(rows, {sealed_date: 1, unsealed_date: 0})
+        self.assertEqual(stats.snapshots_upserted, 2)
+        self.assertEqual(stats.sealed_dirs, 1)
+        self.assertEqual(stats.unsealed_dirs, 1)
+
+    def test_relocates_event_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (icloud, good_sealed, good_unsealed, _orphan,
+             sealed_date, unsealed_date) = self._setup_archive(tmp)
+            db = _fresh_db(tmp)
+            conn = sqlite3.connect(db)
+            host.insert_visit(conn, 'ts0', 'https://a.com', 'A')
+            host.insert_visit(conn, 'ts0', 'https://b.com', 'B')
+            host.tag_visit(conn, 'https://a.com', 'read', 'ts1',
+                           filename=good_sealed)
+            host.tag_visit(conn, 'https://b.com', 'skimmed', 'ts2',
+                           filename=good_unsealed)
+            try:
+                stats = vr.rehydrate_filesystem(
+                    conn, icloud, host.DOWNLOADS_SNAPSHOTS_DIR)
+                read_dir = conn.execute(
+                    'SELECT directory FROM read_events WHERE url = ?',
+                    ('https://a.com',)
+                ).fetchone()[0]
+                skim_dir = conn.execute(
+                    'SELECT directory FROM skimmed_events WHERE url = ?',
+                    ('https://b.com',)
+                ).fetchone()[0]
+            finally:
+                conn.close()
+        self.assertEqual(read_dir, os.path.join(icloud, sealed_date))
+        self.assertEqual(skim_dir, os.path.join(icloud, unsealed_date))
+        # 1 read event + 1 skimmed event relocated.
+        self.assertEqual(stats.events_relocated, 2)
+        # The orphan file (no events row) is reported but not relocated.
+        self.assertEqual(stats.files_without_events, 1)
+
+    def test_does_not_touch_already_relocated_rows(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            icloud, good_sealed, *_, sealed_date, _ = self._setup_archive(tmp)
+            db = _fresh_db(tmp)
+            conn = sqlite3.connect(db)
+            host.insert_visit(conn, 'ts0', 'https://a.com', 'A')
+            # Manually insert with iCloud directory already set.
+            already = os.path.join(icloud, sealed_date)
+            conn.execute(
+                "INSERT INTO read_events (url, timestamp, filename, directory) "
+                "VALUES (?, ?, ?, ?)",
+                ('https://a.com', 'ts1', good_sealed, already),
+            )
+            conn.commit()
+            try:
+                vr.rehydrate_filesystem(
+                    conn, icloud, host.DOWNLOADS_SNAPSHOTS_DIR)
+                row = conn.execute(
+                    'SELECT directory FROM read_events WHERE url = ?',
+                    ('https://a.com',)
+                ).fetchone()
+            finally:
+                conn.close()
+        # Directory unchanged (and still equal to the original iCloud path).
+        self.assertEqual(row[0], already)
+
+    def test_skips_non_date_entries_at_icloud_root(self):
+        # A file named like a date and a directory not named like a date are
+        # both ignored.  Only entries that match _DATE_DIR_RE *and* are
+        # directories produce snapshots rows.
+        with tempfile.TemporaryDirectory() as tmp:
+            icloud = os.path.join(tmp, 'icloud')
+            os.makedirs(os.path.join(icloud, '2026-04-29'))   # real date dir
+            os.makedirs(os.path.join(icloud, 'not-a-date'))   # ignored dir
+            Path(os.path.join(icloud, '2026-04-30')).touch()  # date-named file
+            db = _fresh_db(tmp)
+            conn = sqlite3.connect(db)
+            try:
+                stats = vr.rehydrate_filesystem(
+                    conn, icloud, host.DOWNLOADS_SNAPSHOTS_DIR)
+                rows = conn.execute(
+                    'SELECT date FROM snapshots ORDER BY date'
+                ).fetchall()
+            finally:
+                conn.close()
+        self.assertEqual([r[0] for r in rows], ['2026-04-29'])
+        self.assertEqual(stats.snapshots_upserted, 1)
+
+    def test_missing_icloud_dir_is_a_noop(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = _fresh_db(tmp)
+            conn = sqlite3.connect(db)
+            try:
+                stats = vr.rehydrate_filesystem(
+                    conn, os.path.join(tmp, 'no-such-icloud'),
+                    host.DOWNLOADS_SNAPSHOTS_DIR)
+                n = conn.execute('SELECT COUNT(*) FROM snapshots').fetchone()[0]
+            finally:
+                conn.close()
+        self.assertEqual(n, 0)
+        self.assertEqual(stats.snapshots_upserted, 0)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+class _CLIBase(unittest.TestCase):
+    """Shared setup: build a temp dir with a log + DB + source/dest dirs and
+    return the CLI flag list."""
+
+    def _mk(self, lines=()):
+        """Create a tmp dir and return (tmp, args, paths)."""
+        tmp = tempfile.mkdtemp()
+        paths = {
+            'log':  os.path.join(tmp, 'visits.log'),
+            'db':   os.path.join(tmp, 'visits.db'),
+            'src':  os.path.join(tmp, 'dl'),
+            'dest': os.path.join(tmp, 'icloud'),
+        }
+        _write_log(paths['log'], *lines)
+        os.makedirs(paths['src'])
+        os.makedirs(paths['dest'])
+        args = ['--log',    paths['log'],
+                '--db',     paths['db'],
+                '--source', paths['src'],
+                '--dest',   paths['dest']]
+        return tmp, args, paths
+
+    def _run(self, args):
+        """Run vr.cli with the given args, capturing stdout, restoring globals."""
+        # cli() mutates host.* and snapshot_mover.* globals; restore them so
+        # one test doesn't pollute the next.
+        saved = (
+            host.DOWNLOADS_SNAPSHOTS_DIR, host.DB_FILE,
+            snapshot_mover.ICLOUD_SNAPSHOTS_DIR,
+        )
+        buf = io.StringIO()
+        try:
+            with redirect_stdout(buf):
+                rc = vr.cli(args)
+        finally:
+            (host.DOWNLOADS_SNAPSHOTS_DIR, host.DB_FILE,
+             snapshot_mover.ICLOUD_SNAPSHOTS_DIR) = saved
+        return rc, buf.getvalue()
+
+
+class TestCLI(_CLIBase):
+
+    def test_clean_run_exits_zero(self):
+        tmp, args, paths = self._mk(lines=(
+            _action(REC_A, 'ts', 'https://a.com', 'A'),
+            _result(REC_A, 'success'),
+        ))
+        try:
+            rc, out = self._run(args)
+            self.assertEqual(rc, 0, out)
+            self.assertIn('replay:',    out)
+            self.assertIn('rehydrate:', out)
+            self.assertEqual(_row_count(paths['db'], 'visits'), 1)
+        finally:
+            __import__('shutil').rmtree(tmp, ignore_errors=True)
+
+    def test_orphans_trip_nonzero_exit_but_well_formed_records_still_apply(self):
+        # Orphans should report (non-zero exit) without aborting the rebuild —
+        # the well-formed records around them must still be applied.
+        tmp, args, paths = self._mk(lines=(
+            _action(REC_A, 'ts', 'https://a.com', 'A'),
+            # orphan action — no result
+            _action(REC_B, 'ts', 'https://b.com', 'B'),
+            _result(REC_B, 'success'),
+        ))
+        try:
+            rc, _ = self._run(args)
+            self.assertEqual(rc, 1)
+            urls = sorted(r[0] for r in sqlite3.connect(paths['db']).execute(
+                'SELECT url FROM visits').fetchall())
+            self.assertEqual(urls, ['https://b.com'])
+        finally:
+            __import__('shutil').rmtree(tmp, ignore_errors=True)
+
+    def test_missing_log_exits_nonzero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            args = ['--log', os.path.join(tmp, 'no-such.log'),
+                    '--db',  os.path.join(tmp, 'visits.db')]
+            rc, _ = self._run(args)
+        self.assertEqual(rc, 1)
+
+    def test_truncate_default_wipes_rebuildable_tables_but_keeps_mover_errors(self):
+        tmp, args, paths = self._mk(lines=(
+            _action(REC_A, 'ts0', 'https://a.com', 'A'),
+            _result(REC_A, 'success'),
+        ))
+        try:
+            # Pre-populate every rebuildable table + mover_errors with junk
+            # rows so we can assert each is wiped (or preserved) correctly.
+            conn = sqlite3.connect(paths['db'])
+            host.ensure_db(conn)
+            snapshot_mover._ensure_snapshots_table(conn)
+            snapshot_mover._ensure_mover_errors_table(conn)
+            host.insert_visit(conn, 'old-ts', 'https://stale.example', 'stale')
+            conn.execute(
+                "INSERT INTO read_events (url, timestamp, filename, directory) "
+                "VALUES (?, ?, ?, ?)",
+                ('https://stale.example', 'old-r', 'old.mhtml', '/old/dir'),
+            )
+            conn.execute(
+                "INSERT INTO skimmed_events (url, timestamp, filename, directory) "
+                "VALUES (?, ?, ?, ?)",
+                ('https://stale.example', 'old-s', 'old.mhtml', '/old/dir'),
+            )
+            conn.execute(
+                "INSERT INTO snapshots (date, sealed) VALUES (?, ?)",
+                ('1999-01-01', 1),
+            )
+            conn.execute(
+                "INSERT INTO mover_errors "
+                "(key, operation, target, message, first_seen, last_seen) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ('move:foo', 'move', 'foo', 'some msg', 'ts', 'ts'),
+            )
+            conn.commit()
+            conn.close()
+
+            rc, _ = self._run(args)
+            self.assertEqual(rc, 0)
+
+            conn = sqlite3.connect(paths['db'])
+            urls = [r[0] for r in conn.execute(
+                'SELECT url FROM visits ORDER BY url').fetchall()]
+            stale_re = conn.execute(
+                "SELECT 1 FROM read_events WHERE timestamp = 'old-r'"
+            ).fetchone()
+            stale_se = conn.execute(
+                "SELECT 1 FROM skimmed_events WHERE timestamp = 'old-s'"
+            ).fetchone()
+            stale_snap = conn.execute(
+                "SELECT 1 FROM snapshots WHERE date = '1999-01-01'"
+            ).fetchone()
+            mover_errors_count = conn.execute(
+                'SELECT COUNT(*) FROM mover_errors').fetchone()[0]
+            conn.close()
+            # All four rebuildable tables truncated; only the replayed row remains.
+            self.assertEqual(urls, ['https://a.com'])
+            self.assertIsNone(stale_re)
+            self.assertIsNone(stale_se)
+            self.assertIsNone(stale_snap)
+            # mover_errors row preserved across the rebuild.
+            self.assertEqual(mover_errors_count, 1)
+        finally:
+            __import__('shutil').rmtree(tmp, ignore_errors=True)
+
+    def test_no_truncate_preserves_existing_rows(self):
+        tmp, args, paths = self._mk(lines=(
+            _action(REC_A, 'ts', 'https://a.com', 'A'),
+            _result(REC_A, 'success'),
+        ))
+        try:
+            conn = sqlite3.connect(paths['db'])
+            host.ensure_db(conn)
+            host.insert_visit(conn, 'old-ts', 'https://kept.example', 'kept')
+            conn.close()
+
+            rc, _ = self._run(args + ['--no-truncate'])
+            self.assertEqual(rc, 0)
+            urls = sorted(r[0] for r in sqlite3.connect(paths['db']).execute(
+                'SELECT url FROM visits').fetchall())
+            self.assertEqual(urls, ['https://a.com', 'https://kept.example'])
+        finally:
+            __import__('shutil').rmtree(tmp, ignore_errors=True)
+
+    def test_log_only_skips_rehydrate(self):
+        tmp, args, paths = self._mk(lines=(
+            _action(REC_A, 'ts', 'https://a.com', 'A'),
+            _result(REC_A, 'success'),
+        ))
+        try:
+            # Pre-create an iCloud date dir so rehydrate, if invoked, would
+            # add a snapshots row; --log-only must suppress that.
+            os.makedirs(os.path.join(paths['dest'], '2026-04-29'))
+            rc, out = self._run(args + ['--log-only'])
+            self.assertEqual(rc, 0)
+            self.assertIn('replay:',     out)
+            self.assertNotIn('rehydrate:', out)
+            self.assertEqual(_row_count(paths['db'], 'snapshots'), 0)
+        finally:
+            __import__('shutil').rmtree(tmp, ignore_errors=True)
+
+    def test_rehydrate_only_skips_replay_and_tolerates_missing_log(self):
+        tmp, args, paths = self._mk(lines=())
+        # Point at a non-existent log; --rehydrate-only must not require it.
+        os.unlink(paths['log'])
+        try:
+            os.makedirs(os.path.join(paths['dest'], '2026-04-29'))
+            rc, out = self._run(args + ['--rehydrate-only'])
+            self.assertEqual(rc, 0, out)
+            self.assertNotIn('replay:',  out)
+            self.assertIn('rehydrate:', out)
+            self.assertEqual(_row_count(paths['db'], 'snapshots'), 1)
+            self.assertEqual(_row_count(paths['db'], 'visits'), 0)
+        finally:
+            __import__('shutil').rmtree(tmp, ignore_errors=True)
+
+    def test_missing_db_parent_dir_exits_nonzero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = os.path.join(tmp, 'visits.log')
+            Path(log).touch()
+            args = ['--log', log,
+                    '--db', os.path.join(tmp, 'no-such-dir', 'visits.db')]
+            rc, _ = self._run(args)
+        self.assertEqual(rc, 1)
+
+    def test_unexpected_exception_exits_two(self):
+        # If the orchestrator raises (e.g. a bug or a corrupt DB file),
+        # the CLI should swallow the traceback and exit with code 2 rather
+        # than dumping a stacktrace at the user.
+        tmp, args, _ = self._mk(lines=())
+        try:
+            with patch.object(vr, 'rebuild', side_effect=RuntimeError('boom')):
+                rc, _ = self._run(args)
+            self.assertEqual(rc, 2)
+        finally:
+            __import__('shutil').rmtree(tmp, ignore_errors=True)
+
+    def test_verbose_flag_enables_debug_logging(self):
+        tmp, args, _ = self._mk(lines=())
+        try:
+            rc, _ = self._run(args + ['-v'])
+            self.assertEqual(rc, 0)
+            self.assertEqual(vr.logger.level, __import__('logging').DEBUG)
+        finally:
+            # Reset logger level so we don't leak DEBUG into other tests.
+            vr.logger.setLevel(__import__('logging').WARNING)
+            __import__('shutil').rmtree(tmp, ignore_errors=True)
+
+    def test_log_only_and_rehydrate_only_are_mutually_exclusive(self):
+        tmp, args, _ = self._mk(lines=())
+        try:
+            with self.assertRaises(SystemExit):
+                self._run(args + ['--log-only', '--rehydrate-only'])
+        finally:
+            __import__('shutil').rmtree(tmp, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via host.py + snapshot_mover
+# ---------------------------------------------------------------------------
+
+class TestEndToEnd(unittest.TestCase):
+    """Full pipeline round-trip: drive host.main() for a few messages, run
+    the mover/sealer pass, snapshot the DB, wipe the DB, run rebuild, and
+    diff.  The rebuilt DB must match the original (modulo mover_errors)."""
+
+    def _drive_host(self, message, tmp):
+        """Call host.main() inline with patched paths and a JSON message
+        delivered via stdin in the native-messaging framing format."""
+        import json, struct
+        payload = json.dumps(message).encode('utf-8')
+        framed = struct.pack('<I', len(payload)) + payload
+
+        log_path = os.path.join(tmp, 'visits.log')
+        db_path  = os.path.join(tmp, 'visits.db')
+        src      = os.path.join(tmp, 'dl')
+
+        stdin  = io.BytesIO(framed)
+        stdout = io.BytesIO()
+        stdin.buffer  = stdin   # host expects sys.stdin.buffer
+        stdout.buffer = stdout  # and sys.stdout.buffer
+
+        with patch.object(host, 'LOG_FILE', log_path), \
+             patch.object(host, 'DB_FILE',  db_path), \
+             patch.object(host, 'DOWNLOADS_SNAPSHOTS_DIR', src), \
+             patch.object(sys, 'stdin',  stdin), \
+             patch.object(sys, 'stdout', stdout):
+            host.main()
+
+    def _snapshot_tables(self, db_path):
+        """Return a dict {table: list[tuple]} for the rebuildable tables.
+        mover_errors is intentionally excluded — it's not log-recoverable
+        and the rebuild leaves it untouched."""
+        snap = {}
+        conn = sqlite3.connect(db_path)
+        try:
+            snap['visits'] = conn.execute(
+                'SELECT url, timestamp, title, of_interest, read, skimmed '
+                'FROM visits ORDER BY url'
+            ).fetchall()
+            snap['read_events'] = conn.execute(
+                'SELECT url, timestamp, filename, directory FROM read_events '
+                'ORDER BY url, timestamp'
+            ).fetchall()
+            snap['skimmed_events'] = conn.execute(
+                'SELECT url, timestamp, filename, directory FROM skimmed_events '
+                'ORDER BY url, timestamp'
+            ).fetchall()
+            snap['snapshots'] = conn.execute(
+                'SELECT date, sealed FROM snapshots ORDER BY date'
+            ).fetchall()
+        finally:
+            conn.close()
+        return snap
+
+    def test_round_trip_matches_original(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src  = os.path.join(tmp, 'dl');     os.makedirs(src)
+            dest = os.path.join(tmp, 'icloud'); os.makedirs(dest)
+            db   = os.path.join(tmp, 'visits.db')
+            log  = os.path.join(tmp, 'visits.log')
+
+            # Seed a few host invocations: visit, of_interest, read, skimmed.
+            self._drive_host({'timestamp': '2026-04-29T10:00:00Z',
+                              'url': 'https://a.com', 'title': 'A'}, tmp)
+            self._drive_host({'timestamp': '2026-04-29T10:00:00Z',
+                              'url': 'https://a.com', 'title': 'A',
+                              'tag': 'of_interest'}, tmp)
+
+            # Place a snapshot file so the mover has work to do.
+            read_filename = '2026-04-29T11-00-00Z-aaa.mhtml'
+            Path(os.path.join(src, read_filename)).touch()
+            # Backdate so the mover's freshness gate (60s) lets it pass.
+            os.utime(os.path.join(src, read_filename), (1, 1))
+            self._drive_host({'timestamp': '2026-04-29T11:00:00Z',
+                              'url': 'https://a.com', 'title': 'A',
+                              'tag': 'read', 'filename': read_filename}, tmp)
+
+            skim_filename = '2026-04-29T12-00-00Z-bbb.mhtml'
+            Path(os.path.join(src, skim_filename)).touch()
+            os.utime(os.path.join(src, skim_filename), (1, 1))
+            self._drive_host({'timestamp': '2026-04-29T12:00:00Z',
+                              'url': 'https://b.com', 'title': 'B',
+                              'tag': 'skimmed', 'filename': skim_filename}, tmp)
+
+            # Run a mover + seal pass against these paths.
+            saved = (
+                snapshot_mover.DOWNLOADS_SNAPSHOTS_DIR,
+                snapshot_mover.ICLOUD_SNAPSHOTS_DIR,
+                snapshot_mover.DB_FILE,
+            )
+            try:
+                snapshot_mover.DOWNLOADS_SNAPSHOTS_DIR = src
+                snapshot_mover.ICLOUD_SNAPSHOTS_DIR    = dest
+                snapshot_mover.DB_FILE                 = db
+                conn = sqlite3.connect(db)
+                snapshot_mover._ensure_snapshots_table(conn)
+                snapshot_mover._ensure_mover_errors_table(conn)
+                snapshot_mover._move_pass(conn)
+                snapshot_mover._seal_pass(conn)
+                conn.close()
+            finally:
+                (snapshot_mover.DOWNLOADS_SNAPSHOTS_DIR,
+                 snapshot_mover.ICLOUD_SNAPSHOTS_DIR,
+                 snapshot_mover.DB_FILE) = saved
+
+            # Snapshot table contents, wipe the DB, run the rebuild.
+            before = self._snapshot_tables(db)
+            os.unlink(db)
+
+            saved2 = (host.DOWNLOADS_SNAPSHOTS_DIR, host.DB_FILE,
+                      snapshot_mover.ICLOUD_SNAPSHOTS_DIR)
+            try:
+                rc = vr.cli(['--log', log, '--db', db,
+                             '--source', src, '--dest', dest])
+            finally:
+                (host.DOWNLOADS_SNAPSHOTS_DIR, host.DB_FILE,
+                 snapshot_mover.ICLOUD_SNAPSHOTS_DIR) = saved2
+            self.assertEqual(rc, 0)
+
+            after = self._snapshot_tables(db)
+
+        # All four log/FS-recoverable tables must round-trip identically.
+        # mover_errors is intentionally not compared — it's allowed to
+        # diverge (rebuild leaves it untouched / starts empty).
+        self.assertEqual(before, after)
+
+
+# ---------------------------------------------------------------------------
+# Wrapper smoke (subprocess so we exercise the bash side too)
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestWrapperSmoke(unittest.TestCase):
+
+    def test_wrapper_runs_against_empty_log(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = os.path.join(tmp, 'visits.log')
+            Path(log).touch()
+            db   = os.path.join(tmp, 'visits.db')
+            src  = os.path.join(tmp, 'dl');     os.makedirs(src)
+            dest = os.path.join(tmp, 'icloud'); os.makedirs(dest)
+            result = subprocess.run(
+                [str(REPO_ROOT / 'rebuild_visits_data'),
+                 '--log', log, '--db', db, '--source', src, '--dest', dest],
+                capture_output=True, text=True, timeout=10,
+            )
+        self.assertEqual(result.returncode, 0,
+                         f'stderr: {result.stderr}')
+        self.assertIn('replay:',    result.stdout)
+        self.assertIn('rehydrate:', result.stdout)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- New `rebuild_visits_data` CLI (+ `native-host/visits_rebuilder.py`) reconstructs `browser-visits.db` from two durable side-channels: phase 1 replays the on-disk log; phase 2 walks the iCloud snapshot archive to repopulate the `snapshots` table and relocate `events.directory` from Downloads to the date subdir.
- Log format change: every host invocation now prepends a `uuid4().hex` to both the action and result lines (so the replay tool can pair them under concurrent invocations), and `read`/`skimmed` action lines carry a trailing `filename` column so each event row's snapshot can be reconstructed.
- Latent bug fix in `_insert_event`: the visits counter was incremented unconditionally even when `INSERT OR IGNORE` no-oped on a duplicate `(url, timestamp)`. Counter is now gated on `cursor.rowcount`, making replay (and any future re-application) safe.
- `mover_errors` is intentionally **not** rebuilt — it's operational state that the next mover/sealer/verifier pass repopulates from the FS. Only the four log/FS-recoverable tables (`visits`, `read_events`, `skimmed_events`, `snapshots`) round-trip.
- Design doc: [docs/rebuild-visits-from-log.md](https://github.com/theimer/hello-world/blob/claude/exciting-curie-494058/browser-visit-logger/docs/rebuild-visits-from-log.md).

## Test plan
- [x] `python3 -m pytest tests/ --cov=native-host --cov-report=term-missing` — 374 passing, 100% line coverage on `host.py`, `snapshot_mover.py`, `snapshot_sealer.py`, `snapshot_verifier.py`, and the new `visits_rebuilder.py`.
- [x] `npm test -- --coverage` — 94 passing, 100% coverage on `background.js` and `popup.js`.
- [x] `./rebuild_visits_data --help` prints the wrapper blurb followed by the Python `--help`.
- [x] End-to-end test (`test_round_trip_matches_original`) drives full host → mover → sealer pipeline, snapshots tables, wipes the DB, runs the rebuilder, and asserts every rebuildable table round-trips identically.
- [ ] Manual smoke against real `~/browser-visits.db`: `./rebuild_visits_data --db /tmp/rebuilt.db` against the live log + iCloud archive, then `diff` the dumps to confirm only `mover_errors` differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)