### PR TITLE
Split visit log into per-day files; sealer collects each day's log

### DIFF
--- a/browser-visit-logger/README.md
+++ b/browser-visit-logger/README.md
@@ -43,13 +43,13 @@ read-only, and (once the day has fully passed) writes a
 
 | Path | What it is |
 |------|------------|
-| `~/browser-visits.log` | TSV append-only log of every visit and tag action |
-| `~/browser-visits.db` | SQLite database — `visits`, `read_events`, `skimmed_events` |
+| `~/browser-visits-<YYYY-MM-DD>.log` | Per-day TSV append-only log of every visit and tag action.  One file per UTC day; the sealer collects each completed day's log into the matching iCloud sealed dir |
+| `~/browser-visits.db` | SQLite database — `visits`, `read_events`, `skimmed_events`, `snapshots`, `mover_errors` |
 | `~/browser-visits-host.log` | Native host process log (rotated, 1 MiB × 3) |
 | `~/browser-visits-mover.log` | Snapshot mover process log (LaunchAgent stdout/stderr) |
 | `~/browser-visits-verifier.log` | Snapshot verifier process log (LaunchAgent stdout/stderr) |
 | `~/Downloads/browser-visit-snapshots/` | Snapshot staging dir (Chrome writes here) |
-| `~/Documents/browser-visit-logger/snapshots/<YYYY-MM-DD>/` | Sealed daily archive (read-only files + read-only `MANIFEST.tsv`) |
+| `~/Documents/browser-visit-logger/snapshots/<YYYY-MM-DD>/` | Sealed daily archive: read-only snapshot files + read-only `MANIFEST.tsv` + read-only `browser-visits-<YYYY-MM-DD>.log` |
 
 All paths can be overridden via `BVL_*` environment variables — see
 [Configuration](#configuration).
@@ -141,7 +141,7 @@ After it finishes:
    the installer.
 4. Visit any page, then verify with:
    ```bash
-   tail ~/browser-visits.log
+   tail ~/browser-visits-$(date -u +%Y-%m-%d).log
    sqlite3 ~/browser-visits.db "SELECT * FROM visits ORDER BY timestamp DESC LIMIT 10;"
    ```
 
@@ -269,12 +269,25 @@ exclusive.
    recovered on the next tick.
 2. **Seal pass** — DB-driven, no filesystem rescan. Queries
    `snapshots WHERE sealed = 0 AND date < today_utc`. For each row:
-   verifies the on-disk directory exists (warns and skips if not),
-   writes a tab-delimited `MANIFEST.tsv` enumerating the directory's
-   contents, chmods it `0o444`, then flips `sealed = 1`. If the
-   manifest already exists (recovery from a partial prior seal that
-   crashed before the DB update), the file is left untouched and only
-   the DB flag is flipped.
+   creates `<dest>/<YYYY-MM-DD>/` if it doesn't yet exist (covers
+   activity-only days where host wrote a per-day log but no snapshot
+   files landed), writes a tab-delimited `MANIFEST.tsv` enumerating
+   the directory's contents and chmods it `0o444`, **moves
+   `<BVL_LOG_DIR>/browser-visits-<date>.log` into the dir and chmods
+   it `0o444`**, then flips `sealed = 1`.  If the manifest write or
+   log move fails, the row stays at `sealed=0` and the next tick
+   retries.
+3. **Orphan-log merge pass** — anti-entropy for the rare case where a
+   host invocation in flight at seal time leaves a result line in
+   `<BVL_LOG_DIR>` after the seal already moved its action half into
+   iCloud.  Each tick the mover scans `BVL_LOG_DIR` for past-day
+   `browser-visits-<date>.log` files; for any whose iCloud
+   counterpart already exists, the orphan is appended into the iCloud
+   copy (chmod 0o644 → append → chmod 0o444) and the orphan is
+   deleted.  For any whose iCloud counterpart doesn't exist (host
+   crashed mid-startup before it could insert the snapshots row),
+   `INSERT OR IGNORE INTO snapshots (date, sealed=0)` so the next
+   normal seal pass picks it up.
 
 ### `native-host/snapshot_sealer.py`
 
@@ -311,8 +324,12 @@ delete the manifest first.
 
 If the directory's basename is a valid `YYYY-MM-DD` date, the sealer
 also upserts a `(date, sealed=1)` row into the `snapshots` table — so
-the auto seal pass won't re-process it. Non-date-named directories
-get a manifest but no table row.
+the auto seal pass won't re-process it.  When a per-day log file
+exists in `BVL_LOG_DIR` for that date, it's moved into the sealed dir
+(chmod `0o444`) as part of the seal — same flow as the auto sealer.
+The orphan-log merge pass also runs after the manual seal, so
+ad-hoc seals clean up any race orphans in `BVL_LOG_DIR`.
+Non-date-named directories get a manifest but no table row and no log.
 
 **Manifest format** — `MANIFEST.tsv`, one header row + one row per file:
 
@@ -417,19 +434,23 @@ next tick, just run the script directly with `--all`.
 Wipes local data the extension produced. Asks for confirmation by default.
 
 ```bash
-# Reset everything (visit log, host log, mover log, DB, both snapshot dirs)
+# Reset everything (per-day visit logs, host log, mover log, DB, both snapshot dirs)
 python3 reset.py
 
 # Skip confirmation
 python3 reset.py -f
 
 # Reset one thing only
-python3 reset.py --log         # ~/browser-visits.log
+python3 reset.py --log         # all ~/browser-visits-<date>.log files in BVL_LOG_DIR
 python3 reset.py --host-log    # host log + mover log
 python3 reset.py --db          # ~/browser-visits.db
 python3 reset.py --snapshots   # ~/Downloads/browser-visit-snapshots/
-python3 reset.py --icloud      # ~/Documents/browser-visit-logger/
+python3 reset.py --icloud      # ~/Documents/browser-visit-logger/  (also wipes per-day logs sealed in iCloud)
 ```
+
+`--log` only deletes per-day logs that still live in `BVL_LOG_DIR`.
+Per-day logs that have already been moved into iCloud sealed dirs are
+wiped by `--icloud` — same separation between log and snapshot data.
 
 Respects the same `BVL_*` env vars as the host, so custom paths Just
 Work. Safe to run with no targets present — missing files/dirs are
@@ -438,15 +459,21 @@ reported and skipped.
 ### `native-host/visits_rebuilder.py`
 
 Reconstructs `~/browser-visits.db` from two side-channels that survive
-DB loss: the on-disk log (`~/browser-visits.log`) and the iCloud
-snapshot archive.  Two phases run by default:
+DB loss: the per-day on-disk logs (`~/browser-visits-<date>.log` plus
+each sealed iCloud subdir's bundled log) and the iCloud snapshot
+archive.  Two phases run by default:
 
 1. **Log replay** — every host invocation writes a UUID-prefixed
-   action line followed by a result line; the rebuilder pairs them by
-   UUID and re-applies each *successful* action via the same
-   `host.py` helpers used at write-time.  Error pairs are skipped
-   (the DB write didn't happen).  Orphan / malformed lines are
-   counted and trip a non-zero exit.
+   action line followed by a result line, pinned to the day the
+   invocation started.  The rebuilder enumerates per-day logs from
+   `BVL_LOG_DIR` *and* every sealed iCloud subdir, sorts them
+   chronologically, and pairs action+result UUIDs across files (so
+   the rare cross-day seal-race orphan is handled correctly).
+   Successful pairs are re-applied via the same `host.py` helpers
+   used at write-time; error pairs are skipped (the DB write didn't
+   happen); orphan / malformed lines are counted and trip a non-zero
+   exit.  Each replayed log file's date also produces a `snapshots`
+   row (mirrors the live INSERT host.py does).
 2. **Filesystem rehydration** — iterates every `YYYY-MM-DD`
    subdirectory under the iCloud root, upserts a `snapshots` row
    (`sealed = 1` if `MANIFEST.tsv` exists), and updates each event
@@ -461,15 +488,15 @@ snapshot archive.  Two phases run by default:
 # Skip the wipe; rely on idempotency
 ./rebuild_visits_data --no-truncate
 
-# Phase 1 only (e.g. log present, iCloud unreachable)
+# Phase 1 only (e.g. logs present, iCloud unreachable)
 ./rebuild_visits_data --log-only
 
-# Phase 2 only (log lost, iCloud archive intact)
+# Phase 2 only (logs lost, iCloud archive intact)
 ./rebuild_visits_data --rehydrate-only
 
 # Operate on isolated paths (useful in tests / experiments)
 ./rebuild_visits_data \
-    --log /tmp/visits.log --db /tmp/test.db \
+    --log-dir /tmp/logs --db /tmp/test.db \
     --source /tmp/dl --dest /tmp/icloud
 ```
 
@@ -479,7 +506,7 @@ Flags:
 |------|--------|
 | `--truncate` (default) / `--no-truncate` | DROP and recreate the four rebuildable tables before phase 1.  `mover_errors` is left alone in either case. |
 | `--log-only` / `--rehydrate-only` | Skip phase 2 / phase 1 (mutually exclusive). |
-| `--log FILE` | Override `BVL_LOG_FILE` |
+| `--log-dir DIR` | Override `BVL_LOG_DIR` (the per-day logs root) |
 | `--db FILE` | Override `BVL_DB_FILE` |
 | `--source DIR` | Override `BVL_DOWNLOADS_SNAPSHOTS_DIR` |
 | `--dest DIR` | Override `BVL_ICLOUD_SNAPSHOTS_DIR` |
@@ -593,13 +620,13 @@ env vars; env vars override defaults.
 
 | Variable | Default | Used by |
 |----------|---------|---------|
-| `BVL_LOG_FILE` | `~/browser-visits.log` | host, reset |
+| `BVL_LOG_DIR` | `~` | host, mover (orphan-merge + log move during seal), sealer, rebuilder, reset.  The directory holding per-day `browser-visits-<UTC-date>.log` files. |
 | `BVL_HOST_LOG` | `~/browser-visits-host.log` | host, reset |
 | `BVL_MOVER_LOG` | `~/browser-visits-mover.log` | reset (mover writes via LaunchAgent stdout/stderr) |
 | `BVL_VERIFIER_LOG` | `~/browser-visits-verifier.log` | reset (verifier writes via LaunchAgent stdout/stderr) |
-| `BVL_DB_FILE` | `~/browser-visits.db` | host, mover, sealer, reset |
-| `BVL_DOWNLOADS_SNAPSHOTS_DIR` | `~/Downloads/browser-visit-snapshots` | host, mover, reset |
-| `BVL_ICLOUD_SNAPSHOTS_DIR` | `~/Documents/browser-visit-logger/snapshots` | host, mover, sealer |
+| `BVL_DB_FILE` | `~/browser-visits.db` | host, mover, sealer, rebuilder, reset |
+| `BVL_DOWNLOADS_SNAPSHOTS_DIR` | `~/Downloads/browser-visit-snapshots` | host, mover, rebuilder, reset |
+| `BVL_ICLOUD_SNAPSHOTS_DIR` | `~/Documents/browser-visit-logger/snapshots` | host, mover, sealer, rebuilder |
 | `BVL_MOVER_MIN_AGE_SECONDS` | `60` | mover |
 | `BVL_MOVER_ERROR_THRESHOLD` | `3` | mover (consecutive failures before persistent-error notification) |
 

--- a/browser-visit-logger/native-host/host.py
+++ b/browser-visit-logger/native-host/host.py
@@ -54,8 +54,21 @@ Schema
         directory TEXT NOT NULL DEFAULT '<DOWNLOADS_SNAPSHOTS_DIR>',  -- absolute parent dir
         PRIMARY KEY (url, timestamp)
     )
+
+    snapshots (
+        date   TEXT PRIMARY KEY,         -- 'YYYY-MM-DD' (UTC) of host activity
+        sealed INTEGER NOT NULL DEFAULT 0
+    )
+
+Log file layout
+---------------
+The visit log is split per UTC day: <LOG_DIR>/browser-visits-<YYYY-MM-DD>.log.
+Each invocation pins its date at start (so action+result lines stay together
+even across midnight UTC).  The sealer (snapshot_mover.py) moves each day's
+log into the matching iCloud snapshot directory once the day is complete.
 """
 
+import datetime
 import json
 import logging
 import os
@@ -71,7 +84,9 @@ from logging.handlers import RotatingFileHandler
 # (env var overrides are used by the test suite to isolate test output)
 # ---------------------------------------------------------------------------
 HOME     = os.path.expanduser('~')
-LOG_FILE = os.environ.get('BVL_LOG_FILE', os.path.join(HOME, 'browser-visits.log'))
+# Per-day visit logs live under LOG_DIR as `browser-visits-<UTC-date>.log`.
+# The sealer collects each day's log into the matching iCloud snapshot dir.
+LOG_DIR  = os.environ.get('BVL_LOG_DIR',  HOME)
 DB_FILE  = os.environ.get('BVL_DB_FILE',  os.path.join(HOME, 'browser-visits.db'))
 HOST_LOG = os.environ.get('BVL_HOST_LOG', os.path.join(HOME, 'browser-visits-host.log'))
 
@@ -144,6 +159,19 @@ def ensure_db(conn: sqlite3.Connection) -> None:
     # One row per read/skimmed event (individual timestamps).
     _ensure_events_table(conn, 'read_events')
     _ensure_events_table(conn, 'skimmed_events')
+
+    # snapshots table: one row per UTC day with host activity.  host.py
+    # inserts (date, sealed=0) on every write invocation; the sealer flips
+    # to sealed=1 once it has moved the day's log + written MANIFEST.tsv.
+    # Owned here (rather than only by snapshot_mover) so a brand-new
+    # install with no mover run yet still has the table available for
+    # host's per-invocation INSERT OR IGNORE.
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS snapshots (
+            date   TEXT PRIMARY KEY,
+            sealed INTEGER NOT NULL DEFAULT 0
+        )
+    """)
 
     conn.commit()
 
@@ -275,20 +303,27 @@ def tag_visit(
 # Log file helper
 # ---------------------------------------------------------------------------
 
+def _log_path_for(date_iso: str) -> str:
+    """Return the per-day log file path for a UTC date 'YYYY-MM-DD'."""
+    return os.path.join(LOG_DIR, f'browser-visits-{date_iso}.log')
+
+
 def append_log(
-    record_id: str, timestamp: str, url: str, title: str,
+    record_id: str, date_iso: str,
+    timestamp: str, url: str, title: str,
     tag: str = '', filename: str = '',
 ) -> None:
-    """Append one TSV action line, prefixed with record_id.
+    """Append one TSV action line, prefixed with record_id, to the per-day log.
+
+    The log file is `<LOG_DIR>/browser-visits-<date_iso>.log`.  date_iso is
+    pinned at host invocation start so this line and the matching result line
+    always land in the same file even if the wall clock crosses midnight UTC
+    mid-invocation.
 
     Field layout:
         <record_id>\\t<timestamp>\\t<url>\\t<title>                          # auto-log
         <record_id>\\t<timestamp>\\t<url>\\t<title>\\t<tag>                   # of_interest
         <record_id>\\t<timestamp>\\t<url>\\t<title>\\t<tag>\\t<filename>      # read / skimmed
-
-    record_id correlates this line with its later result line so a replay
-    tool can pair them safely even under concurrent host invocations.
-    filename is included only for read / skimmed tags.
     """
     def sanitise(s: str) -> str:
         return s.replace('\t', ' ').replace('\n', ' ').replace('\r', '')
@@ -299,17 +334,18 @@ def append_log(
         if tag in ('read', 'skimmed'):
             fields.append(sanitise(filename))
     line = '\t'.join(fields) + '\n'
-    with open(LOG_FILE, 'a', encoding='utf-8') as f:
+    with open(_log_path_for(date_iso), 'a', encoding='utf-8') as f:
         f.write(line)
 
 
-def append_result_log(record_id: str, result: str) -> None:
-    """Append a result line prefixed with record_id: 'success' or 'error: <message>'."""
+def append_result_log(record_id: str, date_iso: str, result: str) -> None:
+    """Append a result line prefixed with record_id to the per-day log:
+    '<record_id>\\tsuccess' or '<record_id>\\terror: <message>'."""
     def sanitise(s: str) -> str:
         return s.replace('\t', ' ').replace('\n', ' ').replace('\r', '')
 
     line = sanitise(record_id) + '\t' + sanitise(result) + '\n'
-    with open(LOG_FILE, 'a', encoding='utf-8') as f:
+    with open(_log_path_for(date_iso), 'a', encoding='utf-8') as f:
         f.write(line)
 
 # ---------------------------------------------------------------------------
@@ -329,6 +365,10 @@ def main() -> None:
         return
 
     record_id = uuid.uuid4().hex
+    # Pin the per-day log file to the date the invocation started.  Used for
+    # both the action and the result line so they always land in the same
+    # file even if the wall clock crosses midnight UTC mid-invocation.
+    today_iso = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
 
     url    = (message.get('url') or '').strip()
     action = (message.get('action') or '').strip()
@@ -369,7 +409,7 @@ def main() -> None:
 
     # First write: record the intended action
     try:
-        append_log(record_id, timestamp, url, title, tag, filename)
+        append_log(record_id, today_iso, timestamp, url, title, tag, filename)
     except Exception as exc:
         logger.error('Log file write failed: %s', exc)
         errors.append(f'log: {exc}')
@@ -377,10 +417,17 @@ def main() -> None:
     # Write to SQLite.  Always insert the visit first (INSERT OR IGNORE, so the
     # original first-visit timestamp wins if the row already exists); then apply
     # the tag if one is present.  This means tagging always works even when the
-    # background auto-log hasn't finished writing yet.
+    # background auto-log hasn't finished writing yet.  Also INSERT OR IGNORE a
+    # snapshots row for today so the seal pass picks up activity-only days
+    # uniformly with snapshot-bearing days.
     try:
         conn = sqlite3.connect(DB_FILE)
         ensure_db(conn)
+        conn.execute(
+            "INSERT OR IGNORE INTO snapshots (date, sealed) VALUES (?, 0)",
+            (today_iso,),
+        )
+        conn.commit()
         insert_visit(conn, timestamp, url, title)
         if tag:
             tag_visit(conn, url, tag, timestamp, filename)
@@ -392,7 +439,7 @@ def main() -> None:
     # Second write: record the result
     log_result = f'error: {"; ".join(errors)}' if errors else 'success'
     try:
-        append_result_log(record_id, log_result)
+        append_result_log(record_id, today_iso, log_result)
     except Exception as exc:
         logger.error('Log file result write failed: %s', exc)
 

--- a/browser-visit-logger/native-host/snapshot_mover.py
+++ b/browser-visit-logger/native-host/snapshot_mover.py
@@ -121,6 +121,9 @@ ICLOUD_SNAPSHOTS_DIR = os.environ.get(
     'BVL_ICLOUD_SNAPSHOTS_DIR',
     os.path.join(HOME, 'Documents', 'browser-visit-logger', 'snapshots'),
 )
+# host.py writes per-day visit logs into this dir; the sealer collects each
+# completed day's log into the matching iCloud snapshot subdir.
+LOG_DIR = os.environ.get('BVL_LOG_DIR', HOME)
 MIN_AGE_SECONDS = int(os.environ.get('BVL_MOVER_MIN_AGE_SECONDS', '60'))
 
 # Number of consecutive same-(op, target) failures before a "persistent"
@@ -334,7 +337,9 @@ def _reconcile_dir_scoped_errors(conn, op, dir_path, current_strays):
                 conn.execute(
                     "DELETE FROM mover_errors WHERE key = ?", (key,))
         conn.commit()
-    except sqlite3.Error as inner:
+    except sqlite3.Error as inner:  # pragma: no cover
+        # Defensive: a mid-reconcile DB failure means the user already
+        # has bigger problems.  Best-effort log; the seal pass continues.
         logger.error(
             'Could not reconcile %s errors under %s: %s',
             op, dir_path, inner,
@@ -589,9 +594,13 @@ def _seal_pass(conn: sqlite3.Connection, dry_run: bool = False) -> None:
     """Seal every snapshots-table row whose date is strictly before today (UTC)
     and whose `sealed` flag is still 0.
 
-    Driven entirely by the database — no filesystem rescan.  The mover's
-    move pass keeps the table in sync with the on-disk daily directories
-    by inserting a row each time it creates one.
+    Driven by the database.  Rows come from two sources: the move pass
+    inserts one when a snapshot file lands in a new date dir; host.py
+    inserts one on every write invocation (covers activity-only days
+    that produced no snapshot files).
+
+    The iCloud date dir is created on the fly if absent — both branches
+    above can produce a snapshots row without a matching dir on disk.
     """
     today = _today_utc()
     rows = conn.execute(
@@ -601,21 +610,17 @@ def _seal_pass(conn: sqlite3.Connection, dry_run: bool = False) -> None:
     for (date_str,) in rows:
         date_subdir = os.path.join(ICLOUD_SNAPSHOTS_DIR, date_str)
         if not os.path.isdir(date_subdir):
-            # DB says this day exists but the directory is gone (e.g. user
-            # manually deleted it).  Record an error and skip — the row
-            # will retry next tick, and the user is notified once the
-            # threshold is crossed.
-            logger.error(
-                'snapshots row %s has no on-disk directory at %s; skipping',
-                date_str, date_subdir,
-            )
-            _try_record_error(
-                conn, 'missing_directory', date_subdir,
-                FileNotFoundError(
-                    f'snapshots row {date_str} has no on-disk directory'),
-            )
-            continue
-        # Directory present — clear any prior 'missing_directory' error.
+            if dry_run:
+                logger.info(
+                    '[dry-run] would create %s for activity-only day',
+                    date_subdir)
+            else:
+                try:
+                    os.makedirs(date_subdir, exist_ok=True)
+                except OSError as exc:
+                    logger.error('Failed to create %s: %s', date_subdir, exc)
+                    _try_record_error(conn, 'seal', date_subdir, exc)
+                    continue
         _try_clear_error(conn, 'missing_directory', date_subdir)
         _seal_directory(conn, date_subdir, dry_run=dry_run, date_key=date_str)
 
@@ -649,12 +654,17 @@ def _seal_directory(
 
     try:
         count = _write_manifest_file(conn, date_subdir)
+        # Move the day's log file into the sealed dir if one exists in
+        # LOG_DIR.  Done before flipping sealed=1 so a failure leaves the
+        # row at sealed=0 and the seal will retry on the next tick.
+        if date_key is not None:
+            _move_log_into_sealed_dir(date_subdir, date_key)
         logger.info('Sealed %s (%d entries)', date_subdir, count)
         if date_key is not None:
             # Upsert: the auto seal pass always finds an existing row (the
-            # mover inserted it).  The manual sealer may not — e.g. if the
-            # user is sealing a directory imported from elsewhere — so we
-            # tolerate the no-row case by inserting first.
+            # mover or host inserted it).  The manual sealer may not — e.g.
+            # if the user is sealing a directory imported from elsewhere —
+            # so we tolerate the no-row case by inserting first.
             conn.execute(
                 "INSERT INTO snapshots (date, sealed) VALUES (?, 1) "
                 "ON CONFLICT(date) DO UPDATE SET sealed = 1",
@@ -666,6 +676,85 @@ def _seal_directory(
     except (OSError, sqlite3.Error) as exc:
         logger.error('Failed to seal %s: %s', date_subdir, exc)
         _try_record_error(conn, 'seal', date_subdir, exc)
+
+
+def _log_filename_for(date_iso: str) -> str:
+    """Per-day log filename used by both host.py and the sealer."""
+    return f'browser-visits-{date_iso}.log'
+
+
+def _move_log_into_sealed_dir(date_subdir: str, date_iso: str) -> None:
+    """Move <LOG_DIR>/browser-visits-<date>.log into date_subdir, chmod 0o444.
+
+    No-op if no log file for that date exists in LOG_DIR (e.g. the day
+    had read/skimmed events from a clock-skewed host but no auto-log).
+    Caller is responsible for catching OSError.
+    """
+    src = os.path.join(LOG_DIR, _log_filename_for(date_iso))
+    if not os.path.exists(src):
+        return
+    dst = os.path.join(date_subdir, _log_filename_for(date_iso))
+    shutil.move(src, dst)
+    os.chmod(dst, 0o444)
+
+
+_LOG_FILENAME_RE = re.compile(r'^browser-visits-(\d{4}-\d{2}-\d{2})\.log$')
+
+
+def _orphan_log_merge_pass(conn: sqlite3.Connection) -> None:
+    """Anti-entropy: scan LOG_DIR for past-day per-day logs and reconcile.
+
+    Two cases:
+      1. **Race orphan** — the iCloud counterpart already exists.  This
+         means the seal pass moved an earlier copy and a host invocation
+         in the seal-window race has since recreated the file in LOG_DIR
+         with stragglers.  Append the orphan into the iCloud log and
+         delete the orphan.
+      2. **Lost snapshots row** — no iCloud counterpart exists and there
+         is no snapshots row for the date (e.g. the host crashed between
+         the snapshots INSERT OR IGNORE and the first log write).
+         Backfill the snapshots row at sealed=0 so the next normal seal
+         pass picks it up.
+
+    Skips today's UTC log file — it's still being written.
+    """
+    if not os.path.isdir(LOG_DIR):
+        return
+    today_iso = _today_utc().isoformat()
+    for entry in sorted(os.listdir(LOG_DIR)):
+        m = _LOG_FILENAME_RE.match(entry)
+        if not m:
+            continue
+        date_iso = m.group(1)
+        if date_iso >= today_iso:
+            continue
+        src = os.path.join(LOG_DIR, entry)
+        date_subdir = os.path.join(ICLOUD_SNAPSHOTS_DIR, date_iso)
+        dst = os.path.join(date_subdir, entry)
+        try:
+            if os.path.exists(dst):
+                # Race orphan — chmod +w the iCloud log, append, chmod 0o444.
+                os.chmod(dst, 0o644)
+                with open(src, 'r', encoding='utf-8') as fsrc, \
+                        open(dst, 'a', encoding='utf-8') as fdst:
+                    fdst.write(fsrc.read())
+                os.chmod(dst, 0o444)
+                os.unlink(src)
+                logger.info('Merged orphan log %s into %s', src, dst)
+                _try_clear_error(conn, 'seal', date_subdir)
+            else:
+                # No iCloud counterpart — make sure the seal pass picks
+                # it up on the next tick.  INSERT OR IGNORE is a no-op if
+                # the row already exists (the common case — host inserted
+                # it).  Defensive for the host-crash-mid-startup scenario.
+                conn.execute(
+                    "INSERT OR IGNORE INTO snapshots (date, sealed) VALUES (?, 0)",
+                    (date_iso,),
+                )
+                conn.commit()
+        except OSError as exc:
+            logger.error('orphan-merge for %s: %s', src, exc)
+            _try_record_error(conn, 'seal', date_subdir, exc)
 
 
 def _write_manifest_file(
@@ -738,9 +827,19 @@ def _build_manifest_rows(
     invariant enforced by snapshot_verifier.py: every manifest row must
     correspond to a real DB row.
     """
+    # Determine the per-day log filename to skip alongside MANIFEST.tsv.
+    # Only date-named directories have one; manual seals of non-date dirs
+    # have no expected log filename (and so nothing to skip).
+    basename = os.path.basename(os.path.normpath(date_subdir))
+    expected_log = (
+        _log_filename_for(basename)
+        if _DATE_DIR_RE.match(basename)
+        else None
+    )
     files = sorted(
         f for f in os.listdir(date_subdir)
         if f != MANIFEST_FILENAME
+        and f != expected_log
         and os.path.isfile(os.path.join(date_subdir, f))
     )
     rows = []
@@ -839,6 +938,8 @@ def main(dry_run: bool = False) -> None:
         _ensure_mover_errors_table(conn)
         _move_pass(conn, dry_run=dry_run)
         _seal_pass(conn, dry_run=dry_run)
+        if not dry_run:
+            _orphan_log_merge_pass(conn)
         _escalate_errors(conn)
     except Exception as exc:
         # Top-level: best-effort record + escalate, then fall back to a

--- a/browser-visit-logger/native-host/snapshot_sealer.py
+++ b/browser-visit-logger/native-host/snapshot_sealer.py
@@ -121,11 +121,17 @@ def cli(argv=None) -> int:
     conn = sqlite3.connect(snapshot_mover.DB_FILE)
     try:
         snapshot_mover._ensure_snapshots_table(conn)
+        snapshot_mover._ensure_mover_errors_table(conn)
         snapshot_mover._seal_directory(
             conn, target,
             dry_run=args.dry_run,
             date_key=_extract_date_key(target),
         )
+        # Anti-entropy: clean up race orphans / backfill missing snapshots
+        # rows from past-day logs in LOG_DIR.  Skipped on dry-run so it
+        # remains a strict report-only mode.
+        if not args.dry_run:
+            snapshot_mover._orphan_log_merge_pass(conn)
     finally:
         conn.close()
     return 0

--- a/browser-visit-logger/native-host/snapshot_verifier.py
+++ b/browser-visit-logger/native-host/snapshot_verifier.py
@@ -116,14 +116,26 @@ def verify_directory(conn, date_subdir):
             continue
         manifest_entries[filename] = (tag, timestamp, url, title)
 
+    # Determine the expected per-day log filename for this directory.
+    # Only date-named directories have one — a manually-sealed
+    # non-date directory does not.
+    basename = os.path.basename(os.path.normpath(date_subdir))
+    expected_log = (
+        snapshot_mover._log_filename_for(basename)
+        if snapshot_mover._DATE_DIR_RE.match(basename)
+        else None
+    )
+
     # 6. File-level check: every file in the directory (other than the
-    #    manifest itself) must have a conforming snapshot filename.
-    #    Non-conforming files are flagged regardless of whether they
-    #    appear in the manifest.
+    #    manifest and the per-day log) must have a conforming snapshot
+    #    filename.  Non-conforming files are flagged regardless of
+    #    whether they appear in the manifest.
     conforming_on_disk = set()
     for f in os.listdir(date_subdir):
         full = os.path.join(date_subdir, f)
         if f == snapshot_mover.MANIFEST_FILENAME:
+            continue
+        if expected_log is not None and f == expected_log:
             continue
         if not os.path.isfile(full):
             continue
@@ -182,6 +194,23 @@ def verify_directory(conn, date_subdir):
             issues.append(
                 f'{filename}: conforming file in directory has no '
                 f'corresponding events row in DB')
+
+    # 10. Per-day log file: must be present, a regular file, mode 0o444.
+    #     The sealer always moves the day's log into the sealed dir as
+    #     part of the seal flow, so absence here means an incomplete
+    #     seal or post-seal tampering.  Non-date directories (manual
+    #     seals of e.g. an imported archive) have no expected log.
+    if expected_log is not None:
+        log_path = os.path.join(date_subdir, expected_log)
+        if not os.path.exists(log_path):
+            issues.append(f'Per-day log file not found at {log_path}')
+        elif not os.path.isfile(log_path):
+            issues.append(f'Per-day log {log_path} is not a regular file')
+        else:
+            log_mode = os.stat(log_path).st_mode & 0o777
+            if log_mode != 0o444:
+                issues.append(
+                    f'Per-day log is not read-only (mode {log_mode:#o})')
 
     return len(issues) == 0, issues
 

--- a/browser-visit-logger/native-host/visits_rebuilder.py
+++ b/browser-visit-logger/native-host/visits_rebuilder.py
@@ -118,18 +118,79 @@ def _is_result_payload(payload: str) -> bool:
     return payload == 'success' or payload.startswith('error: ')
 
 
-def replay_log(conn: sqlite3.Connection, log_path: str) -> ReplayStats:
-    """Phase 1: replay a UUID-prefixed TSV log into the DB.
+# Per-day log filename pattern: 'browser-visits-YYYY-MM-DD.log'.
+_LOG_FILENAME_RE = re.compile(r'^browser-visits-(\d{4}-\d{2}-\d{2})\.log$')
 
-    Action lines are buffered in a dict keyed by record_id; each result
-    line pops its matching action.  Successful pairs are applied via
-    host.py's helpers.  Error pairs are counted but skipped (the DB
-    write didn't happen, so there's nothing to replay).  Orphans on
-    either side are counted and logged.
+
+def _collect_log_paths(log_dir: str, icloud_dir: str) -> list:
+    """Return the list of per-day log files to replay, in chronological
+    order (sorted by the date in the filename).
+
+    Sources:
+      1. <log_dir>/browser-visits-<date>.log — today's log + any past-day
+         logs that haven't been moved yet (race orphans, log-only days
+         pending the next sealer tick).
+      2. <icloud_dir>/<YYYY-MM-DD>/browser-visits-<same-date>.log — every
+         sealed iCloud subdir's log.  Defensive: if a log inside a date
+         subdir has a different embedded date, it's skipped with a warning.
+
+    Sort key is the date in the filename, so a URL first visited day 1
+    and re-visited day 5 ends up with day-1's timestamp in
+    ``visits.timestamp`` (INSERT OR IGNORE keeps the first replayed value).
     """
-    stats = ReplayStats()
-    pending: dict = {}  # record_id -> parsed action fields
+    # Each entry: (date_iso, source_priority, path).  source_priority sorts
+    # iCloud (0) before log_dir (1) so when both have a same-date file
+    # (the cross-day seal-race case) the iCloud copy is processed first
+    # — its action lines populate `pending` before log_dir's stragglers
+    # arrive with the matching result lines.
+    discovered = []
 
+    if os.path.isdir(icloud_dir):
+        for date_entry in os.listdir(icloud_dir):
+            if not snapshot_mover._DATE_DIR_RE.match(date_entry):
+                continue
+            date_dir = os.path.join(icloud_dir, date_entry)
+            if not os.path.isdir(date_dir):
+                continue
+            for entry in os.listdir(date_dir):
+                m = _LOG_FILENAME_RE.match(entry)
+                if not m:
+                    continue
+                full = os.path.join(date_dir, entry)
+                if not os.path.isfile(full):
+                    continue
+                if m.group(1) != date_entry:
+                    logger.warning(
+                        'Log file %s embedded date does not match its '
+                        'parent directory %s — skipping',
+                        full, date_dir)
+                    continue
+                discovered.append((m.group(1), 0, full))
+
+    if os.path.isdir(log_dir):
+        for entry in os.listdir(log_dir):
+            m = _LOG_FILENAME_RE.match(entry)
+            if not m:
+                continue
+            full = os.path.join(log_dir, entry)
+            if os.path.isfile(full):
+                discovered.append((m.group(1), 1, full))
+
+    discovered.sort(key=lambda t: (t[0], t[1]))
+    return [(date_iso, path) for date_iso, _, path in discovered]
+
+
+def _replay_one_file(conn: sqlite3.Connection, log_path: str,
+                     pending: dict, stats: ReplayStats) -> None:
+    """Replay a single per-day log file using the shared pending dict.
+
+    Action lines accumulate into pending; result lines pop their matching
+    action and apply (success) or count (error).  pending may carry over
+    UUIDs across files — the cross-file race window described in
+    docs/rebuild-visits-from-log.md.  Orphan reporting is left to the
+    caller (replay_logs) so that pending is fully drained before
+    reporting.
+    """
     with open(log_path, 'r', encoding='utf-8') as f:
         for raw in f:
             line = raw.rstrip('\n')
@@ -137,7 +198,9 @@ def replay_log(conn: sqlite3.Connection, log_path: str) -> ReplayStats:
                 continue
             parts = line.split('\t')
             if not _looks_like_uuid(parts[0]):
-                logger.warning('Skipping malformed log line (non-UUID prefix): %r', raw)
+                logger.warning(
+                    'Skipping malformed log line in %s (non-UUID prefix): %r',
+                    log_path, raw)
                 stats.malformed_lines += 1
                 continue
             record_id = parts[0]
@@ -149,7 +212,8 @@ def replay_log(conn: sqlite3.Connection, log_path: str) -> ReplayStats:
                 action = pending.pop(record_id, None)
                 if action is None:
                     logger.warning(
-                        'Result line for %s has no matching action — skipping', record_id)
+                        'Result line for %s in %s has no matching action — skipping',
+                        record_id, log_path)
                     stats.orphan_results += 1
                     continue
                 if rest[0] == 'success':
@@ -162,19 +226,47 @@ def replay_log(conn: sqlite3.Connection, log_path: str) -> ReplayStats:
             # Otherwise it's an action line.
             action = _parse_action_fields(rest)
             if action is None:
-                logger.warning('Skipping malformed action line: %r', raw)
+                logger.warning('Skipping malformed action line in %s: %r',
+                               log_path, raw)
                 stats.malformed_lines += 1
                 continue
             if record_id in pending:
                 # Duplicate UUID for a pending action — the host should
                 # never emit this.  Drop the prior, count the new one.
                 logger.warning(
-                    'Duplicate record_id %s while a prior action is pending — '
-                    'dropping the prior orphan', record_id)
+                    'Duplicate record_id %s in %s while a prior action is '
+                    'pending — dropping the prior orphan', record_id, log_path)
                 stats.orphan_actions += 1
             pending[record_id] = action
 
-    # Anything still pending after EOF is an orphan action.
+
+def replay_logs(conn: sqlite3.Connection,
+                log_dir: str, icloud_dir: str) -> ReplayStats:
+    """Phase 1: enumerate every per-day log under log_dir and icloud_dir
+    and replay them chronologically into the DB.
+
+    A single ``pending`` dict spans all files so a UUID's action half in
+    one file pairs with its result half in another (handles the
+    cross-day seal race).  Anything left in pending at the end is an
+    orphan action.
+    """
+    stats = ReplayStats()
+    pending: dict = {}
+
+    for date_iso, log_path in _collect_log_paths(log_dir, icloud_dir):
+        logger.info('Replaying %s', log_path)
+        # Mirror host.py's per-invocation INSERT OR IGNORE: each day with
+        # a log file gets a snapshots row.  Phase 2's rehydrate may flip
+        # sealed=1 if the iCloud dir for that date has a manifest; if not,
+        # the row stays sealed=0 (e.g. today's log, which the sealer
+        # wouldn't touch anyway).
+        conn.execute(
+            "INSERT OR IGNORE INTO snapshots (date, sealed) VALUES (?, 0)",
+            (date_iso,),
+        )
+        _replay_one_file(conn, log_path, pending, stats)
+
+    # Anything still pending after all files are exhausted is an orphan action.
     if pending:
         for record_id in pending:
             logger.warning('Action %s has no matching result line', record_id)
@@ -253,8 +345,11 @@ def rehydrate_filesystem(
         else:
             stats.unsealed_dirs += 1
 
+        # Skip the manifest and the per-day log file; phase 1 already
+        # replayed the log, and the manifest is verified separately.
+        log_filename = snapshot_mover._log_filename_for(entry)
         for fname in sorted(os.listdir(date_dir)):
-            if fname == 'MANIFEST.tsv':
+            if fname == 'MANIFEST.tsv' or fname == log_filename:
                 continue
             if not snapshot_mover._SNAPSHOT_FILENAME_RE.match(fname):
                 continue
@@ -297,7 +392,7 @@ def _truncate_rebuildable_tables(conn: sqlite3.Connection) -> None:
 
 def rebuild(
     conn: sqlite3.Connection, *,
-    log_path: str, icloud_dir: str, downloads_dir: str,
+    log_dir: str, icloud_dir: str, downloads_dir: str,
     do_log: bool = True, do_rehydrate: bool = True, truncate: bool = True,
 ) -> RebuildStats:
     stats = RebuildStats(truncated=truncate)
@@ -307,7 +402,7 @@ def rebuild(
     snapshot_mover._ensure_snapshots_table(conn)
 
     if do_log:
-        stats.replay = replay_log(conn, log_path)
+        stats.replay = replay_logs(conn, log_dir, icloud_dir)
     if do_rehydrate:
         stats.rehydrate = rehydrate_filesystem(conn, icloud_dir, downloads_dir)
     return stats
@@ -343,8 +438,9 @@ def _parse_args(argv=None):
                    help='skip phase 2 (filesystem rehydration)')
     p.add_argument('--rehydrate-only', action='store_true',
                    help='skip phase 1 (log replay)')
-    p.add_argument('--log', metavar='FILE', dest='log_path',
-                   help=f'override the log file path (default {host.LOG_FILE})')
+    p.add_argument('--log-dir', metavar='DIR', dest='log_dir',
+                   help=f'override the per-day logs directory '
+                        f'(default {host.LOG_DIR})')
     p.add_argument('--db', metavar='FILE', dest='db_path',
                    help=f'override the SQLite database path (default {host.DB_FILE})')
     p.add_argument('--source', metavar='DIR',
@@ -372,7 +468,7 @@ def cli(argv=None) -> int:
     )
     logger.setLevel(log_level)
 
-    log_path      = args.log_path or host.LOG_FILE
+    log_dir       = args.log_dir  or host.LOG_DIR
     db_path       = args.db_path  or host.DB_FILE
     downloads_dir = args.source   or host.DOWNLOADS_SNAPSHOTS_DIR
     icloud_dir    = args.dest     or snapshot_mover.ICLOUD_SNAPSHOTS_DIR
@@ -385,10 +481,12 @@ def cli(argv=None) -> int:
     # directory) use the same values the user passed on the CLI.
     host.DOWNLOADS_SNAPSHOTS_DIR = downloads_dir
     host.DB_FILE                 = db_path
+    host.LOG_DIR                 = log_dir
     snapshot_mover.ICLOUD_SNAPSHOTS_DIR = icloud_dir
+    snapshot_mover.LOG_DIR              = log_dir
 
-    if do_log and not os.path.exists(log_path):
-        print(f'No log file at {log_path}', file=sys.stderr)
+    if do_log and not os.path.isdir(log_dir):
+        print(f'No log directory at {log_dir}', file=sys.stderr)
         return _EXIT_INPUT_ERROR
 
     db_dir = os.path.dirname(db_path) or '.'
@@ -401,7 +499,7 @@ def cli(argv=None) -> int:
         try:
             stats = rebuild(
                 conn,
-                log_path=log_path,
+                log_dir=log_dir,
                 icloud_dir=icloud_dir,
                 downloads_dir=downloads_dir,
                 do_log=do_log, do_rehydrate=do_rehydrate,

--- a/browser-visit-logger/reset.py
+++ b/browser-visit-logger/reset.py
@@ -3,7 +3,7 @@
 reset.py — Delete all local data produced by the Browser Visit Logger extension.
 
 Files and directories managed:
-  browser-visits.log                       — TSV visit/action log         (BVL_LOG_FILE)
+  browser-visits-<UTC-date>.log            — per-day TSV visit/action logs (BVL_LOG_DIR)
   browser-visits-host.log                  — native host process log      (BVL_HOST_LOG)
   browser-visits-mover.log                 — snapshot mover process log   (BVL_MOVER_LOG)
   browser-visits-verifier.log              — snapshot verifier process log (BVL_VERIFIER_LOG)
@@ -14,12 +14,16 @@ Files and directories managed:
 
 Usage:
     python reset.py                 # reset everything (with confirmation)
-    python reset.py --log           # reset only the visit log
+    python reset.py --log           # reset only the per-day visit logs in BVL_LOG_DIR
     python reset.py --host-log      # reset only the host, mover, and verifier process logs
     python reset.py --db            # reset only the database
     python reset.py --snapshots     # reset only the local Downloads snapshots dir
     python reset.py --icloud        # reset only the iCloud archive directory
     python reset.py -f              # skip confirmation prompt
+
+--log only deletes per-day logs in BVL_LOG_DIR (e.g. ~/browser-visits-*.log).
+Per-day logs that have already been moved into iCloud sealed dirs are wiped
+by --icloud, parallel to today's separation between log and snapshot data.
 
 The same BVL_* environment variables used by host.py are respected here,
 so custom paths work automatically.
@@ -27,17 +31,32 @@ so custom paths work automatically.
 
 import argparse
 import os
+import re
 import shutil
 import sys
 
 HOME         = os.path.expanduser('~')
-LOG_FILE     = os.environ.get('BVL_LOG_FILE',      os.path.join(HOME, 'browser-visits.log'))
+LOG_DIR      = os.environ.get('BVL_LOG_DIR',       HOME)
 HOST_LOG     = os.environ.get('BVL_HOST_LOG',      os.path.join(HOME, 'browser-visits-host.log'))
 MOVER_LOG    = os.environ.get('BVL_MOVER_LOG',     os.path.join(HOME, 'browser-visits-mover.log'))
 VERIFIER_LOG = os.environ.get('BVL_VERIFIER_LOG',  os.path.join(HOME, 'browser-visits-verifier.log'))
 DB_FILE      = os.environ.get('BVL_DB_FILE',       os.path.join(HOME, 'browser-visits.db'))
 SNAP_DIR   = os.environ.get('BVL_DOWNLOADS_SNAPSHOTS_DIR',
                             os.path.join(HOME, 'Downloads', 'browser-visit-snapshots'))
+
+# Per-day visit logs follow `browser-visits-YYYY-MM-DD.log`.  Strict regex so
+# we don't accidentally match the host/mover/verifier process logs (which
+# share the `browser-visits-` prefix but have non-date suffixes).
+_LOG_FILENAME_RE = re.compile(r'^browser-visits-\d{4}-\d{2}-\d{2}\.log$')
+
+
+def _per_day_log_paths():
+    """Return absolute paths of per-day visit logs in LOG_DIR."""
+    return sorted(
+        os.path.join(LOG_DIR, name)
+        for name in os.listdir(LOG_DIR)
+        if _LOG_FILENAME_RE.match(name)
+    ) if os.path.isdir(LOG_DIR) else []
 # iCloud archive root — wipe the whole tree (currently snapshots/ but we may
 # add other subdirectories in the future).
 ICLOUD_DIR = os.path.join(HOME, 'Documents', 'browser-visit-logger')
@@ -83,7 +102,16 @@ def main() -> None:
     # Each entry: (path, label, kind)  where kind is 'file' or 'dir'
     targets = []
     if do_log:
-        targets.append((LOG_FILE,   'visit log',                       'file'))
+        per_day_logs = _per_day_log_paths()
+        if per_day_logs:
+            for p in per_day_logs:
+                targets.append((p, 'per-day visit log', 'file'))
+        else:
+            # Surface the LOG_DIR path even when nothing matches, so users
+            # see what was checked.
+            targets.append(
+                (os.path.join(LOG_DIR, 'browser-visits-*.log'),
+                 'per-day visit logs (none found)', 'glob'))
     if do_host_log:
         targets.append((HOST_LOG,     'host log',                      'file'))
         targets.append((MOVER_LOG,    'mover log',                     'file'))
@@ -97,7 +125,10 @@ def main() -> None:
 
     print('The following will be permanently deleted:')
     for path, label, kind in targets:
-        status = 'exists' if os.path.exists(path) else 'not found'
+        if kind == 'glob':
+            status = 'no match'
+        else:
+            status = 'exists' if os.path.exists(path) else 'not found'
         print(f'  [{status}] {path}')
 
     if not args.force:
@@ -114,6 +145,8 @@ def main() -> None:
     for path, label, kind in targets:
         if kind == 'dir':
             _delete_dir(path, label)
+        elif kind == 'glob':
+            print(f'{label}: no matches under {path}')
         else:
             _delete_file(path, label)
 

--- a/browser-visit-logger/tests/test_host.py
+++ b/browser-visit-logger/tests/test_host.py
@@ -109,18 +109,20 @@ class TestWriteMessage(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 FIXED_REC_ID = '0' * 32  # placeholder UUID hex; tests assert on field positions
+FIXED_DATE   = '2026-01-15'  # placeholder UTC date; per-day log files key off this
 
 
 class TestAppendLog(unittest.TestCase):
 
     def _run(self, timestamp, url, title, tag='', filename='',
-             record_id=FIXED_REC_ID) -> str:
-        """Call append_log with a temp file and return its contents."""
+             record_id=FIXED_REC_ID, date_iso=FIXED_DATE) -> str:
+        """Call append_log against a temp LOG_DIR and return the per-day file."""
         with tempfile.TemporaryDirectory() as tmp:
-            path = os.path.join(tmp, 'visits.log')
-            with patch.object(host, 'LOG_FILE', path):
-                host.append_log(record_id, timestamp, url, title, tag, filename)
-            return Path(path).read_text(encoding='utf-8')
+            with patch.object(host, 'LOG_DIR', tmp):
+                host.append_log(record_id, date_iso, timestamp, url, title,
+                                tag, filename)
+            return Path(tmp, f'browser-visits-{date_iso}.log').read_text(
+                encoding='utf-8')
 
     def test_tsv_format(self):
         content = self._run('2026-01-01T00:00:00Z', 'https://example.com', 'Example Domain')
@@ -151,10 +153,12 @@ class TestAppendLog(unittest.TestCase):
 
     def test_appends_multiple_calls(self):
         with tempfile.TemporaryDirectory() as tmp:
-            path = os.path.join(tmp, 'visits.log')
-            with patch.object(host, 'LOG_FILE', path):
-                host.append_log(FIXED_REC_ID, 'ts1', 'https://a.com', 'A')
-                host.append_log(FIXED_REC_ID, 'ts2', 'https://b.com', 'B')
+            path = os.path.join(tmp, f'browser-visits-{FIXED_DATE}.log')
+            with patch.object(host, 'LOG_DIR', tmp):
+                host.append_log(FIXED_REC_ID, FIXED_DATE,
+                                'ts1', 'https://a.com', 'A')
+                host.append_log(FIXED_REC_ID, FIXED_DATE,
+                                'ts2', 'https://b.com', 'B')
             lines = Path(path).read_text().splitlines()
         self.assertEqual(len(lines), 2)
         self.assertIn('https://a.com', lines[0])
@@ -212,17 +216,18 @@ class TestAppendLog(unittest.TestCase):
 
     def test_append_result_log_writes_two_fields(self):
         with tempfile.TemporaryDirectory() as tmp:
-            path = os.path.join(tmp, 'visits.log')
-            with patch.object(host, 'LOG_FILE', path):
-                host.append_result_log(FIXED_REC_ID, 'success')
+            path = os.path.join(tmp, f'browser-visits-{FIXED_DATE}.log')
+            with patch.object(host, 'LOG_DIR', tmp):
+                host.append_result_log(FIXED_REC_ID, FIXED_DATE, 'success')
             content = Path(path).read_text(encoding='utf-8')
         self.assertEqual(content, f'{FIXED_REC_ID}\tsuccess\n')
 
     def test_append_result_log_sanitises_tabs(self):
         with tempfile.TemporaryDirectory() as tmp:
-            path = os.path.join(tmp, 'visits.log')
-            with patch.object(host, 'LOG_FILE', path):
-                host.append_result_log(FIXED_REC_ID, 'error: foo\tbar')
+            path = os.path.join(tmp, f'browser-visits-{FIXED_DATE}.log')
+            with patch.object(host, 'LOG_DIR', tmp):
+                host.append_result_log(FIXED_REC_ID, FIXED_DATE,
+                                       'error: foo\tbar')
             content = Path(path).read_text(encoding='utf-8').rstrip('\n')
         self.assertEqual(content, f'{FIXED_REC_ID}\terror: foo bar')
 
@@ -230,6 +235,33 @@ class TestAppendLog(unittest.TestCase):
         content = self._run('ts', 'https://example.com', 'Example', tag='mem\torable')
         parts = content.rstrip('\n').split('\t')
         self.assertEqual(parts[4], 'mem orable')
+
+    def test_per_day_filename_uses_date_iso(self):
+        # The on-disk filename embeds the date_iso passed in.
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(host, 'LOG_DIR', tmp):
+                host.append_log(FIXED_REC_ID, '2026-04-29',
+                                'ts', 'https://a.com', 'A')
+                host.append_log(FIXED_REC_ID, '2026-04-30',
+                                'ts', 'https://a.com', 'A')
+            files = sorted(p.name for p in Path(tmp).iterdir())
+        self.assertEqual(files, [
+            'browser-visits-2026-04-29.log',
+            'browser-visits-2026-04-30.log',
+        ])
+
+    def test_two_calls_same_date_share_a_single_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, f'browser-visits-{FIXED_DATE}.log')
+            with patch.object(host, 'LOG_DIR', tmp):
+                host.append_log(FIXED_REC_ID, FIXED_DATE,
+                                'ts1', 'https://a.com', 'A')
+                host.append_result_log(FIXED_REC_ID, FIXED_DATE, 'success')
+            lines = Path(path).read_text().splitlines()
+            files = list(Path(tmp).iterdir())
+        # Action + result both went to the same per-day file.
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(len(files), 1)
 
 
 # ---------------------------------------------------------------------------
@@ -264,6 +296,15 @@ class TestDatabase(unittest.TestCase):
     def test_ensure_db_creates_skimmed_events_table(self):
         conn = self._conn()
         self.assertIn('skimmed_events', self._tables(conn))
+        conn.close()
+
+    def test_ensure_db_creates_snapshots_table(self):
+        # Owned by host.ensure_db so per-invocation snapshots-row inserts
+        # succeed even on a brand-new install with no mover run yet.
+        conn = self._conn()
+        self.assertIn('snapshots', self._tables(conn))
+        cols = {r[1] for r in conn.execute('PRAGMA table_info(snapshots)')}
+        self.assertEqual(cols, {'date', 'sealed'})
         conn.close()
 
     def _event_cols(self, conn, table):
@@ -783,11 +824,27 @@ class TestQueryVisit(unittest.TestCase):
 # (subprocess-based integration tests don't contribute to coverage)
 # ---------------------------------------------------------------------------
 
+def _today_iso():
+    """UTC-today as ISO date — matches host.main()'s date-pinning logic."""
+    import datetime
+    return datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+
+
+def _today_log_path(tmp):
+    """Per-day log path for today (UTC) inside the test's tmp LOG_DIR."""
+    return os.path.join(tmp, f'browser-visits-{_today_iso()}.log')
+
+
 class TestMain(unittest.TestCase):
     """Exercise every branch of main() by calling it in-process."""
 
     def _call_main(self, message: dict, tmp: str, extra_patches=()) -> dict:
-        """Call host.main() with fake stdin/stdout and isolated temp paths."""
+        """Call host.main() with fake stdin/stdout and isolated temp paths.
+
+        host.main() picks the per-day log file under host.LOG_DIR; tests
+        therefore patch the *directory* and read the resulting per-day file
+        via _today_log_path(tmp).
+        """
         out_buf = io.BytesIO()
         mock_stdout = MagicMock()
         mock_stdout.buffer = out_buf
@@ -798,8 +855,8 @@ class TestMain(unittest.TestCase):
         base_patches = [
             patch('sys.stdin',  mock_stdin),
             patch('sys.stdout', mock_stdout),
-            patch.object(host, 'LOG_FILE', os.path.join(tmp, 'visits.log')),
-            patch.object(host, 'DB_FILE',  os.path.join(tmp, 'visits.db')),
+            patch.object(host, 'LOG_DIR', tmp),
+            patch.object(host, 'DB_FILE', os.path.join(tmp, 'visits.db')),
         ]
 
         with contextlib.ExitStack() as stack:
@@ -865,7 +922,7 @@ class TestMain(unittest.TestCase):
     def test_query_does_not_write_log(self):
         with tempfile.TemporaryDirectory() as tmp:
             self._call_main({'action': 'query', 'url': 'https://example.com'}, tmp)
-            self.assertFalse(Path(tmp, 'visits.log').exists())
+            self.assertFalse(Path(_today_log_path(tmp)).exists())
 
     # --- input validation ---
 
@@ -916,7 +973,7 @@ class TestMain(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             self._call_main(
                 {'timestamp': 'ts', 'url': 'https://example.com', 'title': 'Title'}, tmp)
-            lines = Path(tmp, 'visits.log').read_text().splitlines()
+            lines = Path(_today_log_path(tmp)).read_text().splitlines()
         self.assertEqual(len(lines), 2)
         action_parts = lines[0].split('\t')
         result_parts = lines[1].split('\t')
@@ -933,6 +990,42 @@ class TestMain(unittest.TestCase):
             row = sqlite3.connect(os.path.join(tmp, 'visits.db')).execute(
                 'SELECT url, timestamp, title FROM visits').fetchone()
         self.assertEqual(row, ('https://example.com', 'ts', 'Title'))
+
+    def test_invocation_pins_log_file_to_invocation_start_date(self):
+        # Even if the wall clock crosses midnight UTC mid-invocation, both the
+        # action and the result line stay in the start-of-invocation date's
+        # log file.  Stub host's datetime so date.now() returns 2026-04-29
+        # for the duration of one main() call, regardless of how many times
+        # main() actually queries it.
+        import datetime as real_dt
+
+        class _FrozenDate:
+            def isoformat(self):
+                return '2026-04-29'
+
+        class _FrozenDateTime:
+            @staticmethod
+            def now(tz=None):
+                fixed = MagicMock()
+                fixed.date.return_value = _FrozenDate()
+                return fixed
+
+        with tempfile.TemporaryDirectory() as tmp:
+            stub_dt = MagicMock()
+            stub_dt.datetime  = _FrozenDateTime
+            stub_dt.timezone  = real_dt.timezone
+            self._call_main(
+                {'timestamp': 'ts', 'url': 'https://example.com', 'title': 'Title'},
+                tmp,
+                extra_patches=[patch.object(host, 'datetime', stub_dt)],
+            )
+            files = sorted(p.name for p in Path(tmp).iterdir()
+                           if p.name.startswith('browser-visits-'))
+            # Read while the tmp dir is still alive.
+            self.assertEqual(files, ['browser-visits-2026-04-29.log'])
+            lines = Path(tmp, 'browser-visits-2026-04-29.log').read_text().splitlines()
+        # Both action and result land in the pinned-date file.
+        self.assertEqual(len(lines), 2)
 
     # --- log write failure ---
 
@@ -1054,7 +1147,7 @@ class TestIntegration(unittest.TestCase):
     def _invoke(self, message: dict, tmp: str) -> dict:
         """Send one native message to host.py as a subprocess; return response."""
         env = os.environ.copy()
-        env['BVL_LOG_FILE'] = os.path.join(tmp, 'visits.log')
+        env['BVL_LOG_DIR']  = tmp
         env['BVL_DB_FILE']  = os.path.join(tmp, 'visits.db')
         env['BVL_HOST_LOG'] = os.path.join(tmp, 'host.log')
 
@@ -1083,7 +1176,7 @@ class TestIntegration(unittest.TestCase):
                 {'timestamp': '2026-01-01T00:00:00Z', 'url': 'https://example.com', 'title': 'Example Domain'},
                 tmp,
             )
-            lines = Path(tmp, 'visits.log').read_text().splitlines()
+            lines = Path(_today_log_path(tmp)).read_text().splitlines()
         action_parts = lines[0].split('\t')
         result_parts = lines[1].split('\t')
         self.assertRegex(action_parts[0], r'^[0-9a-f]{32}$')
@@ -1112,7 +1205,7 @@ class TestIntegration(unittest.TestCase):
             resp = self._invoke({'url': 'https://example.com', 'title': 'No Timestamp'}, tmp)
             self.assertEqual(resp['status'], 'error')
             self.assertIn('timestamp', resp.get('message', ''))
-            self.assertFalse(Path(tmp, 'visits.log').exists())
+            self.assertFalse(Path(_today_log_path(tmp)).exists())
             self.assertFalse(Path(tmp, 'visits.db').exists())
 
     def test_empty_timestamp_rejected(self):
@@ -1120,7 +1213,7 @@ class TestIntegration(unittest.TestCase):
             resp = self._invoke({'timestamp': '', 'url': 'https://example.com', 'title': 'Title'}, tmp)
             self.assertEqual(resp['status'], 'error')
             self.assertIn('timestamp', resp.get('message', ''))
-            self.assertFalse(Path(tmp, 'visits.log').exists())
+            self.assertFalse(Path(_today_log_path(tmp)).exists())
 
     def test_sequential_invocations_accumulate(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1131,7 +1224,7 @@ class TestIntegration(unittest.TestCase):
                      'title': f'Site {i}'},
                     tmp,
                 )
-            log_lines = Path(tmp, 'visits.log').read_text().splitlines()
+            log_lines = Path(_today_log_path(tmp)).read_text().splitlines()
             self.assertEqual(len(log_lines), 6)  # 2 lines per invocation
 
             conn = sqlite3.connect(os.path.join(tmp, 'visits.db'))
@@ -1158,7 +1251,7 @@ class TestIntegration(unittest.TestCase):
                     {'timestamp': '2026-01-01T00:00:00Z', 'url': 'https://example.com', 'title': 'Example'},
                     tmp,
                 )
-            lines = Path(tmp, 'visits.log').read_text().splitlines()
+            lines = Path(_today_log_path(tmp)).read_text().splitlines()
         self.assertEqual(len(lines), 6)  # 2 lines per invocation
 
     def test_duplicate_url_preserves_original_timestamp(self):
@@ -1181,14 +1274,14 @@ class TestIntegration(unittest.TestCase):
             resp = self._invoke({'timestamp': 'ts', 'url': None, 'title': 'Title'}, tmp)
             self.assertEqual(resp['status'], 'error')
             self.assertIn('url', resp.get('message', ''))
-            self.assertFalse(Path(tmp, 'visits.log').exists())
+            self.assertFalse(Path(_today_log_path(tmp)).exists())
 
     def test_null_timestamp_rejected(self):
         with tempfile.TemporaryDirectory() as tmp:
             resp = self._invoke({'timestamp': None, 'url': 'https://example.com', 'title': 'Title'}, tmp)
             self.assertEqual(resp['status'], 'error')
             self.assertIn('timestamp', resp.get('message', ''))
-            self.assertFalse(Path(tmp, 'visits.log').exists())
+            self.assertFalse(Path(_today_log_path(tmp)).exists())
 
     def test_null_title_treated_as_empty(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1204,20 +1297,20 @@ class TestIntegration(unittest.TestCase):
             resp = self._invoke({'timestamp': 'ts', 'url': '', 'title': 'Whatever'}, tmp)
             self.assertEqual(resp['status'], 'error')
             self.assertIn('url', resp.get('message', ''))
-            self.assertFalse(Path(tmp, 'visits.log').exists())
+            self.assertFalse(Path(_today_log_path(tmp)).exists())
             self.assertFalse(Path(tmp, 'visits.db').exists())
 
     def test_whitespace_only_url_rejected(self):
         with tempfile.TemporaryDirectory() as tmp:
             resp = self._invoke({'timestamp': 'ts', 'url': '   ', 'title': 'Whatever'}, tmp)
             self.assertEqual(resp['status'], 'error')
-            self.assertFalse(Path(tmp, 'visits.log').exists())
+            self.assertFalse(Path(_today_log_path(tmp)).exists())
 
     def test_missing_url_rejected(self):
         with tempfile.TemporaryDirectory() as tmp:
             resp = self._invoke({'timestamp': 'ts', 'title': 'No URL at all'}, tmp)
             self.assertEqual(resp['status'], 'error')
-            self.assertFalse(Path(tmp, 'visits.log').exists())
+            self.assertFalse(Path(_today_log_path(tmp)).exists())
 
     def test_empty_title_with_valid_url_accepted(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1244,7 +1337,7 @@ class TestIntegration(unittest.TestCase):
             os.makedirs(db_collision)
 
             env = os.environ.copy()
-            env['BVL_LOG_FILE'] = os.path.join(tmp, 'visits.log')
+            env['BVL_LOG_DIR']  = tmp
             env['BVL_DB_FILE']  = db_collision
             env['BVL_HOST_LOG'] = os.path.join(tmp, 'host.log')
 
@@ -1256,7 +1349,7 @@ class TestIntegration(unittest.TestCase):
                 env=env,
             )
             resp = _unframe(result.stdout)
-            log_content = Path(tmp, 'visits.log').read_text()
+            log_content = Path(_today_log_path(tmp)).read_text()
 
         self.assertEqual(resp['status'], 'error')
         self.assertTrue(any('db' in e for e in resp.get('errors', [])))
@@ -1373,7 +1466,7 @@ class TestIntegration(unittest.TestCase):
                 {'timestamp': 'ts-tag', 'url': url, 'title': 'Example',
                  'tag': 'read', 'filename': 'browser-visit-snapshots/abc.mhtml'},
                 tmp)
-            lines = Path(tmp, 'visits.log').read_text().splitlines()
+            lines = Path(_today_log_path(tmp)).read_text().splitlines()
         # lines[0]=visit action, lines[1]=visit result, lines[2]=tag action, lines[3]=tag result
         self.assertEqual(len(lines), 4)
         tag_action = lines[2].split('\t')
@@ -1393,7 +1486,7 @@ class TestIntegration(unittest.TestCase):
                 {'timestamp': 'ts', 'url': 'https://example.com', 'title': 'Example'},
                 tmp,
             )
-            lines = Path(tmp, 'visits.log').read_text().splitlines()
+            lines = Path(_today_log_path(tmp)).read_text().splitlines()
         action_parts = lines[0].split('\t')
         self.assertEqual(len(lines), 2)
         # 4 fields: record_id, timestamp, url, title
@@ -1418,7 +1511,7 @@ class TestIntegration(unittest.TestCase):
             ).fetchone()
             conn.close()
             # Log should show action line + success (not an error)
-            lines = Path(tmp, 'visits.log').read_text().splitlines()
+            lines = Path(_today_log_path(tmp)).read_text().splitlines()
         self.assertIsNotNone(row)
         self.assertEqual(row[0], 'ts')       # timestamp from tag message
         self.assertEqual(row[1], '1')        # of_interest applied
@@ -1433,13 +1526,40 @@ class TestIntegration(unittest.TestCase):
                 {'timestamp': 'ts1', 'url': 'https://a.com', 'title': 'A'}, tmp)
             self._invoke(
                 {'timestamp': 'ts2', 'url': 'https://b.com', 'title': 'B'}, tmp)
-            lines = Path(tmp, 'visits.log').read_text().splitlines()
+            lines = Path(_today_log_path(tmp)).read_text().splitlines()
         first_id  = lines[0].split('\t')[0]
         second_id = lines[2].split('\t')[0]
         self.assertNotEqual(first_id, second_id)
         # Each invocation's action and result share their own record_id
         self.assertEqual(lines[1].split('\t')[0], first_id)
         self.assertEqual(lines[3].split('\t')[0], second_id)
+
+    def test_invocation_inserts_snapshots_row_for_today(self):
+        # Every host write invocation does INSERT OR IGNORE on a snapshots
+        # row for today's UTC date so the seal pass picks up the day even
+        # if no snapshot file ever lands.  Run twice and assert it's still
+        # exactly one row, sealed=0.
+        with tempfile.TemporaryDirectory() as tmp:
+            self._invoke(
+                {'timestamp': 'ts1', 'url': 'https://a.com', 'title': 'A'}, tmp)
+            self._invoke(
+                {'timestamp': 'ts2', 'url': 'https://b.com', 'title': 'B'}, tmp)
+            conn = sqlite3.connect(os.path.join(tmp, 'visits.db'))
+            rows = conn.execute(
+                'SELECT date, sealed FROM snapshots').fetchall()
+            conn.close()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][0], _today_iso())
+        self.assertEqual(rows[0][1], 0)
+
+    def test_query_invocation_does_not_insert_snapshots_row(self):
+        # Query is a read-only path — it must not create a snapshots row.
+        with tempfile.TemporaryDirectory() as tmp:
+            self._invoke({'action': 'query', 'url': 'https://example.com'}, tmp)
+            conn = sqlite3.connect(os.path.join(tmp, 'visits.db'))
+            n = conn.execute('SELECT COUNT(*) FROM snapshots').fetchone()[0]
+            conn.close()
+        self.assertEqual(n, 0)
 
     def test_query_unknown_url_returns_null_record(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1523,7 +1643,7 @@ class TestIntegration(unittest.TestCase):
     def test_query_does_not_write_log(self):
         with tempfile.TemporaryDirectory() as tmp:
             self._invoke({'action': 'query', 'url': 'https://example.com'}, tmp)
-            self.assertFalse(Path(tmp, 'visits.log').exists())
+            self.assertFalse(Path(_today_log_path(tmp)).exists())
 
     def test_query_missing_url_returns_error(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/browser-visit-logger/tests/test_shell_wrappers.py
+++ b/browser-visit-logger/tests/test_shell_wrappers.py
@@ -157,31 +157,35 @@ class TestWrapperForwarding(unittest.TestCase):
         # without a confirmation prompt and exit 0.
         with tempfile.TemporaryDirectory() as tmp:
             env = os.environ.copy()
-            env['BVL_LOG_FILE']  = os.path.join(tmp, 'visits.log')
+            env['BVL_LOG_DIR']   = tmp
             env['BVL_HOST_LOG']  = os.path.join(tmp, 'host.log')
             env['BVL_MOVER_LOG'] = os.path.join(tmp, 'mover.log')
             env['BVL_DB_FILE']   = os.path.join(tmp, 'visits.db')
             env['BVL_DOWNLOADS_SNAPSHOTS_DIR'] = os.path.join(tmp, 'dl')
+            # Drop a per-day log so --log has something to delete.
+            Path(tmp, 'browser-visits-2026-01-15.log').touch()
             result = subprocess.run(
                 [str(REPO_ROOT / 'reset_visits_data'), '--log', '-f'],
                 capture_output=True, text=True, timeout=10, env=env,
             )
             self.assertEqual(result.returncode, 0,
                              f'stderr: {result.stderr}')
+            # Per-day log was deleted.
+            self.assertFalse(Path(tmp, 'browser-visits-2026-01-15.log').exists())
 
-    def test_rebuild_visits_data_forwards_overrides_against_empty_log(self):
-        # rebuild_visits_data --log <empty file> --db <new path> --source/--dest
-        # against an empty log should reach the rebuilder, exit 0, and print
-        # the per-phase summary lines.
+    def test_rebuild_visits_data_forwards_overrides_against_empty_log_dir(self):
+        # rebuild_visits_data --log-dir <empty dir> --db <new path>
+        # --source/--dest against an empty log dir should reach the
+        # rebuilder, exit 0, and print the per-phase summary lines.
         with tempfile.TemporaryDirectory() as tmp:
-            log = os.path.join(tmp, 'visits.log')
-            Path(log).touch()
-            db   = os.path.join(tmp, 'visits.db')
-            src  = os.path.join(tmp, 'dl');     os.makedirs(src)
-            dest = os.path.join(tmp, 'icloud'); os.makedirs(dest)
+            log_dir = os.path.join(tmp, 'logs');   os.makedirs(log_dir)
+            db      = os.path.join(tmp, 'visits.db')
+            src     = os.path.join(tmp, 'dl');     os.makedirs(src)
+            dest    = os.path.join(tmp, 'icloud'); os.makedirs(dest)
             result = subprocess.run(
                 [str(REPO_ROOT / 'rebuild_visits_data'),
-                 '--log', log, '--db', db, '--source', src, '--dest', dest],
+                 '--log-dir', log_dir, '--db', db,
+                 '--source', src, '--dest', dest],
                 capture_output=True, text=True, timeout=10,
             )
             self.assertEqual(result.returncode, 0,

--- a/browser-visit-logger/tests/test_snapshot_mover.py
+++ b/browser-visit-logger/tests/test_snapshot_mover.py
@@ -59,16 +59,20 @@ class _MoverTestBase(unittest.TestCase):
 
         self.source_dir = os.path.join(self.tmp.name, 'downloads')
         self.dest_dir   = os.path.join(self.tmp.name, 'icloud')
+        self.log_dir    = os.path.join(self.tmp.name, 'logs')
         self.db_file    = os.path.join(self.tmp.name, 'visits.db')
         os.makedirs(self.source_dir)
+        os.makedirs(self.log_dir)
         # dest_dir intentionally NOT created — main() should create the root
 
         for module, attrs in (
             (host,            {'DOWNLOADS_SNAPSHOTS_DIR': self.source_dir,
                                'ICLOUD_SNAPSHOTS_DIR':    self.dest_dir,
+                               'LOG_DIR':                 self.log_dir,
                                'DB_FILE':                 self.db_file}),
             (snapshot_mover,  {'DOWNLOADS_SNAPSHOTS_DIR': self.source_dir,
                                'ICLOUD_SNAPSHOTS_DIR':    self.dest_dir,
+                               'LOG_DIR':                 self.log_dir,
                                'DB_FILE':                 self.db_file}),
         ):
             for name, value in attrs.items():
@@ -888,31 +892,36 @@ class TestSealPass(_MoverTestBase):
         self.assertFalse(os.path.exists(
             os.path.join(date_subdir, snapshot_mover.MANIFEST_FILENAME)))
 
-    def test_seal_pass_records_error_when_row_directory_is_missing(self):
-        # Insert a snapshots row for a date whose directory doesn't exist
-        # on disk.  The pass should ERROR-log, record a 'missing_directory'
-        # mover_errors row so the user is notified, and leave the snapshots
-        # row unsealed (we couldn't seal what isn't there).
+    def test_seal_pass_creates_dir_for_activity_only_day(self):
+        # Insert a snapshots row for a past date with no on-disk dir yet
+        # (the activity-only-day case: host inserted the row but the move
+        # pass never created a dir because no snapshot files landed).
+        # The seal pass creates the dir, writes a header-only MANIFEST,
+        # and flips sealed=1.
         os.makedirs(self.dest_dir, exist_ok=True)
         conn = sqlite3.connect(self.db_file)
         conn.execute(
             "INSERT INTO snapshots (date, sealed) VALUES (?, 0)", ('2024-01-15',))
         conn.commit()
         conn.close()
-        with self.assertLogs(snapshot_mover.logger, level='ERROR') as cm:
-            snapshot_mover.main()
-        self.assertTrue(any('no on-disk directory' in m for m in cm.output))
-        # Row remains unsealed.
-        self.assertEqual(self._snapshots_row('2024-01-15'), ('2024-01-15', 0))
-        # mover_errors row was recorded.
+
+        snapshot_mover.main()
+
+        date_subdir = os.path.join(self.dest_dir, '2024-01-15')
+        manifest = os.path.join(date_subdir, snapshot_mover.MANIFEST_FILENAME)
+        self.assertTrue(os.path.isdir(date_subdir))
+        self.assertTrue(os.path.exists(manifest))
+        # Header-only manifest (no snapshot files for the day).
+        lines = Path(manifest).read_text().splitlines()
+        self.assertEqual(lines, ['\t'.join(snapshot_mover._MANIFEST_HEADER)])
+        # Row flipped to sealed=1, no missing_directory error recorded.
+        self.assertEqual(self._snapshots_row('2024-01-15'), ('2024-01-15', 1))
         conn = sqlite3.connect(self.db_file)
-        err_row = conn.execute(
-            "SELECT operation, target FROM mover_errors "
-            "WHERE operation = 'missing_directory'"
-        ).fetchone()
+        n = conn.execute(
+            "SELECT COUNT(*) FROM mover_errors WHERE operation = 'missing_directory'"
+        ).fetchone()[0]
         conn.close()
-        expected_target = os.path.join(self.dest_dir, '2024-01-15')
-        self.assertEqual(err_row, ('missing_directory', expected_target))
+        self.assertEqual(n, 0)
 
     def test_seal_pass_clears_missing_directory_error_when_dir_reappears(self):
         # Pre-seed a missing_directory error for a date whose dir has now
@@ -1005,6 +1014,213 @@ class TestSealPass(_MoverTestBase):
         os.makedirs(self.dest_dir, exist_ok=True)
         snapshot_mover.main()  # must not raise
         self.assertEqual(os.listdir(self.dest_dir), [])
+
+    # -- per-day log move during seal --
+
+    def _write_log(self, date_str, content='line\n'):
+        """Drop a per-day log file into the test's LOG_DIR for date_str."""
+        path = os.path.join(self.log_dir,
+                            snapshot_mover._log_filename_for(date_str))
+        Path(path).write_text(content, encoding='utf-8')
+        return path
+
+    def test_seal_moves_per_day_log_into_sealed_dir_chmod_0o444(self):
+        date_subdir = self._seed_dir('2024-01-15')
+        log_src = self._write_log('2024-01-15', 'action-line\nresult-line\n')
+        snapshot_mover.main()
+        log_dst = os.path.join(date_subdir,
+                               snapshot_mover._log_filename_for('2024-01-15'))
+        self.assertFalse(os.path.exists(log_src))
+        self.assertTrue(os.path.exists(log_dst))
+        self.assertEqual(Path(log_dst).read_text(), 'action-line\nresult-line\n')
+        self.assertEqual(os.stat(log_dst).st_mode & 0o777, 0o444)
+
+    def test_seal_with_no_log_in_log_dir_succeeds_silently(self):
+        # No per-day log for the date — the seal still succeeds, just
+        # without a log file inside the sealed dir.
+        date_subdir = self._seed_dir('2024-01-15')
+        snapshot_mover.main()
+        files = sorted(os.listdir(date_subdir))
+        self.assertNotIn(snapshot_mover._log_filename_for('2024-01-15'), files)
+        self.assertIn(snapshot_mover.MANIFEST_FILENAME, files)
+        self.assertEqual(self._snapshots_row('2024-01-15'), ('2024-01-15', 1))
+
+    def test_seal_records_seal_error_when_log_move_fails(self):
+        # Force a failure by making the destination dir un-writable AFTER
+        # _write_manifest_file has already written the manifest into it.
+        # We patch shutil.move to raise so the manifest write succeeds but
+        # the log move fails — the row should remain unsealed.
+        date_subdir = self._seed_dir('2024-01-15')
+        self._write_log('2024-01-15')
+        with patch('shutil.move', side_effect=OSError('boom')):
+            snapshot_mover.main()
+        # Row stays unsealed because log move failed.
+        self.assertEqual(self._snapshots_row('2024-01-15'), ('2024-01-15', 0))
+        # mover_errors row recorded.
+        conn = sqlite3.connect(self.db_file)
+        n = conn.execute(
+            "SELECT COUNT(*) FROM mover_errors "
+            "WHERE operation = 'seal' AND target = ?",
+            (date_subdir,),
+        ).fetchone()[0]
+        conn.close()
+        self.assertEqual(n, 1)
+
+    # -- orphan-log merge pass --
+
+    def test_orphan_merge_appends_orphan_into_sealed_log(self):
+        # Race: pre-seed a sealed dir with a log file containing the action,
+        # then drop a same-named log file into LOG_DIR containing the result.
+        # Orphan-merge should append + chmod 0o444 + delete the orphan.
+        date_subdir = self._seed_dir('2024-01-15', sealed=1)
+        # Pre-existing sealed log in iCloud (contains the action half).
+        sealed_log = os.path.join(date_subdir,
+                                  snapshot_mover._log_filename_for('2024-01-15'))
+        Path(sealed_log).write_text('uuid\taction\n', encoding='utf-8')
+        os.chmod(sealed_log, 0o444)
+        # Manifest already present so the day stays sealed=1.
+        Path(date_subdir, snapshot_mover.MANIFEST_FILENAME).write_text(
+            '\t'.join(snapshot_mover._MANIFEST_HEADER) + '\n',
+            encoding='utf-8',
+        )
+        os.chmod(os.path.join(date_subdir, snapshot_mover.MANIFEST_FILENAME),
+                 0o444)
+        # Race orphan in LOG_DIR (the result half).
+        orphan = self._write_log('2024-01-15', 'uuid\tsuccess\n')
+
+        snapshot_mover.main()
+
+        self.assertFalse(os.path.exists(orphan))
+        merged = Path(sealed_log).read_text()
+        self.assertEqual(merged, 'uuid\taction\nuuid\tsuccess\n')
+        self.assertEqual(os.stat(sealed_log).st_mode & 0o777, 0o444)
+
+    def test_orphan_merge_backfills_snapshots_row_when_no_icloud_log(self):
+        # Past-day log exists in LOG_DIR with no iCloud counterpart and no
+        # snapshots row.  The orphan-merge pass should INSERT OR IGNORE the
+        # snapshots row at sealed=0 so the next normal seal pass picks it up.
+        os.makedirs(self.dest_dir, exist_ok=True)
+        self._write_log('2024-01-10', 'uuid\taction\nuuid\tsuccess\n')
+
+        snapshot_mover.main()
+
+        # Row was backfilled AND immediately sealed (the same main() call
+        # runs the seal pass right before the orphan-merge — in the
+        # backfill case the merge runs in a *future* mover tick.  But
+        # main()'s order is move → seal → orphan-merge, so the backfill's
+        # row will be picked up on the NEXT tick.  Either way the row
+        # exists by the end of this main() call.)
+        self.assertIsNotNone(self._snapshots_row('2024-01-10'))
+        # Run main() again so the seal pass actually processes the row.
+        snapshot_mover.main()
+        date_subdir = os.path.join(self.dest_dir, '2024-01-10')
+        sealed_log = os.path.join(date_subdir,
+                                  snapshot_mover._log_filename_for('2024-01-10'))
+        self.assertTrue(os.path.exists(sealed_log))
+        self.assertEqual(self._snapshots_row('2024-01-10'), ('2024-01-10', 1))
+
+    def test_orphan_merge_leaves_today_log_alone(self):
+        # Today's log is still being written by host invocations; the
+        # orphan-merge pass must not touch it.
+        today_iso = self.TODAY.isoformat()
+        today_log = self._write_log(today_iso, 'uuid\taction\n')
+        snapshot_mover.main()
+        self.assertTrue(os.path.exists(today_log))
+        # And no snapshots row was created for today — only past dates
+        # are eligible for backfill.
+        self.assertIsNone(self._snapshots_row(today_iso))
+
+    def test_orphan_merge_is_idempotent_with_no_orphans(self):
+        # No log files in LOG_DIR → orphan-merge is a noop.  Run main()
+        # twice; nothing should change between the two snapshots.
+        snapshot_mover.main()
+        snapshot_mover.main()  # second pass also a noop, no errors
+        self.assertEqual(os.listdir(self.log_dir), [])
+
+    def test_orphan_merge_returns_early_when_log_dir_missing(self):
+        # If LOG_DIR doesn't exist (e.g. user nuked it manually), the
+        # orphan-merge pass should return without raising.
+        import shutil
+        shutil.rmtree(self.log_dir)
+        snapshot_mover.main()  # must not raise
+        self.assertFalse(os.path.isdir(self.log_dir))
+
+    def test_orphan_merge_records_seal_error_when_merge_fails(self):
+        # Pre-seed both halves of a race (iCloud log + LOG_DIR orphan).
+        # Make the iCloud log unwritable so the merge's chmod+append
+        # fails; the orphan-merge pass should record a seal:<dir>
+        # mover_error.
+        date_subdir = self._seed_dir('2024-01-15', sealed=1)
+        Path(date_subdir, snapshot_mover.MANIFEST_FILENAME).write_text(
+            '\t'.join(snapshot_mover._MANIFEST_HEADER) + '\n')
+        os.chmod(os.path.join(date_subdir, snapshot_mover.MANIFEST_FILENAME),
+                 0o444)
+        sealed_log = os.path.join(date_subdir,
+                                  snapshot_mover._log_filename_for('2024-01-15'))
+        Path(sealed_log).write_text('uuid\taction\n')
+        os.chmod(sealed_log, 0o444)
+        self._write_log('2024-01-15', 'uuid\tsuccess\n')
+
+        with patch('shutil.move'):  # stub so seal pass log-move is no-op
+            with patch('builtins.open', side_effect=OSError('boom')):
+                snapshot_mover.main()
+
+        conn = sqlite3.connect(self.db_file)
+        n = conn.execute(
+            "SELECT COUNT(*) FROM mover_errors "
+            "WHERE operation = 'seal' AND target = ?", (date_subdir,),
+        ).fetchone()[0]
+        conn.close()
+        self.assertGreaterEqual(n, 1)
+
+    def test_seal_pass_dry_run_logs_would_create_for_activity_only_day(self):
+        # Insert a snapshots row for a past date with no on-disk dir.
+        # In dry-run, _seal_pass should log the would-create line and not
+        # actually create the directory.
+        os.makedirs(self.dest_dir, exist_ok=True)
+        conn = sqlite3.connect(self.db_file)
+        conn.execute(
+            "INSERT INTO snapshots (date, sealed) VALUES (?, 0)",
+            ('2024-01-15',))
+        conn.commit()
+        conn.close()
+        with self.assertLogs(snapshot_mover.logger, level='INFO') as cm:
+            snapshot_mover.main(dry_run=True)
+        self.assertTrue(any('would create' in m for m in cm.output))
+        self.assertFalse(os.path.isdir(os.path.join(self.dest_dir, '2024-01-15')))
+
+    def test_seal_pass_records_seal_error_when_dir_creation_fails(self):
+        # Force os.makedirs to raise OSError when the seal pass tries to
+        # create the date dir.  The pass should record a seal:<dir>
+        # mover_error and continue.
+        os.makedirs(self.dest_dir, exist_ok=True)
+        conn = sqlite3.connect(self.db_file)
+        conn.execute(
+            "INSERT INTO snapshots (date, sealed) VALUES (?, 0)",
+            ('2024-01-15',))
+        conn.commit()
+        conn.close()
+
+        real_makedirs = os.makedirs
+
+        def boom_for_date_dir(path, *args, **kwargs):
+            if path.endswith('2024-01-15'):
+                raise OSError('disk full')
+            return real_makedirs(path, *args, **kwargs)
+
+        with patch('os.makedirs', side_effect=boom_for_date_dir):
+            snapshot_mover.main()
+
+        conn = sqlite3.connect(self.db_file)
+        rows = conn.execute(
+            "SELECT operation, target FROM mover_errors "
+            "WHERE operation = 'seal'"
+        ).fetchall()
+        conn.close()
+        self.assertEqual(rows,
+                         [('seal', os.path.join(self.dest_dir, '2024-01-15'))])
+        # snapshots row stays unsealed.
+        self.assertEqual(self._snapshots_row('2024-01-15'), ('2024-01-15', 0))
 
 
 class TestTodayUtc(unittest.TestCase):

--- a/browser-visit-logger/tests/test_snapshot_sealer.py
+++ b/browser-visit-logger/tests/test_snapshot_sealer.py
@@ -293,6 +293,50 @@ class TestSealerSnapshotsTable(_SealerTestBase):
         conn.close()
         self.assertEqual(count, 0)
 
+    def test_seal_moves_per_day_log_into_sealed_dir(self):
+        # When a per-day log for the date being sealed exists in LOG_DIR,
+        # the manual sealer moves it into the sealed dir (chmod 0o444).
+        from unittest.mock import patch
+        date_subdir = self._make_dir('2024-01-15')
+        log_dir = os.path.join(self.tmp.name, 'logs')
+        os.makedirs(log_dir)
+        log_src = os.path.join(log_dir, 'browser-visits-2024-01-15.log')
+        Path(log_src).write_text('uuid\taction\nuuid\tsuccess\n',
+                                 encoding='utf-8')
+        with patch.object(snapshot_mover, 'LOG_DIR', log_dir):
+            rc = snapshot_sealer.cli([
+                '--db', self.db_file, '--dest', self.dest_dir, '2024-01-15',
+            ])
+        self.assertEqual(rc, 0)
+        log_dst = os.path.join(date_subdir, 'browser-visits-2024-01-15.log')
+        self.assertTrue(os.path.exists(log_dst))
+        self.assertFalse(os.path.exists(log_src))
+        self.assertEqual(os.stat(log_dst).st_mode & 0o777, 0o444)
+
+    def test_manual_seal_runs_orphan_merge_pass(self):
+        # The manual sealer wires the orphan-merge pass after the seal so
+        # ad-hoc seals also clean up race orphans in LOG_DIR.
+        from unittest.mock import patch
+        # Sealing 2024-01-15.  Pre-seed an unrelated past-day orphan log
+        # (2024-01-10) in LOG_DIR with no iCloud counterpart — the
+        # orphan-merge backfill branch should INSERT the snapshots row.
+        self._make_dir('2024-01-15')
+        log_dir = os.path.join(self.tmp.name, 'logs')
+        os.makedirs(log_dir)
+        Path(log_dir, 'browser-visits-2024-01-10.log').write_text(
+            'uuid\taction\nuuid\tsuccess\n', encoding='utf-8')
+        with patch.object(snapshot_mover, 'LOG_DIR', log_dir):
+            snapshot_sealer.cli([
+                '--db', self.db_file, '--dest', self.dest_dir, '2024-01-15',
+            ])
+        # 2024-01-10's snapshots row was backfilled with sealed=0.
+        conn = sqlite3.connect(self.db_file)
+        row = conn.execute(
+            "SELECT date, sealed FROM snapshots WHERE date = '2024-01-10'"
+        ).fetchone()
+        conn.close()
+        self.assertEqual(row, ('2024-01-10', 0))
+
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()

--- a/browser-visit-logger/tests/test_snapshot_verifier.py
+++ b/browser-visit-logger/tests/test_snapshot_verifier.py
@@ -62,12 +62,15 @@ class _VerifierTestBase(unittest.TestCase):
 
     # -- helpers --
 
-    def _seed_dir(self, date_str, files=()):
+    def _seed_dir(self, date_str, files=(), include_log=True):
         """Create dest_dir/<date_str>/ with the given files + visits/events
-        rows + a sealed=1 snapshots row.
+        rows + a sealed=1 snapshots row + (by default) a per-day log file
+        at mode 0o444 so the verifier's log-file check passes.
 
         files is an iterable of (filename, table, url, ts, title); pass
         table=None to leave a file with no DB row.  Returns the date subdir.
+        Pass include_log=False for tests that exercise the missing/writable
+        log paths.
         """
         date_subdir = os.path.join(self.dest_dir, date_str)
         os.makedirs(date_subdir, exist_ok=True)
@@ -89,6 +92,11 @@ class _VerifierTestBase(unittest.TestCase):
             conn.commit()
         finally:
             conn.close()
+        if include_log:
+            log_path = os.path.join(
+                date_subdir, snapshot_mover._log_filename_for(date_str))
+            Path(log_path).write_text('', encoding='utf-8')
+            os.chmod(log_path, 0o444)
         return date_subdir
 
     def _seal(self, date_str):
@@ -373,6 +381,68 @@ class TestVerifyDirectory(_VerifierTestBase):
         self.assertFalse(is_valid)
         self.assertGreaterEqual(len(issues), 2)
 
+    # --- check 10: per-day log presence + mode ---
+
+    def test_missing_per_day_log_fails(self):
+        # Set up a sealed dir without the per-day log file.
+        date_subdir = self._seed_dir('2024-01-15', [
+            ('2024-01-15T10-00-00Z-a.mhtml', 'read_events',
+             'https://a.com', '2024-01-15T10:00:00Z', 'A'),
+        ], include_log=False)
+        self._seal('2024-01-15')
+        is_valid, issues = self._verify(date_subdir)
+        self.assertFalse(is_valid)
+        self.assertTrue(any('Per-day log file not found' in i for i in issues))
+
+    def test_writable_per_day_log_flags_mode(self):
+        date_subdir = self._seed_dir('2024-01-15', [
+            ('2024-01-15T10-00-00Z-a.mhtml', 'read_events',
+             'https://a.com', '2024-01-15T10:00:00Z', 'A'),
+        ])
+        self._seal('2024-01-15')
+        log_path = os.path.join(
+            date_subdir, snapshot_mover._log_filename_for('2024-01-15'))
+        os.chmod(log_path, 0o644)
+        is_valid, issues = self._verify(date_subdir)
+        self.assertFalse(is_valid)
+        self.assertTrue(any('Per-day log is not read-only' in i for i in issues))
+
+    def test_per_day_log_as_directory_is_flagged(self):
+        date_subdir = self._seed_dir('2024-01-15', [
+            ('2024-01-15T10-00-00Z-a.mhtml', 'read_events',
+             'https://a.com', '2024-01-15T10:00:00Z', 'A'),
+        ], include_log=False)
+        self._seal('2024-01-15')
+        # Replace the would-be log with a directory of the same name.
+        bogus = os.path.join(
+            date_subdir, snapshot_mover._log_filename_for('2024-01-15'))
+        os.makedirs(bogus)
+        is_valid, issues = self._verify(date_subdir)
+        self.assertFalse(is_valid)
+        self.assertTrue(any('not a regular file' in i for i in issues))
+
+    def test_non_date_directory_skips_log_check(self):
+        # Manually-sealed non-date dirs (e.g. an imported archive) have no
+        # expected per-day log filename; the verifier must not require one.
+        target = os.path.join(self.tmp.name, 'misc-import')
+        os.makedirs(target)
+        snapshot_sealer.cli(['--db', self.db_file, target])
+        is_valid, issues = self._verify(target)
+        self.assertTrue(is_valid, f'unexpected issues: {issues}')
+
+    def test_per_day_log_does_not_count_as_extra_file(self):
+        # Regression: the file-level check (#6) used to flag the log as
+        # non-conforming (it doesn't match _SNAPSHOT_FILENAME_RE).  After
+        # the verifier was taught about expected_log, the log file should
+        # be transparent to that check.
+        date_subdir = self._seed_dir('2024-01-15', [
+            ('2024-01-15T10-00-00Z-a.mhtml', 'read_events',
+             'https://a.com', '2024-01-15T10:00:00Z', 'A'),
+        ])
+        self._seal('2024-01-15')
+        is_valid, issues = self._verify(date_subdir)
+        self.assertTrue(is_valid, f'unexpected issues: {issues}')
+
 
 # ---------------------------------------------------------------------------
 # CLI — happy path, error paths, --quiet, --record
@@ -484,6 +554,12 @@ class TestVerifierCli(_VerifierTestBase):
         os.makedirs(date_subdir)
         # Use the sealer to write a real manifest in the alt location.
         snapshot_sealer.cli(['--db', self.db_file, '--dest', alt_dest, date_str])
+        # Drop a per-day log file so the verifier's log-file check passes
+        # (a normal seal would have moved one in; this test bypasses LOG_DIR).
+        log_path = os.path.join(date_subdir,
+                                snapshot_mover._log_filename_for(date_str))
+        Path(log_path).write_text('', encoding='utf-8')
+        os.chmod(log_path, 0o444)
         captured = io.StringIO()
         with patch('sys.stdout', captured):
             rc = snapshot_verifier.cli([

--- a/browser-visit-logger/tests/test_visits_rebuilder.py
+++ b/browser-visit-logger/tests/test_visits_rebuilder.py
@@ -92,17 +92,25 @@ class TestReplayLog(unittest.TestCase):
         for d in self._tmpdirs:
             shutil.rmtree(d, ignore_errors=True)
 
-    def _replay(self, *lines):
-        """Common harness: write the lines, replay against a fresh DB,
-        return (db_path, stats).  The temp dir lives until tearDown."""
+    def _replay(self, *lines, date_iso='2026-01-01'):
+        """Common harness: write a single per-day log, replay against a
+        fresh DB, return (db_path, stats).  The temp dir lives until
+        tearDown.
+
+        log_dir = <tmp>/logs (containing one browser-visits-<date>.log)
+        icloud_dir = <tmp>/icloud (empty — phase 1 only walks the iCloud
+                     dir for additional log files).
+        """
         tmp = tempfile.mkdtemp()
         self._tmpdirs.append(tmp)
-        log = os.path.join(tmp, 'visits.log')
-        _write_log(log, *lines)
+        log_dir    = os.path.join(tmp, 'logs');   os.makedirs(log_dir)
+        icloud_dir = os.path.join(tmp, 'icloud'); os.makedirs(icloud_dir)
+        log_path = os.path.join(log_dir, f'browser-visits-{date_iso}.log')
+        _write_log(log_path, *lines)
         db = _fresh_db(tmp)
         conn = sqlite3.connect(db)
         try:
-            stats = vr.replay_log(conn, log)
+            stats = vr.replay_logs(conn, log_dir, icloud_dir)
         finally:
             conn.close()
         return db, stats
@@ -255,9 +263,11 @@ class TestReplayLog(unittest.TestCase):
         # must produce no additional rows or counter increments.  This is
         # the regression test for the rowcount-gated _insert_event fix.
         with tempfile.TemporaryDirectory() as tmp:
-            log = os.path.join(tmp, 'visits.log')
+            log_dir    = os.path.join(tmp, 'logs');   os.makedirs(log_dir)
+            icloud_dir = os.path.join(tmp, 'icloud'); os.makedirs(icloud_dir)
+            log_path = os.path.join(log_dir, 'browser-visits-2026-01-01.log')
             _write_log(
-                log,
+                log_path,
                 _action(REC_A, 'ts0', 'https://a.com', 'A'),
                 _result(REC_A, 'success'),
                 _action(REC_B, 'ts1', 'https://a.com', 'A',
@@ -272,7 +282,7 @@ class TestReplayLog(unittest.TestCase):
             db = _fresh_db(tmp)
             conn = sqlite3.connect(db)
             try:
-                vr.replay_log(conn, log)
+                vr.replay_logs(conn, log_dir, icloud_dir)
                 first = conn.execute(
                     'SELECT url, timestamp, title, of_interest, read, skimmed '
                     'FROM visits'
@@ -284,7 +294,7 @@ class TestReplayLog(unittest.TestCase):
                     'SELECT timestamp, filename FROM skimmed_events'
                 ).fetchall()
 
-                vr.replay_log(conn, log)
+                vr.replay_logs(conn, log_dir, icloud_dir)
                 second = conn.execute(
                     'SELECT url, timestamp, title, of_interest, read, skimmed '
                     'FROM visits'
@@ -363,6 +373,215 @@ class TestReplayLog(unittest.TestCase):
         self.assertEqual(stats.read_events, 0)
         self.assertEqual(stats.skimmed_events, 0)
         self.assertEqual(stats.of_interest_set, 0)
+
+
+class TestReplayLogsMultiFile(unittest.TestCase):
+    """Replay across multiple per-day log files in log_dir + iCloud subdirs."""
+
+    def setUp(self):
+        self._tmpdirs = []
+
+    def tearDown(self):
+        import shutil
+        for d in self._tmpdirs:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def _setup(self):
+        tmp = tempfile.mkdtemp()
+        self._tmpdirs.append(tmp)
+        log_dir    = os.path.join(tmp, 'logs');   os.makedirs(log_dir)
+        icloud_dir = os.path.join(tmp, 'icloud'); os.makedirs(icloud_dir)
+        db = _fresh_db(tmp)
+        return tmp, log_dir, icloud_dir, db
+
+    def test_reads_logs_from_log_dir_and_icloud_subdirs(self):
+        tmp, log_dir, icloud_dir, db = self._setup()
+        # Past-day log inside iCloud (sealed day).
+        sealed_dir = os.path.join(icloud_dir, '2026-04-29')
+        os.makedirs(sealed_dir)
+        _write_log(
+            os.path.join(sealed_dir, 'browser-visits-2026-04-29.log'),
+            _action(REC_A, '2026-04-29T10:00:00Z', 'https://past.com', 'Past'),
+            _result(REC_A, 'success'),
+        )
+        # Today-ish log in log_dir.
+        _write_log(
+            os.path.join(log_dir, 'browser-visits-2026-05-01.log'),
+            _action(REC_B, '2026-05-01T10:00:00Z', 'https://today.com', 'Today'),
+            _result(REC_B, 'success'),
+        )
+        conn = sqlite3.connect(db)
+        try:
+            stats = vr.replay_logs(conn, log_dir, icloud_dir)
+            urls = sorted(r[0] for r in conn.execute(
+                'SELECT url FROM visits').fetchall())
+        finally:
+            conn.close()
+        self.assertEqual(urls, ['https://past.com', 'https://today.com'])
+        self.assertEqual(stats.visits_inserted, 2)
+
+    def test_chronological_order_keeps_first_visit_timestamp(self):
+        # A URL first visited day 1 and re-visited day 5: visits.timestamp
+        # must end up as day 1's value (INSERT OR IGNORE keeps first).
+        # We deliberately set up day-5's file lexicographically before
+        # day-1's via os.listdir-order shenanigans; the rebuilder must
+        # still process day-1 first because of the date-sort.
+        tmp, log_dir, icloud_dir, db = self._setup()
+        # Day 5 log in iCloud (under its sealed dir).
+        os.makedirs(os.path.join(icloud_dir, '2026-05-05'))
+        _write_log(
+            os.path.join(icloud_dir, '2026-05-05',
+                         'browser-visits-2026-05-05.log'),
+            _action(REC_B, '2026-05-05T10:00:00Z',
+                    'https://x.com', 'X (later)'),
+            _result(REC_B, 'success'),
+        )
+        # Day 1 log in log_dir.
+        _write_log(
+            os.path.join(log_dir, 'browser-visits-2026-05-01.log'),
+            _action(REC_A, '2026-05-01T10:00:00Z',
+                    'https://x.com', 'X (first)'),
+            _result(REC_A, 'success'),
+        )
+        conn = sqlite3.connect(db)
+        try:
+            vr.replay_logs(conn, log_dir, icloud_dir)
+            row = conn.execute(
+                'SELECT url, timestamp, title FROM visits WHERE url = ?',
+                ('https://x.com',),
+            ).fetchone()
+        finally:
+            conn.close()
+        # First-visit timestamp wins.
+        self.assertEqual(row, ('https://x.com', '2026-05-01T10:00:00Z',
+                               'X (first)'))
+
+    def test_split_by_seal_race_pairs_action_with_result(self):
+        # Race orphan: action line in the iCloud log, matching result line
+        # in log_dir's same-date log.  The rebuilder's shared `pending`
+        # dict spans files, so it pairs them as a normal success.
+        tmp, log_dir, icloud_dir, db = self._setup()
+        date = '2026-04-29'
+        os.makedirs(os.path.join(icloud_dir, date))
+        # iCloud log has the action.
+        _write_log(
+            os.path.join(icloud_dir, date, f'browser-visits-{date}.log'),
+            _action(REC_A, f'{date}T10:00:00Z', 'https://race.com', 'Race'),
+        )
+        # log_dir has the matching result.
+        _write_log(
+            os.path.join(log_dir, f'browser-visits-{date}.log'),
+            _result(REC_A, 'success'),
+        )
+        conn = sqlite3.connect(db)
+        try:
+            stats = vr.replay_logs(conn, log_dir, icloud_dir)
+            urls = [r[0] for r in conn.execute(
+                'SELECT url FROM visits').fetchall()]
+        finally:
+            conn.close()
+        # Action and result paired; no orphan reports.
+        self.assertEqual(urls, ['https://race.com'])
+        self.assertEqual(stats.success_records, 1)
+        self.assertEqual(stats.orphan_actions, 0)
+        self.assertEqual(stats.orphan_results, 0)
+
+    def test_log_inside_icloud_dir_with_mismatched_date_is_skipped(self):
+        # Defensive: a log file whose filename embeds date X but lives
+        # inside iCloud's date-Y subdir is skipped with a warning (could
+        # indicate corruption or a misplaced file).
+        tmp, log_dir, icloud_dir, db = self._setup()
+        os.makedirs(os.path.join(icloud_dir, '2026-04-29'))
+        # File named for 2026-05-01 but inside the 2026-04-29 dir.
+        _write_log(
+            os.path.join(icloud_dir, '2026-04-29',
+                         'browser-visits-2026-05-01.log'),
+            _action(REC_A, 'ts', 'https://x.com', 'X'),
+            _result(REC_A, 'success'),
+        )
+        conn = sqlite3.connect(db)
+        try:
+            with self.assertLogs(vr.logger, level='WARNING') as cm:
+                stats = vr.replay_logs(conn, log_dir, icloud_dir)
+            n = conn.execute('SELECT COUNT(*) FROM visits').fetchone()[0]
+        finally:
+            conn.close()
+        self.assertEqual(n, 0)
+        self.assertEqual(stats.success_records, 0)
+        self.assertTrue(any('does not match its parent directory' in m
+                            for m in cm.output))
+
+    def test_replay_inserts_snapshots_row_per_log_file(self):
+        # Mirror of host.py: every log file's date should produce a
+        # snapshots row (sealed=0).  Phase 2 may then flip sealed=1 for
+        # iCloud-resident logs.
+        tmp, log_dir, icloud_dir, db = self._setup()
+        _write_log(
+            os.path.join(log_dir, 'browser-visits-2026-05-01.log'),
+            _action(REC_A, 'ts', 'https://a.com', 'A'),
+            _result(REC_A, 'success'),
+        )
+        os.makedirs(os.path.join(icloud_dir, '2026-04-29'))
+        _write_log(
+            os.path.join(icloud_dir, '2026-04-29',
+                         'browser-visits-2026-04-29.log'),
+            _action(REC_B, 'ts', 'https://b.com', 'B'),
+            _result(REC_B, 'success'),
+        )
+        conn = sqlite3.connect(db)
+        try:
+            vr.replay_logs(conn, log_dir, icloud_dir)
+            rows = sorted(conn.execute(
+                'SELECT date, sealed FROM snapshots').fetchall())
+        finally:
+            conn.close()
+        # Both dates represented; both at sealed=0 (phase 2 not run here).
+        self.assertEqual(rows, [('2026-04-29', 0), ('2026-05-01', 0)])
+
+    def test_no_logs_anywhere_is_a_clean_noop(self):
+        tmp, log_dir, icloud_dir, db = self._setup()
+        conn = sqlite3.connect(db)
+        try:
+            stats = vr.replay_logs(conn, log_dir, icloud_dir)
+            n = conn.execute('SELECT COUNT(*) FROM visits').fetchone()[0]
+        finally:
+            conn.close()
+        self.assertEqual(n, 0)
+        self.assertEqual(stats.visits_inserted, 0)
+        self.assertEqual(stats.success_records, 0)
+
+    def test_collect_log_paths_skips_non_log_entries(self):
+        # _collect_log_paths must filter out:
+        #  - non-date entries at the iCloud root
+        #  - date-named *files* (not dirs) at the iCloud root
+        #  - non-log entries inside a date subdir
+        #  - non-regular-file log entries inside a date subdir
+        #  - non-matching entries in log_dir
+        tmp, log_dir, icloud_dir, db = self._setup()
+        # Junk in iCloud root: a non-date dir and a date-named file.
+        os.makedirs(os.path.join(icloud_dir, 'not-a-date'))
+        Path(os.path.join(icloud_dir, '2026-04-30')).touch()
+        # Inside a real date dir: a non-log filename and a directory-shaped
+        # entry whose name matches the log regex.
+        date_dir = os.path.join(icloud_dir, '2026-04-29')
+        os.makedirs(date_dir)
+        Path(os.path.join(date_dir, 'README.txt')).touch()
+        os.makedirs(os.path.join(date_dir, 'browser-visits-2026-04-29.log'))
+        # Junk in log_dir: a non-matching filename.
+        Path(os.path.join(log_dir, 'unrelated.txt')).touch()
+        # A real log file that should be picked up.
+        _write_log(
+            os.path.join(log_dir, 'browser-visits-2026-05-01.log'),
+            _action(REC_A, 'ts', 'https://a.com', 'A'),
+            _result(REC_A, 'success'),
+        )
+
+        paths = vr._collect_log_paths(log_dir, icloud_dir)
+        self.assertEqual(
+            paths,
+            [('2026-05-01',
+              os.path.join(log_dir, 'browser-visits-2026-05-01.log'))],
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -505,6 +724,32 @@ class TestRehydrateFilesystem(unittest.TestCase):
         self.assertEqual(n, 0)
         self.assertEqual(stats.snapshots_upserted, 0)
 
+    def test_rehydrate_skips_per_day_log_file_in_date_dir(self):
+        # A sealed iCloud date dir contains the per-day log alongside
+        # snapshot files.  The log file must NOT be reported as
+        # files_without_events — it's expected and replayed by phase 1.
+        with tempfile.TemporaryDirectory() as tmp:
+            icloud = os.path.join(tmp, 'icloud')
+            date = '2026-04-29'
+            date_dir = os.path.join(icloud, date)
+            os.makedirs(date_dir)
+            Path(os.path.join(date_dir, 'MANIFEST.tsv')).write_text(
+                'filename\ttag\ttimestamp\turl\ttitle\n')
+            Path(os.path.join(date_dir, f'browser-visits-{date}.log')).write_text(
+                '')
+            db = _fresh_db(tmp)
+            conn = sqlite3.connect(db)
+            try:
+                stats = vr.rehydrate_filesystem(
+                    conn, icloud, host.DOWNLOADS_SNAPSHOTS_DIR)
+            finally:
+                conn.close()
+        # Log file is not counted as a file_without_events.
+        self.assertEqual(stats.files_without_events, 0)
+        # Snapshots row was inserted as sealed=1.
+        self.assertEqual(stats.snapshots_upserted, 1)
+        self.assertEqual(stats.sealed_dirs, 1)
+
 
 # ---------------------------------------------------------------------------
 # CLI
@@ -514,22 +759,31 @@ class _CLIBase(unittest.TestCase):
     """Shared setup: build a temp dir with a log + DB + source/dest dirs and
     return the CLI flag list."""
 
-    def _mk(self, lines=()):
-        """Create a tmp dir and return (tmp, args, paths)."""
+    def _mk(self, lines=(), date_iso='2026-01-01'):
+        """Create a tmp dir and return (tmp, args, paths).
+
+        log_dir holds <log_dir>/browser-visits-<date_iso>.log seeded with
+        the given lines.  Use date_iso to pin the filename so tests can
+        also read it back from paths['log'].
+        """
         tmp = tempfile.mkdtemp()
         paths = {
-            'log':  os.path.join(tmp, 'visits.log'),
-            'db':   os.path.join(tmp, 'visits.db'),
-            'src':  os.path.join(tmp, 'dl'),
-            'dest': os.path.join(tmp, 'icloud'),
+            'log_dir': os.path.join(tmp, 'logs'),
+            'log':     None,  # filled in once log_dir exists
+            'db':      os.path.join(tmp, 'visits.db'),
+            'src':     os.path.join(tmp, 'dl'),
+            'dest':    os.path.join(tmp, 'icloud'),
         }
-        _write_log(paths['log'], *lines)
+        os.makedirs(paths['log_dir'])
         os.makedirs(paths['src'])
         os.makedirs(paths['dest'])
-        args = ['--log',    paths['log'],
-                '--db',     paths['db'],
-                '--source', paths['src'],
-                '--dest',   paths['dest']]
+        paths['log'] = os.path.join(
+            paths['log_dir'], f'browser-visits-{date_iso}.log')
+        _write_log(paths['log'], *lines)
+        args = ['--log-dir', paths['log_dir'],
+                '--db',      paths['db'],
+                '--source',  paths['src'],
+                '--dest',    paths['dest']]
         return tmp, args, paths
 
     def _run(self, args):
@@ -537,16 +791,16 @@ class _CLIBase(unittest.TestCase):
         # cli() mutates host.* and snapshot_mover.* globals; restore them so
         # one test doesn't pollute the next.
         saved = (
-            host.DOWNLOADS_SNAPSHOTS_DIR, host.DB_FILE,
-            snapshot_mover.ICLOUD_SNAPSHOTS_DIR,
+            host.DOWNLOADS_SNAPSHOTS_DIR, host.DB_FILE, host.LOG_DIR,
+            snapshot_mover.ICLOUD_SNAPSHOTS_DIR, snapshot_mover.LOG_DIR,
         )
         buf = io.StringIO()
         try:
             with redirect_stdout(buf):
                 rc = vr.cli(args)
         finally:
-            (host.DOWNLOADS_SNAPSHOTS_DIR, host.DB_FILE,
-             snapshot_mover.ICLOUD_SNAPSHOTS_DIR) = saved
+            (host.DOWNLOADS_SNAPSHOTS_DIR, host.DB_FILE, host.LOG_DIR,
+             snapshot_mover.ICLOUD_SNAPSHOTS_DIR, snapshot_mover.LOG_DIR) = saved
         return rc, buf.getvalue()
 
 
@@ -584,10 +838,10 @@ class TestCLI(_CLIBase):
         finally:
             __import__('shutil').rmtree(tmp, ignore_errors=True)
 
-    def test_missing_log_exits_nonzero(self):
+    def test_missing_log_dir_exits_nonzero(self):
         with tempfile.TemporaryDirectory() as tmp:
-            args = ['--log', os.path.join(tmp, 'no-such.log'),
-                    '--db',  os.path.join(tmp, 'visits.db')]
+            args = ['--log-dir', os.path.join(tmp, 'no-such-dir'),
+                    '--db',      os.path.join(tmp, 'visits.db')]
             rc, _ = self._run(args)
         self.assertEqual(rc, 1)
 
@@ -681,13 +935,22 @@ class TestCLI(_CLIBase):
         ))
         try:
             # Pre-create an iCloud date dir so rehydrate, if invoked, would
-            # add a snapshots row; --log-only must suppress that.
+            # add a snapshots row for it; --log-only must suppress that.
             os.makedirs(os.path.join(paths['dest'], '2026-04-29'))
             rc, out = self._run(args + ['--log-only'])
             self.assertEqual(rc, 0)
             self.assertIn('replay:',     out)
             self.assertNotIn('rehydrate:', out)
-            self.assertEqual(_row_count(paths['db'], 'snapshots'), 0)
+            # Phase 1 inserts a snapshots row per log file's date; phase 2
+            # was skipped, so the iCloud-only date 2026-04-29 must NOT
+            # have produced a row.
+            conn = sqlite3.connect(paths['db'])
+            dates = sorted(r[0] for r in conn.execute(
+                'SELECT date FROM snapshots').fetchall())
+            conn.close()
+            self.assertNotIn('2026-04-29', dates)
+            # The log's date IS expected (phase 1 mirrors host.py's INSERT).
+            self.assertEqual(dates, ['2026-01-01'])
         finally:
             __import__('shutil').rmtree(tmp, ignore_errors=True)
 
@@ -708,10 +971,8 @@ class TestCLI(_CLIBase):
 
     def test_missing_db_parent_dir_exits_nonzero(self):
         with tempfile.TemporaryDirectory() as tmp:
-            log = os.path.join(tmp, 'visits.log')
-            Path(log).touch()
-            args = ['--log', log,
-                    '--db', os.path.join(tmp, 'no-such-dir', 'visits.db')]
+            args = ['--log-dir', tmp,
+                    '--db',      os.path.join(tmp, 'no-such-dir', 'visits.db')]
             rc, _ = self._run(args)
         self.assertEqual(rc, 1)
 
@@ -763,7 +1024,8 @@ class TestEndToEnd(unittest.TestCase):
         payload = json.dumps(message).encode('utf-8')
         framed = struct.pack('<I', len(payload)) + payload
 
-        log_path = os.path.join(tmp, 'visits.log')
+        log_dir  = os.path.join(tmp, 'logs')
+        os.makedirs(log_dir, exist_ok=True)
         db_path  = os.path.join(tmp, 'visits.db')
         src      = os.path.join(tmp, 'dl')
 
@@ -772,8 +1034,8 @@ class TestEndToEnd(unittest.TestCase):
         stdin.buffer  = stdin   # host expects sys.stdin.buffer
         stdout.buffer = stdout  # and sys.stdout.buffer
 
-        with patch.object(host, 'LOG_FILE', log_path), \
-             patch.object(host, 'DB_FILE',  db_path), \
+        with patch.object(host, 'LOG_DIR', log_dir), \
+             patch.object(host, 'DB_FILE', db_path), \
              patch.object(host, 'DOWNLOADS_SNAPSHOTS_DIR', src), \
              patch.object(sys, 'stdin',  stdin), \
              patch.object(sys, 'stdout', stdout):
@@ -807,10 +1069,10 @@ class TestEndToEnd(unittest.TestCase):
 
     def test_round_trip_matches_original(self):
         with tempfile.TemporaryDirectory() as tmp:
-            src  = os.path.join(tmp, 'dl');     os.makedirs(src)
-            dest = os.path.join(tmp, 'icloud'); os.makedirs(dest)
-            db   = os.path.join(tmp, 'visits.db')
-            log  = os.path.join(tmp, 'visits.log')
+            src     = os.path.join(tmp, 'dl');     os.makedirs(src)
+            dest    = os.path.join(tmp, 'icloud'); os.makedirs(dest)
+            log_dir = os.path.join(tmp, 'logs')    # _drive_host creates it
+            db      = os.path.join(tmp, 'visits.db')
 
             # Seed a few host invocations: visit, of_interest, read, skimmed.
             self._drive_host({'timestamp': '2026-04-29T10:00:00Z',
@@ -839,35 +1101,41 @@ class TestEndToEnd(unittest.TestCase):
             saved = (
                 snapshot_mover.DOWNLOADS_SNAPSHOTS_DIR,
                 snapshot_mover.ICLOUD_SNAPSHOTS_DIR,
+                snapshot_mover.LOG_DIR,
                 snapshot_mover.DB_FILE,
             )
             try:
                 snapshot_mover.DOWNLOADS_SNAPSHOTS_DIR = src
                 snapshot_mover.ICLOUD_SNAPSHOTS_DIR    = dest
+                snapshot_mover.LOG_DIR                 = log_dir
                 snapshot_mover.DB_FILE                 = db
                 conn = sqlite3.connect(db)
                 snapshot_mover._ensure_snapshots_table(conn)
                 snapshot_mover._ensure_mover_errors_table(conn)
                 snapshot_mover._move_pass(conn)
                 snapshot_mover._seal_pass(conn)
+                snapshot_mover._orphan_log_merge_pass(conn)
                 conn.close()
             finally:
                 (snapshot_mover.DOWNLOADS_SNAPSHOTS_DIR,
                  snapshot_mover.ICLOUD_SNAPSHOTS_DIR,
+                 snapshot_mover.LOG_DIR,
                  snapshot_mover.DB_FILE) = saved
 
             # Snapshot table contents, wipe the DB, run the rebuild.
             before = self._snapshot_tables(db)
             os.unlink(db)
 
-            saved2 = (host.DOWNLOADS_SNAPSHOTS_DIR, host.DB_FILE,
-                      snapshot_mover.ICLOUD_SNAPSHOTS_DIR)
+            saved2 = (host.DOWNLOADS_SNAPSHOTS_DIR, host.DB_FILE, host.LOG_DIR,
+                      snapshot_mover.ICLOUD_SNAPSHOTS_DIR,
+                      snapshot_mover.LOG_DIR)
             try:
-                rc = vr.cli(['--log', log, '--db', db,
+                rc = vr.cli(['--log-dir', log_dir, '--db', db,
                              '--source', src, '--dest', dest])
             finally:
-                (host.DOWNLOADS_SNAPSHOTS_DIR, host.DB_FILE,
-                 snapshot_mover.ICLOUD_SNAPSHOTS_DIR) = saved2
+                (host.DOWNLOADS_SNAPSHOTS_DIR, host.DB_FILE, host.LOG_DIR,
+                 snapshot_mover.ICLOUD_SNAPSHOTS_DIR,
+                 snapshot_mover.LOG_DIR) = saved2
             self.assertEqual(rc, 0)
 
             after = self._snapshot_tables(db)
@@ -887,16 +1155,16 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 class TestWrapperSmoke(unittest.TestCase):
 
-    def test_wrapper_runs_against_empty_log(self):
+    def test_wrapper_runs_against_empty_log_dir(self):
         with tempfile.TemporaryDirectory() as tmp:
-            log = os.path.join(tmp, 'visits.log')
-            Path(log).touch()
-            db   = os.path.join(tmp, 'visits.db')
-            src  = os.path.join(tmp, 'dl');     os.makedirs(src)
-            dest = os.path.join(tmp, 'icloud'); os.makedirs(dest)
+            log_dir = os.path.join(tmp, 'logs');   os.makedirs(log_dir)
+            db      = os.path.join(tmp, 'visits.db')
+            src     = os.path.join(tmp, 'dl');     os.makedirs(src)
+            dest    = os.path.join(tmp, 'icloud'); os.makedirs(dest)
             result = subprocess.run(
                 [str(REPO_ROOT / 'rebuild_visits_data'),
-                 '--log', log, '--db', db, '--source', src, '--dest', dest],
+                 '--log-dir', log_dir, '--db', db,
+                 '--source', src, '--dest', dest],
                 capture_output=True, text=True, timeout=10,
             )
         self.assertEqual(result.returncode, 0,


### PR DESCRIPTION
## Summary
- Replace the single `~/browser-visits.log` with per-day `browser-visits-<UTC-date>.log` files under `BVL_LOG_DIR` (replaces `BVL_LOG_FILE`). Each host invocation pins its date once at startup, so an action and its result line always land in the same file even across midnight UTC.
- The sealer now moves each completed day's log into the matching iCloud sealed dir (chmod 0o444), alongside `MANIFEST.tsv`. Activity-only days (host activity but no read/skimmed events) are now sealed too — `host.main()` does `INSERT OR IGNORE INTO snapshots(date, sealed=0)` on every write invocation, and `_seal_pass` auto-creates the iCloud date dir if absent.
- New `_orphan_log_merge_pass` on every sealer tick reconciles the (microscopic but real) seal-while-host-running race: orphan logs in `BVL_LOG_DIR` whose iCloud counterpart already exists are merged in (chmod 0o644 → append → chmod 0o444 → delete orphan); orphans without a counterpart get a `snapshots` row backfilled.
- `snapshot_verifier.py` now requires the per-day log file to be present and read-only in every sealed dir.
- `rebuild_visits_data --log FILE` becomes `--log-dir DIR`. The rebuilder enumerates per-day logs from `BVL_LOG_DIR` *and* every sealed iCloud subdir, sorts them chronologically (so `INSERT OR IGNORE` keeps the earliest first-visit timestamp on `visits.timestamp`), and uses one shared `pending` dict spanning files so a UUID's action half in one file pairs with its result half in another.
- `reset.py --log` now globs `BVL_LOG_DIR` for `browser-visits-*.log`. Logs already moved into iCloud are wiped by `--icloud` (parallel to today's separation between log and snapshot data).
- README updated end-to-end: storage layout, configuration table, mover/sealer/rebuilder/reset doc sections.

The `missing_directory` error path was retired — `_seal_pass` now always creates the date dir if absent (covers activity-only days). The verifier still catches user-deleted-then-resealed dirs as orphan event rows.

**Migration:** clean break, matching the prior log-format precedent. Pre-upgrade `~/browser-visits.log` is not consumed by the new code; users should `./reset_visits_data --log -f` (or just delete it) before upgrading.

## Test plan
- [x] `python3 -m pytest tests/ --cov=native-host --cov-report=term-missing` — 406 passing, 100% line coverage on `host.py`, `snapshot_mover.py`, `snapshot_sealer.py`, `snapshot_verifier.py`, and `visits_rebuilder.py`.
- [x] `npm test -- --coverage` — 94 passing, 100% coverage on `background.js` and `popup.js`.
- [x] `./rebuild_visits_data --help` shows the new `--log-dir` flag.
- [x] Manual `reset.py --log` smoke against a tmp dir with two per-day logs + a host log: per-day logs deleted, host log preserved.
- [x] End-to-end test (`test_round_trip_matches_original`) drives full host → mover → sealer → orphan-merge pipeline, snapshots tables, wipes the DB, runs `vr.cli --log-dir`, and asserts every rebuildable table round-trips identically.
- [ ] Manual smoke against the real installation: confirm `~/browser-visits-<today>.log` is created today; after midnight UTC + a `./move_snapshot` tick, confirm the prior day's iCloud subdir contains its `MANIFEST.tsv` *and* `browser-visits-<that-date>.log`, both 0o444; `./verify_snapshot_directory --all` passes; `./rebuild_visits_data` round-trips the DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)