### PR TITLE
Relocate snapshots out of TCC-protected ~/Downloads via host.py

### DIFF
--- a/browser-visit-logger/README.md
+++ b/browser-visit-logger/README.md
@@ -31,11 +31,22 @@ directly to avoid Chrome's mangled PDF viewer output). Each file is named
 from the click timestamp so the file's name is permanent and globally
 sortable.
 
-Snapshots land first in `~/Downloads/browser-visit-snapshots/`. A
-background mover then archives them into
+Chrome's downloads API forces every file under `~/Downloads`, so each
+snapshot lands first in `~/Downloads/browser-visit-snapshots/`. The
+native host (`host.py`) immediately relocates it to a non-Downloads
+staging dir at
+`~/Library/Application Support/browser-visit-logger/inbox/`. A
+background mover (`snapshot_mover.py`) then archives staged files into
 `~/Documents/browser-visit-logger/snapshots/<YYYY-MM-DD>/`, makes them
 read-only, and (once the day has fully passed) writes a
 `MANIFEST.tsv` summarising the directory.
+
+The relocate hop exists because `~/Downloads` is TCC-protected on
+macOS: the launchd-spawned mover cannot read it, but `host.py` (spawned
+by Chrome via native messaging) inherits Chrome's TCC grant and can.
+Each `host.py` invocation also sweeps any files left in the Downloads
+dir by a prior crashed run, so stragglers self-heal on the next user
+action.
 
 ---
 
@@ -48,7 +59,8 @@ read-only, and (once the day has fully passed) writes a
 | `~/browser-visits-host.log` | Native host process log (rotated, 1 MiB × 3) |
 | `~/browser-visits-mover.log` | Snapshot mover process log (LaunchAgent stdout/stderr) |
 | `~/browser-visits-verifier.log` | Snapshot verifier process log (LaunchAgent stdout/stderr) |
-| `~/Downloads/browser-visit-snapshots/` | Snapshot staging dir (Chrome writes here) |
+| `~/Downloads/browser-visit-snapshots/` | Chrome's drop point (host.py clears it on each invocation) |
+| `~/Library/Application Support/browser-visit-logger/inbox/` | Snapshot staging dir (host.py moves files here from Downloads; mover reads from here) |
 | `~/Documents/browser-visit-logger/snapshots/<YYYY-MM-DD>/` | Sealed daily archive: read-only snapshot files + read-only `MANIFEST.tsv` + read-only `browser-visits-<YYYY-MM-DD>.log` |
 
 All paths can be overridden via `BVL_*` environment variables — see
@@ -72,7 +84,7 @@ read_events / skimmed_events (
     url       TEXT NOT NULL,
     timestamp TEXT NOT NULL,                   -- when the user tagged
     filename  TEXT NOT NULL DEFAULT '',        -- snapshot basename
-    directory TEXT NOT NULL DEFAULT '<Downloads dir>',
+    directory TEXT NOT NULL DEFAULT '<staging dir>',
     PRIMARY KEY (url, timestamp)
 )
 
@@ -256,9 +268,10 @@ exclusive.
 
 **What it does each run:**
 
-1. **Move pass** — for every file in `~/Downloads/browser-visit-snapshots/`
-   matching the snapshot filename format and at least `MIN_AGE_SECONDS`
-   old: copy it to `<dest>/<YYYY-MM-DD>/`, chmod read-only, update the
+1. **Move pass** — for every file in
+   `~/Library/Application Support/browser-visit-logger/inbox/` matching
+   the snapshot filename format and at least `MIN_AGE_SECONDS` old:
+   copy it to `<dest>/<YYYY-MM-DD>/`, chmod read-only, update the
    `directory` column in `read_events`/`skimmed_events`, and
    `INSERT OR IGNORE` a `(date, sealed=0)` row into the `snapshots`
    table; then unlink the source. **Straggler handling:** if the
@@ -444,7 +457,7 @@ python3 reset.py -f
 python3 reset.py --log         # all ~/browser-visits-<date>.log files in BVL_LOG_DIR
 python3 reset.py --host-log    # host log + mover log
 python3 reset.py --db          # ~/browser-visits.db
-python3 reset.py --snapshots   # ~/Downloads/browser-visit-snapshots/
+python3 reset.py --snapshots   # staging dir + ~/Downloads/browser-visit-snapshots/
 python3 reset.py --icloud      # ~/Documents/browser-visit-logger/  (also wipes per-day logs sealed in iCloud)
 ```
 
@@ -477,8 +490,8 @@ archive.  Two phases run by default:
 2. **Filesystem rehydration** — iterates every `YYYY-MM-DD`
    subdirectory under the iCloud root, upserts a `snapshots` row
    (`sealed = 1` if `MANIFEST.tsv` exists), and updates each event
-   row's `directory` column from Downloads to the date subdir for
-   files that have already been moved.
+   row's `directory` column from the staging dir to the date subdir
+   for files that have already been moved.
 
 ```bash
 # Rebuild against the configured paths (DROPs and recreates
@@ -567,12 +580,11 @@ notification once the row qualifies:
   - `manifest_invalid` — `snapshot_verifier.py --record` found a
     sealed directory whose `MANIFEST.tsv` failed one or more checks.
     Auto-clears on the next successful verification.
-  - `invalid_filename` — a file in `~/Downloads/browser-visit-snapshots/`
-    or in a daily snapshot directory has a name that doesn't match the
-    canonical `<YYYY-MM-DDTHH-MM-SSZ>-<hash>.<ext>` format.  The
-    Downloads file is left in place; date-dir files are excluded from
-    the manifest.  The row auto-clears when the user removes or
-    renames the file.
+  - `invalid_filename` — a file in the staging dir or in a daily
+    snapshot directory has a name that doesn't match the canonical
+    `<YYYY-MM-DDTHH-MM-SSZ>-<hash>.<ext>` format.  The staging file is
+    left in place; date-dir files are excluded from the manifest.  The
+    row auto-clears when the user removes or renames the file.
   - `orphan_file` — a conforming-named snapshot file in a daily
     directory has no matching `read_events` / `skimmed_events` row.
     The file is excluded from the manifest.  The row auto-clears when
@@ -625,7 +637,8 @@ env vars; env vars override defaults.
 | `BVL_MOVER_LOG` | `~/browser-visits-mover.log` | reset (mover writes via LaunchAgent stdout/stderr) |
 | `BVL_VERIFIER_LOG` | `~/browser-visits-verifier.log` | reset (verifier writes via LaunchAgent stdout/stderr) |
 | `BVL_DB_FILE` | `~/browser-visits.db` | host, mover, sealer, rebuilder, reset |
-| `BVL_DOWNLOADS_SNAPSHOTS_DIR` | `~/Downloads/browser-visit-snapshots` | host, mover, rebuilder, reset |
+| `BVL_DOWNLOADS_SNAPSHOTS_DIR` | `~/Downloads/browser-visit-snapshots` | host (relocate source), reset.  Where Chrome drops snapshots before host.py moves them to the staging dir. |
+| `BVL_STAGING_SNAPSHOTS_DIR` | `~/Library/Application Support/browser-visit-logger/inbox` | host (relocate dest, events row directory), mover (read source), rebuilder, reset |
 | `BVL_ICLOUD_SNAPSHOTS_DIR` | `~/Documents/browser-visit-logger/snapshots` | host, mover, sealer, rebuilder |
 | `BVL_MOVER_MIN_AGE_SECONDS` | `60` | mover |
 | `BVL_MOVER_ERROR_THRESHOLD` | `3` | mover (consecutive failures before persistent-error notification) |

--- a/browser-visit-logger/native-host/host.py
+++ b/browser-visit-logger/native-host/host.py
@@ -21,12 +21,19 @@ Tag action (from popup.js / background.js):
     → INSERT OR IGNORE the visit row first (so tagging always works even if the
       auto-log hasn't fired yet), then update of_interest, read, or skimmed;
       append 4-field TSV line.
-      For "read" and "skimmed": Chrome saves a snapshot and sends its filename
-      (Chrome's relative path under ~/Downloads). This host normalizes the
-      filename to its basename and records both the basename and the parent
-      directory (initially the Downloads snapshots dir). A separate periodic
-      mover (snapshot_mover.py) later copies the file to the iCloud directory
-      and updates the directory column in place.
+      For "read" and "skimmed": Chrome saves a snapshot to ~/Downloads and
+      sends its Downloads-relative path.  host.py immediately relocates the
+      file out of ~/Downloads (a TCC-protected location) into a staging dir
+      under ~/Library/Application Support, then records the basename plus the
+      staging dir as the event row's directory.  A separate periodic mover
+      (snapshot_mover.py) later copies the file to the iCloud directory and
+      updates the directory column in place.
+
+      Why the relocate: the launchd-spawned mover does not inherit Chrome's
+      TCC grant for ~/Downloads, so it cannot read snapshots dropped there.
+      host.py is spawned by Chrome via native messaging and therefore can —
+      so we use that one Chrome-spawned hop to escape Downloads before the
+      mover ever has to look.
 
 Schema
 ------
@@ -43,7 +50,7 @@ Schema
         url       TEXT NOT NULL,
         timestamp TEXT NOT NULL,
         filename  TEXT NOT NULL DEFAULT '',  -- snapshot basename, e.g. <hash>.mhtml
-        directory TEXT NOT NULL DEFAULT '<DOWNLOADS_SNAPSHOTS_DIR>',  -- absolute parent dir
+        directory TEXT NOT NULL DEFAULT '<STAGING_SNAPSHOTS_DIR>',  -- absolute parent dir
         PRIMARY KEY (url, timestamp)
     )
 
@@ -51,7 +58,7 @@ Schema
         url       TEXT NOT NULL,
         timestamp TEXT NOT NULL,
         filename  TEXT NOT NULL DEFAULT '',  -- snapshot basename, e.g. <hash>.mhtml
-        directory TEXT NOT NULL DEFAULT '<DOWNLOADS_SNAPSHOTS_DIR>',  -- absolute parent dir
+        directory TEXT NOT NULL DEFAULT '<STAGING_SNAPSHOTS_DIR>',  -- absolute parent dir
         PRIMARY KEY (url, timestamp)
     )
 
@@ -90,11 +97,22 @@ LOG_DIR  = os.environ.get('BVL_LOG_DIR',  HOME)
 DB_FILE  = os.environ.get('BVL_DB_FILE',  os.path.join(HOME, 'browser-visits.db'))
 HOST_LOG = os.environ.get('BVL_HOST_LOG', os.path.join(HOME, 'browser-visits-host.log'))
 
-# Snapshot storage locations.  Chrome writes snapshots to the Downloads dir;
-# the periodic mover later copies them to the iCloud-synced Documents dir.
+# Snapshot storage locations.
+#
+# Chrome's downloads API forces files under ~/Downloads, so that's where
+# every snapshot first lands.  ~/Downloads is TCC-protected on macOS and
+# the launchd-spawned mover cannot read it.  host.py runs under Chrome's
+# TCC grant, so we use it as a one-hop relocator: each invocation moves
+# any file from DOWNLOADS_SNAPSHOTS_DIR into STAGING_SNAPSHOTS_DIR.  The
+# events table records the staging dir; the mover reads from there.
 DOWNLOADS_SNAPSHOTS_DIR = os.environ.get(
     'BVL_DOWNLOADS_SNAPSHOTS_DIR',
     os.path.join(HOME, 'Downloads', 'browser-visit-snapshots'),
+)
+STAGING_SNAPSHOTS_DIR = os.environ.get(
+    'BVL_STAGING_SNAPSHOTS_DIR',
+    os.path.join(HOME, 'Library', 'Application Support',
+                 'browser-visit-logger', 'inbox'),
 )
 ICLOUD_SNAPSHOTS_DIR = os.environ.get(
     'BVL_ICLOUD_SNAPSHOTS_DIR',
@@ -181,12 +199,12 @@ def _ensure_events_table(conn: sqlite3.Connection, table: str) -> None:
 
     table is a trusted internal constant, never user-supplied.
 
-    The DEFAULT for directory embeds DOWNLOADS_SNAPSHOTS_DIR at table-creation
+    The DEFAULT for directory embeds STAGING_SNAPSHOTS_DIR at table-creation
     time so that ad-hoc INSERTs (e.g. via sqlite3 CLI) get a sensible value;
     _insert_event always specifies the directory explicitly.  Single-quotes in
     the path are escaped to prevent SQL syntax errors on unusual home paths.
     """
-    default_dir_lit = "'" + DOWNLOADS_SNAPSHOTS_DIR.replace("'", "''") + "'"
+    default_dir_lit = "'" + STAGING_SNAPSHOTS_DIR.replace("'", "''") + "'"
     conn.execute(f"""
         CREATE TABLE IF NOT EXISTS {table} (
             url       TEXT NOT NULL,
@@ -208,7 +226,9 @@ def _insert_event(
     The filename is normalized to its basename before being stored (background.js
     sends Chrome's relative path under Downloads, e.g. 'browser-visit-snapshots/
     <hash>.mhtml'; the parent directory is captured separately in the directory
-    column so the basename alone is sufficient).
+    column so the basename alone is sufficient).  The directory recorded is
+    STAGING_SNAPSHOTS_DIR — host.py's main() relocates the file there from
+    Downloads before this call runs.
 
     Returns True if the URL exists (event inserted or duplicate ignored),
     False if no visits record exists for the URL.
@@ -221,7 +241,7 @@ def _insert_event(
         cursor = conn.execute(
             f"INSERT OR IGNORE INTO {table} (url, timestamp, filename, directory) "
             f"VALUES (?, ?, ?, ?)",
-            (url, timestamp, basename, DOWNLOADS_SNAPSHOTS_DIR),
+            (url, timestamp, basename, STAGING_SNAPSHOTS_DIR),
         )
         if cursor.rowcount > 0:
             conn.execute(
@@ -298,6 +318,58 @@ def tag_visit(
         return False
     conn.commit()
     return cursor.rowcount > 0
+
+# ---------------------------------------------------------------------------
+# Snapshot relocation — escape Downloads' TCC bubble while we're still
+# spawned by Chrome.  See module docstring for the why.
+# ---------------------------------------------------------------------------
+
+def _sweep_downloads_to_staging() -> None:
+    """Move every file in DOWNLOADS_SNAPSHOTS_DIR to STAGING_SNAPSHOTS_DIR.
+
+    Called at the start of every write invocation.  Handles two cases in
+    one pass:
+
+      1. The file Chrome just dropped for *this* invocation's tag message —
+         its filename matches what background.js reported, and after this
+         call it lives in the staging dir where _insert_event records it.
+      2. Files left behind by a prior host.py crash between Chrome's
+         download and the original sweep — the mover can't reach them
+         (no TCC grant for Downloads), but host.py can, so each fresh
+         host.py invocation gets a chance to recover them.
+
+    Best-effort: any failure is logged but does not raise.  The events row
+    for case (1) is still written pointing at STAGING_SNAPSHOTS_DIR even if
+    the move failed — orphan rows (row without file) are surfaced later by
+    the snapshot verifier; orphan files (file without row, e.g. case 2
+    recoveries that arrive in staging before the user has re-tagged the
+    URL) by the seal pass.  Idempotent.
+    """
+    if not os.path.isdir(DOWNLOADS_SNAPSHOTS_DIR):
+        return
+    try:
+        os.makedirs(STAGING_SNAPSHOTS_DIR, exist_ok=True)
+    except OSError as exc:
+        logger.error('Sweep: could not create staging dir %s: %s',
+                     STAGING_SNAPSHOTS_DIR, exc)
+        return
+    try:
+        names = os.listdir(DOWNLOADS_SNAPSHOTS_DIR)
+    except OSError as exc:
+        logger.error('Sweep: could not list %s: %s',
+                     DOWNLOADS_SNAPSHOTS_DIR, exc)
+        return
+    for name in names:
+        src = os.path.join(DOWNLOADS_SNAPSHOTS_DIR, name)
+        dst = os.path.join(STAGING_SNAPSHOTS_DIR, name)
+        try:
+            if not os.path.isfile(src):
+                continue
+            os.replace(src, dst)
+        except OSError as exc:
+            logger.error('Sweep: failed to relocate %s -> %s: %s',
+                         src, dst, exc)
+
 
 # ---------------------------------------------------------------------------
 # Log file helper
@@ -406,6 +478,14 @@ def main() -> None:
         return
 
     errors = []
+
+    # Move Chrome's snapshot drops out of ~/Downloads (TCC-protected on
+    # macOS, unreadable by the launchd-spawned mover) into the staging
+    # dir before any DB/log writes.  This runs on every write invocation
+    # so a host.py crash that left a file behind in Downloads gets a
+    # chance to be recovered on the next user action.  Best-effort —
+    # logged failures don't block the rest of the invocation.
+    _sweep_downloads_to_staging()
 
     # First write: record the intended action
     try:

--- a/browser-visit-logger/native-host/snapshot_mover.py
+++ b/browser-visit-logger/native-host/snapshot_mover.py
@@ -1,12 +1,18 @@
 #!/usr/bin/env python3
 """
 snapshot_mover.py — Periodically archive snapshot files from the local
-Downloads folder to the iCloud-synced Documents folder, updating the
+staging directory to the iCloud-synced Documents folder, updating the
 SQLite database to point at the new location, and sealing each daily
 archive directory once its UTC date has fully passed.
 
 Designed to be run by a launchd LaunchAgent every N seconds (default 1 h);
 each invocation does one pass and exits.
+
+The staging dir is populated by host.py: Chrome saves each snapshot into
+~/Downloads (its downloads API forces files there), then host.py — which
+inherits Chrome's TCC grant for ~/Downloads — relocates the file into the
+staging dir.  This mover never reads ~/Downloads itself; doing so would
+fail under launchd because the launchd-spawned process has no TCC grant.
 
 Algorithm
 ---------
@@ -14,7 +20,7 @@ Algorithm
 2. Open the SQLite database.
 3. Ensure the `snapshots` table exists (one row per daily directory the
    mover has ever created; stores its sealed flag).
-4. Move pass — scan the Downloads directory for snapshot files:
+4. Move pass — scan the staging directory for snapshot files:
      For each file whose name matches the snapshot format
      '<YYYY-MM-DDTHH-MM-SSZ>-<hash>.<ext>' and whose mtime is at least
      MIN_AGE_SECONDS old:
@@ -23,7 +29,7 @@ Algorithm
        c. shutil.copy2(source, dest)          — preserves mtime; safe to repeat
        d. os.chmod(dest, 0o444)               — make archived copy read-only
        e. UPDATE {read,skimmed}_events SET directory = <date_subdir>
-          WHERE filename = <this file> AND directory = DOWNLOADS_SNAPSHOTS_DIR
+          WHERE filename = <this file> AND directory = STAGING_SNAPSHOTS_DIR
        f. INSERT OR IGNORE INTO snapshots (date, sealed) VALUES (<date>, 0)
        g. commit()
        h. source.unlink()
@@ -48,7 +54,7 @@ Algorithm
 6. Close the DB.
 
 The filesystem scan (rather than a DB query) means that any file left in
-Downloads by a failed prior run is automatically retried — no special
+the staging dir by a failed prior run is automatically retried — no special
 "orphan sweep" is required.  Crash-safety analysis:
 
   Crash after (c) only:  source still present, dest exists → next run copies
@@ -66,12 +72,13 @@ record time:
 The date portion (first 10 characters) determines the iCloud date subdir:
     ICLOUD_SNAPSHOTS_DIR/2026-04-30/2026-04-30T14-35-22Z-abc123.mhtml
 
-Files in Downloads that do not match this format are silently skipped.
+Files in the staging dir that do not match this format are silently skipped.
 
 Configuration
 -------------
 DB_FILE                  — BVL_DB_FILE, default ~/browser-visits.db
-DOWNLOADS_SNAPSHOTS_DIR  — BVL_DOWNLOADS_SNAPSHOTS_DIR, default ~/Downloads/browser-visit-snapshots
+STAGING_SNAPSHOTS_DIR    — BVL_STAGING_SNAPSHOTS_DIR,
+                           default ~/Library/Application Support/browser-visit-logger/inbox
 ICLOUD_SNAPSHOTS_DIR     — BVL_ICLOUD_SNAPSHOTS_DIR,    default ~/Documents/browser-visit-logger/snapshots
 MIN_AGE_SECONDS          — BVL_MOVER_MIN_AGE_SECONDS,   default 60 (1 min)
 
@@ -113,9 +120,10 @@ import time
 
 HOME = os.path.expanduser('~')
 DB_FILE = os.environ.get('BVL_DB_FILE', os.path.join(HOME, 'browser-visits.db'))
-DOWNLOADS_SNAPSHOTS_DIR = os.environ.get(
-    'BVL_DOWNLOADS_SNAPSHOTS_DIR',
-    os.path.join(HOME, 'Downloads', 'browser-visit-snapshots'),
+STAGING_SNAPSHOTS_DIR = os.environ.get(
+    'BVL_STAGING_SNAPSHOTS_DIR',
+    os.path.join(HOME, 'Library', 'Application Support',
+                 'browser-visit-logger', 'inbox'),
 )
 ICLOUD_SNAPSHOTS_DIR = os.environ.get(
     'BVL_ICLOUD_SNAPSHOTS_DIR',
@@ -317,7 +325,7 @@ def _reconcile_dir_scoped_errors(conn, op, dir_path, current_strays):
     current_strays set — i.e. files the user has since renamed,
     removed, or otherwise resolved.  Used by:
 
-      - _move_pass with op='invalid_filename' on Downloads.
+      - _move_pass with op='invalid_filename' on the staging dir.
       - _build_manifest_rows with op='invalid_filename' on the date dir
         (non-conforming filenames excluded from the manifest).
       - _build_manifest_rows with op='orphan_file' on the date dir
@@ -362,7 +370,7 @@ def _is_immediate(op, exc):
          - 'invalid_filename' inside a date subdir runs once per
            successful seal of that dir; after sealed=1 the row is never
            re-visited.
-       (The Downloads-side 'invalid_filename' rows DO accumulate on each
+       (The staging-side 'invalid_filename' rows DO accumulate on each
        tick that re-encounters the file, but treating both as immediate
        keeps the classification simple and gets the user notified faster.)
     3. Catastrophic OSError errnos and DB integrity errors — the
@@ -476,18 +484,18 @@ _SNAPSHOT_FILENAME_RE = re.compile(
 
 
 def _move_pass(conn: sqlite3.Connection, dry_run: bool = False) -> None:
-    """Scan the Downloads directory and move every old-enough snapshot to iCloud.
+    """Scan the staging directory and move every old-enough snapshot to iCloud.
 
-    Uses the filesystem as the source of truth, so any file left in Downloads
-    by a failed prior run is automatically retried.
+    Uses the filesystem as the source of truth, so any file left in the
+    staging dir by a failed prior run is automatically retried.
     """
-    if not os.path.isdir(DOWNLOADS_SNAPSHOTS_DIR):
+    if not os.path.isdir(STAGING_SNAPSHOTS_DIR):
         return
 
     now = time.time()
     current_invalid = []   # paths flagged this pass; used to reconcile errors
-    for filename in os.listdir(DOWNLOADS_SNAPSHOTS_DIR):
-        source = os.path.join(DOWNLOADS_SNAPSHOTS_DIR, filename)
+    for filename in os.listdir(STAGING_SNAPSHOTS_DIR):
+        source = os.path.join(STAGING_SNAPSHOTS_DIR, filename)
         if not os.path.isfile(source):
             continue
 
@@ -495,7 +503,7 @@ def _move_pass(conn: sqlite3.Connection, dry_run: bool = False) -> None:
         if not m:
             logger.error(
                 'Skipping %s — does not match snapshot filename format; '
-                'leaving in Downloads', source,
+                'leaving in staging dir', source,
             )
             _try_record_error(
                 conn, 'invalid_filename', source,
@@ -512,10 +520,10 @@ def _move_pass(conn: sqlite3.Connection, dry_run: bool = False) -> None:
         date_str = m.group(1)   # 'YYYY-MM-DD'
         _move_one(conn, source, filename, date_str, dry_run=dry_run)
 
-    # Auto-heal: clear invalid_filename rows for files in Downloads that
-    # the user has since renamed or removed.
+    # Auto-heal: clear invalid_filename rows for files in the staging dir
+    # that the user has since renamed or removed.
     _reconcile_dir_scoped_errors(
-        conn, 'invalid_filename', DOWNLOADS_SNAPSHOTS_DIR, current_invalid)
+        conn, 'invalid_filename', STAGING_SNAPSHOTS_DIR, current_invalid)
 
 
 def _move_one(
@@ -536,14 +544,14 @@ def _move_one(
         shutil.copy2(source, dest)
         # (c) Make the archived copy read-only.
         os.chmod(dest, 0o444)
-        # (d) Update DB rows that still record this file as living in Downloads.
+        # (d) Update DB rows that still record this file as living in staging.
         #     Rows already pointing to iCloud (from a prior partial run) are
         #     untouched by the WHERE clause — that's correct.
         for table in EVENTS_TABLES:
             conn.execute(
                 f"UPDATE {table} SET directory = ?"
                 f" WHERE filename = ? AND directory = ?",
-                (date_subdir, filename, DOWNLOADS_SNAPSHOTS_DIR),
+                (date_subdir, filename, STAGING_SNAPSHOTS_DIR),
             )
         # (e) Detect a "straggler": a file whose date maps to a directory
         #     whose snapshots row already says sealed=1.  We need to know
@@ -972,7 +980,7 @@ def main(dry_run: bool = False) -> None:
 def _parse_args(argv=None) -> argparse.Namespace:
     p = argparse.ArgumentParser(
         prog='snapshot_mover.py',
-        description='Move browser-snapshot files from the local Downloads dir '
+        description='Move browser-snapshot files from the local staging dir '
                     'to the iCloud-synced Documents archive.',
     )
     p.add_argument('--dry-run', action='store_true',
@@ -986,8 +994,8 @@ def _parse_args(argv=None) -> argparse.Namespace:
                    help=f'override the persistent-error notification threshold '
                         f'(default {MOVER_ERROR_THRESHOLD})')
     p.add_argument('--source', metavar='DIR',
-                   help=f'override the source (Downloads) directory '
-                        f'(default {DOWNLOADS_SNAPSHOTS_DIR})')
+                   help=f'override the source (staging) directory '
+                        f'(default {STAGING_SNAPSHOTS_DIR})')
     p.add_argument('--dest', metavar='DIR',
                    help=f'override the destination (iCloud) directory '
                         f'(default {ICLOUD_SNAPSHOTS_DIR})')
@@ -1009,12 +1017,12 @@ def _parse_args(argv=None) -> argparse.Namespace:
 
 def _apply_args(args: argparse.Namespace) -> None:
     """Apply parsed CLI args to module-level constants and the logger."""
-    global DOWNLOADS_SNAPSHOTS_DIR, ICLOUD_SNAPSHOTS_DIR, DB_FILE
+    global STAGING_SNAPSHOTS_DIR, ICLOUD_SNAPSHOTS_DIR, DB_FILE
     global MIN_AGE_SECONDS, MOVER_ERROR_THRESHOLD
     if args.verbose:
         logger.setLevel(logging.DEBUG)
     if args.source is not None:
-        DOWNLOADS_SNAPSHOTS_DIR = args.source
+        STAGING_SNAPSHOTS_DIR = args.source
     if args.dest is not None:
         ICLOUD_SNAPSHOTS_DIR = args.dest
     if args.db is not None:

--- a/browser-visit-logger/native-host/visits_rebuilder.py
+++ b/browser-visit-logger/native-host/visits_rebuilder.py
@@ -17,7 +17,7 @@ tool restores it from two side-channels that *are* still durable:
      once the directory has been sealed.  Phase 2 ("filesystem
      rehydration") repopulates the ``snapshots`` table and updates the
      ``directory`` column on event rows whose snapshot file has since
-     been moved out of Downloads.
+     been moved out of the staging dir.
 
 ``mover_errors`` is intentionally *not* recovered.  Filesystem-derived
 rows (orphan_file, invalid_filename, missing_directory,
@@ -308,13 +308,13 @@ def _apply_action(conn: sqlite3.Connection, action: dict, stats: ReplayStats) ->
 # ---------------------------------------------------------------------------
 
 def rehydrate_filesystem(
-    conn: sqlite3.Connection, icloud_dir: str, downloads_dir: str,
+    conn: sqlite3.Connection, icloud_dir: str, staging_dir: str,
 ) -> RehydrateStats:
     """Phase 2: walk the iCloud archive, repopulate snapshots, relocate events.
 
     Files matching the snapshot filename pattern have any matching event
     rows updated to point at the date subdirectory (only rows whose
-    ``directory`` column still says Downloads — already-relocated rows
+    ``directory`` column still says staging — already-relocated rows
     are left alone).  Orphan files are *not* deleted; the next
     snapshot_verifier pass will flag them.
     """
@@ -358,7 +358,7 @@ def rehydrate_filesystem(
                 cur = conn.execute(
                     f"UPDATE {table} SET directory = ? "
                     f"WHERE filename = ? AND directory = ?",
-                    (date_dir, fname, downloads_dir),
+                    (date_dir, fname, staging_dir),
                 )
                 relocated_here += cur.rowcount
             if relocated_here > 0:
@@ -392,7 +392,7 @@ def _truncate_rebuildable_tables(conn: sqlite3.Connection) -> None:
 
 def rebuild(
     conn: sqlite3.Connection, *,
-    log_dir: str, icloud_dir: str, downloads_dir: str,
+    log_dir: str, icloud_dir: str, staging_dir: str,
     do_log: bool = True, do_rehydrate: bool = True, truncate: bool = True,
 ) -> RebuildStats:
     stats = RebuildStats(truncated=truncate)
@@ -404,7 +404,7 @@ def rebuild(
     if do_log:
         stats.replay = replay_logs(conn, log_dir, icloud_dir)
     if do_rehydrate:
-        stats.rehydrate = rehydrate_filesystem(conn, icloud_dir, downloads_dir)
+        stats.rehydrate = rehydrate_filesystem(conn, icloud_dir, staging_dir)
     return stats
 
 
@@ -444,8 +444,8 @@ def _parse_args(argv=None):
     p.add_argument('--db', metavar='FILE', dest='db_path',
                    help=f'override the SQLite database path (default {host.DB_FILE})')
     p.add_argument('--source', metavar='DIR',
-                   help=f'override the Downloads snapshots root '
-                        f'(default {host.DOWNLOADS_SNAPSHOTS_DIR})')
+                   help=f'override the staging snapshots root '
+                        f'(default {host.STAGING_SNAPSHOTS_DIR})')
     p.add_argument('--dest', metavar='DIR',
                    help=f'override the iCloud snapshots root '
                         f'(default {snapshot_mover.ICLOUD_SNAPSHOTS_DIR})')
@@ -468,10 +468,10 @@ def cli(argv=None) -> int:
     )
     logger.setLevel(log_level)
 
-    log_dir       = args.log_dir  or host.LOG_DIR
-    db_path       = args.db_path  or host.DB_FILE
-    downloads_dir = args.source   or host.DOWNLOADS_SNAPSHOTS_DIR
-    icloud_dir    = args.dest     or snapshot_mover.ICLOUD_SNAPSHOTS_DIR
+    log_dir     = args.log_dir  or host.LOG_DIR
+    db_path     = args.db_path  or host.DB_FILE
+    staging_dir = args.source   or host.STAGING_SNAPSHOTS_DIR
+    icloud_dir  = args.dest     or snapshot_mover.ICLOUD_SNAPSHOTS_DIR
 
     do_log       = not args.rehydrate_only
     do_rehydrate = not args.log_only
@@ -479,11 +479,12 @@ def cli(argv=None) -> int:
     # Apply overrides to the imported modules so helpers downstream (e.g.
     # _ensure_events_table's directory DEFAULT, tag_visit's recorded
     # directory) use the same values the user passed on the CLI.
-    host.DOWNLOADS_SNAPSHOTS_DIR = downloads_dir
-    host.DB_FILE                 = db_path
-    host.LOG_DIR                 = log_dir
-    snapshot_mover.ICLOUD_SNAPSHOTS_DIR = icloud_dir
-    snapshot_mover.LOG_DIR              = log_dir
+    host.STAGING_SNAPSHOTS_DIR          = staging_dir
+    host.DB_FILE                        = db_path
+    host.LOG_DIR                        = log_dir
+    snapshot_mover.STAGING_SNAPSHOTS_DIR = staging_dir
+    snapshot_mover.ICLOUD_SNAPSHOTS_DIR  = icloud_dir
+    snapshot_mover.LOG_DIR               = log_dir
 
     if do_log and not os.path.isdir(log_dir):
         print(f'No log directory at {log_dir}', file=sys.stderr)
@@ -501,7 +502,7 @@ def cli(argv=None) -> int:
                 conn,
                 log_dir=log_dir,
                 icloud_dir=icloud_dir,
-                downloads_dir=downloads_dir,
+                staging_dir=staging_dir,
                 do_log=do_log, do_rehydrate=do_rehydrate,
                 truncate=args.truncate,
             )

--- a/browser-visit-logger/reset.py
+++ b/browser-visit-logger/reset.py
@@ -8,7 +8,11 @@ Files and directories managed:
   browser-visits-mover.log                 — snapshot mover process log   (BVL_MOVER_LOG)
   browser-visits-verifier.log              — snapshot verifier process log (BVL_VERIFIER_LOG)
   browser-visits.db                        — SQLite visit database        (BVL_DB_FILE)
-  ~/Downloads/browser-visit-snapshots/     — local snapshot staging dir
+  ~/Library/Application Support/browser-visit-logger/inbox/  — local staging dir
+                                              (snapshots host.py has relocated out
+                                              of ~/Downloads, awaiting the mover)
+  ~/Downloads/browser-visit-snapshots/     — Chrome's drop point (host.py
+                                              normally clears it on each invocation)
   ~/Documents/browser-visit-logger/        — iCloud-synced archive (snapshots and any
                                               other future data under this directory)
 
@@ -17,7 +21,7 @@ Usage:
     python reset.py --log           # reset only the per-day visit logs in BVL_LOG_DIR
     python reset.py --host-log      # reset only the host, mover, and verifier process logs
     python reset.py --db            # reset only the database
-    python reset.py --snapshots     # reset only the local Downloads snapshots dir
+    python reset.py --snapshots     # reset only the staging + Downloads snapshot dirs
     python reset.py --icloud        # reset only the iCloud archive directory
     python reset.py -f              # skip confirmation prompt
 
@@ -41,8 +45,11 @@ HOST_LOG     = os.environ.get('BVL_HOST_LOG',      os.path.join(HOME, 'browser-v
 MOVER_LOG    = os.environ.get('BVL_MOVER_LOG',     os.path.join(HOME, 'browser-visits-mover.log'))
 VERIFIER_LOG = os.environ.get('BVL_VERIFIER_LOG',  os.path.join(HOME, 'browser-visits-verifier.log'))
 DB_FILE      = os.environ.get('BVL_DB_FILE',       os.path.join(HOME, 'browser-visits.db'))
-SNAP_DIR   = os.environ.get('BVL_DOWNLOADS_SNAPSHOTS_DIR',
-                            os.path.join(HOME, 'Downloads', 'browser-visit-snapshots'))
+DOWNLOADS_DIR = os.environ.get('BVL_DOWNLOADS_SNAPSHOTS_DIR',
+                               os.path.join(HOME, 'Downloads', 'browser-visit-snapshots'))
+STAGING_DIR   = os.environ.get('BVL_STAGING_SNAPSHOTS_DIR',
+                               os.path.join(HOME, 'Library', 'Application Support',
+                                            'browser-visit-logger', 'inbox'))
 
 # Per-day visit logs follow `browser-visits-YYYY-MM-DD.log`.  Strict regex so
 # we don't accidentally match the host/mover/verifier process logs (which
@@ -86,7 +93,7 @@ def main() -> None:
     parser.add_argument('--host-log',  action='store_true', help='reset only the host, mover, and verifier process logs')
     parser.add_argument('--db',        action='store_true', help='reset only the database')
     parser.add_argument('--snapshots', action='store_true',
-                        help='reset only the local Downloads snapshots directory')
+                        help='reset only the local staging + Downloads snapshot directories')
     parser.add_argument('--icloud',    action='store_true',
                         help='reset only the iCloud archive directory')
     parser.add_argument('-f', '--force', action='store_true', help='skip confirmation prompt')
@@ -119,7 +126,8 @@ def main() -> None:
     if do_db:
         targets.append((DB_FILE,    'database',                        'file'))
     if do_snapshots:
-        targets.append((SNAP_DIR,   'Downloads snapshots directory',   'dir'))
+        targets.append((STAGING_DIR,   'staging snapshots directory',     'dir'))
+        targets.append((DOWNLOADS_DIR, 'Downloads snapshots directory',   'dir'))
     if do_icloud:
         targets.append((ICLOUD_DIR, 'iCloud archive directory',        'dir'))
 

--- a/browser-visit-logger/tests/test_host.py
+++ b/browser-visit-logger/tests/test_host.py
@@ -330,9 +330,9 @@ class TestDatabase(unittest.TestCase):
         self.assertIn('directory', self._event_cols(conn, 'skimmed_events'))
         conn.close()
 
-    def test_directory_column_defaults_to_downloads_dir(self):
+    def test_directory_column_defaults_to_staging_dir(self):
         # An ad-hoc INSERT (without specifying directory) should pick up the
-        # column's DEFAULT, which embeds DOWNLOADS_SNAPSHOTS_DIR at table
+        # column's DEFAULT, which embeds STAGING_SNAPSHOTS_DIR at table
         # creation time.
         conn = self._conn()
         host.insert_visit(conn, 'ts', 'https://example.com', 'Example')
@@ -345,7 +345,7 @@ class TestDatabase(unittest.TestCase):
             "SELECT directory FROM read_events WHERE url = ?", ('https://example.com',)
         ).fetchone()[0]
         conn.close()
-        self.assertEqual(directory, host.DOWNLOADS_SNAPSHOTS_DIR)
+        self.assertEqual(directory, host.STAGING_SNAPSHOTS_DIR)
 
     def test_ensure_db_creates_timestamp_index(self):
         conn = self._conn()
@@ -499,7 +499,7 @@ class TestTagVisit(unittest.TestCase):
             "SELECT directory FROM read_events WHERE url = ?", ('https://example.com',)
         ).fetchone()[0]
         conn.close()
-        self.assertEqual(directory, host.DOWNLOADS_SNAPSHOTS_DIR)
+        self.assertEqual(directory, host.STAGING_SNAPSHOTS_DIR)
 
     def test_tag_visit_read_increments_visits_read_counter(self):
         conn = self._conn()
@@ -586,7 +586,7 @@ class TestTagVisit(unittest.TestCase):
             "SELECT directory FROM skimmed_events WHERE url = ?", ('https://example.com',)
         ).fetchone()[0]
         conn.close()
-        self.assertEqual(directory, host.DOWNLOADS_SNAPSHOTS_DIR)
+        self.assertEqual(directory, host.STAGING_SNAPSHOTS_DIR)
 
     def test_tag_visit_skimmed_increments_visits_skimmed_counter(self):
         conn = self._conn()
@@ -739,7 +739,7 @@ class TestQueryVisit(unittest.TestCase):
         self.assertEqual(result['read'], [
             {'timestamp': 'ts-read',
              'filename': 'abc.mhtml',
-             'directory': host.DOWNLOADS_SNAPSHOTS_DIR},
+             'directory': host.STAGING_SNAPSHOTS_DIR},
         ])
         self.assertEqual(result['skimmed'], [])       # not skimmed — empty list
 
@@ -754,9 +754,9 @@ class TestQueryVisit(unittest.TestCase):
         conn.close()
         self.assertEqual(result['read'], [
             {'timestamp': '2026-01-01T10:00:00Z', 'filename': 'f1.mhtml',
-             'directory': host.DOWNLOADS_SNAPSHOTS_DIR},
+             'directory': host.STAGING_SNAPSHOTS_DIR},
             {'timestamp': '2026-01-02T10:00:00Z', 'filename': 'f2.mhtml',
-             'directory': host.DOWNLOADS_SNAPSHOTS_DIR},
+             'directory': host.STAGING_SNAPSHOTS_DIR},
         ])
 
     def test_query_visit_returns_all_skimmed_events_in_order(self):
@@ -770,9 +770,9 @@ class TestQueryVisit(unittest.TestCase):
         conn.close()
         self.assertEqual(result['skimmed'], [
             {'timestamp': '2026-01-01T10:00:00Z', 'filename': 's1.mhtml',
-             'directory': host.DOWNLOADS_SNAPSHOTS_DIR},
+             'directory': host.STAGING_SNAPSHOTS_DIR},
             {'timestamp': '2026-01-02T10:00:00Z', 'filename': 's2.mhtml',
-             'directory': host.DOWNLOADS_SNAPSHOTS_DIR},
+             'directory': host.STAGING_SNAPSHOTS_DIR},
         ])
 
     def test_query_visit_includes_basename_filename_in_read_events(self):
@@ -800,7 +800,7 @@ class TestQueryVisit(unittest.TestCase):
                        filename='browser-visit-snapshots/myfile.mhtml')
         result = host.query_visit(conn, 'https://example.com')
         conn.close()
-        self.assertEqual(result['read'][0]['directory'], host.DOWNLOADS_SNAPSHOTS_DIR)
+        self.assertEqual(result['read'][0]['directory'], host.STAGING_SNAPSHOTS_DIR)
 
     def test_query_visit_includes_directory_in_skimmed_events(self):
         conn = self._conn()
@@ -809,7 +809,7 @@ class TestQueryVisit(unittest.TestCase):
                        filename='browser-visit-snapshots/myfile.pdf')
         result = host.query_visit(conn, 'https://example.com')
         conn.close()
-        self.assertEqual(result['skimmed'][0]['directory'], host.DOWNLOADS_SNAPSHOTS_DIR)
+        self.assertEqual(result['skimmed'][0]['directory'], host.STAGING_SNAPSHOTS_DIR)
 
     def test_does_not_return_record_for_different_url(self):
         conn = self._conn()
@@ -1139,6 +1139,258 @@ class TestMain(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Downloads-to-staging sweep — verifies host.py escapes the TCC-protected
+# Downloads folder by relocating snapshots into a non-protected staging
+# dir before any DB / log writes, on every write invocation.
+# ---------------------------------------------------------------------------
+
+class TestSweepDownloadsToStaging(unittest.TestCase):
+    """Direct unit tests on _sweep_downloads_to_staging."""
+
+    def _patch_dirs(self, downloads, staging):
+        """Patch host's module-level path constants for one test."""
+        return (
+            patch.object(host, 'DOWNLOADS_SNAPSHOTS_DIR', downloads),
+            patch.object(host, 'STAGING_SNAPSHOTS_DIR',   staging),
+        )
+
+    def test_moves_file_from_downloads_to_staging(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            downloads = os.path.join(tmp, 'downloads')
+            staging   = os.path.join(tmp, 'staging')
+            os.makedirs(downloads)
+            src = os.path.join(downloads, 'abc.mhtml')
+            Path(src).write_text('hello')
+            with contextlib.ExitStack() as stack:
+                for p in self._patch_dirs(downloads, staging):
+                    stack.enter_context(p)
+                host._sweep_downloads_to_staging()
+            self.assertFalse(os.path.exists(src))
+            self.assertTrue(os.path.exists(os.path.join(staging, 'abc.mhtml')))
+            self.assertEqual(
+                Path(staging, 'abc.mhtml').read_text(), 'hello')
+
+    def test_creates_staging_dir_if_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            downloads = os.path.join(tmp, 'downloads')
+            staging   = os.path.join(tmp, 'staging')   # NOT created
+            os.makedirs(downloads)
+            Path(downloads, 'abc.mhtml').write_text('x')
+            with contextlib.ExitStack() as stack:
+                for p in self._patch_dirs(downloads, staging):
+                    stack.enter_context(p)
+                host._sweep_downloads_to_staging()
+            self.assertTrue(os.path.isdir(staging))
+
+    def test_noop_when_downloads_dir_absent(self):
+        # The most common case: Chrome hasn't downloaded anything yet, so
+        # ~/Downloads/browser-visit-snapshots/ doesn't even exist.
+        with tempfile.TemporaryDirectory() as tmp:
+            downloads = os.path.join(tmp, 'never-created')
+            staging   = os.path.join(tmp, 'staging')
+            with contextlib.ExitStack() as stack:
+                for p in self._patch_dirs(downloads, staging):
+                    stack.enter_context(p)
+                host._sweep_downloads_to_staging()
+            # Function must return without raising.  The staging dir is
+            # not pre-created in this branch (no work to do).
+            self.assertFalse(os.path.isdir(staging))
+
+    def test_overwrites_same_name_in_staging(self):
+        # Idempotent overwrite: a file already in staging with the same
+        # name (e.g. from a partial earlier sweep) is replaced — os.replace
+        # semantics, exercised explicitly here so a future regression
+        # to e.g. shutil.move (which would error) gets caught.
+        with tempfile.TemporaryDirectory() as tmp:
+            downloads = os.path.join(tmp, 'downloads')
+            staging   = os.path.join(tmp, 'staging')
+            os.makedirs(downloads)
+            os.makedirs(staging)
+            Path(downloads, 'abc.mhtml').write_text('new')
+            Path(staging,   'abc.mhtml').write_text('old')
+            with contextlib.ExitStack() as stack:
+                for p in self._patch_dirs(downloads, staging):
+                    stack.enter_context(p)
+                host._sweep_downloads_to_staging()
+            self.assertEqual(
+                Path(staging, 'abc.mhtml').read_text(), 'new')
+            self.assertFalse(os.path.exists(os.path.join(downloads, 'abc.mhtml')))
+
+    def test_skips_subdirectory_entries(self):
+        # os.replace on a directory would raise; the sweep uses
+        # os.path.isfile to filter.  Pin the contract.
+        with tempfile.TemporaryDirectory() as tmp:
+            downloads = os.path.join(tmp, 'downloads')
+            staging   = os.path.join(tmp, 'staging')
+            os.makedirs(os.path.join(downloads, 'a-subdir'))
+            Path(downloads, 'abc.mhtml').write_text('x')
+            with contextlib.ExitStack() as stack:
+                for p in self._patch_dirs(downloads, staging):
+                    stack.enter_context(p)
+                host._sweep_downloads_to_staging()
+            # The regular file moved; the subdirectory was left alone.
+            self.assertTrue(os.path.isdir(os.path.join(downloads, 'a-subdir')))
+            self.assertTrue(os.path.exists(os.path.join(staging, 'abc.mhtml')))
+
+    def test_sweeps_unfiltered_filenames(self):
+        # The sweep does not filter by snapshot filename pattern — its
+        # job is to clear Downloads.  Non-conforming files become orphans
+        # in staging, which the mover surfaces via invalid_filename
+        # errors.  This pins the unfiltered contract.
+        with tempfile.TemporaryDirectory() as tmp:
+            downloads = os.path.join(tmp, 'downloads')
+            staging   = os.path.join(tmp, 'staging')
+            os.makedirs(downloads)
+            Path(downloads, 'random-notes.txt').write_text('x')
+            with contextlib.ExitStack() as stack:
+                for p in self._patch_dirs(downloads, staging):
+                    stack.enter_context(p)
+                host._sweep_downloads_to_staging()
+            self.assertTrue(os.path.exists(os.path.join(staging, 'random-notes.txt')))
+
+    def test_listdir_failure_is_caught_and_logged(self):
+        # If listdir raises (TCC denial, transient I/O error) the sweep
+        # logs and returns without propagating — every host.py invocation
+        # would otherwise abort before the DB write.
+        with tempfile.TemporaryDirectory() as tmp:
+            downloads = os.path.join(tmp, 'downloads')
+            staging   = os.path.join(tmp, 'staging')
+            os.makedirs(downloads)
+            with contextlib.ExitStack() as stack:
+                for p in self._patch_dirs(downloads, staging):
+                    stack.enter_context(p)
+                stack.enter_context(patch('os.listdir',
+                                          side_effect=OSError('permission denied')))
+                cm = stack.enter_context(
+                    self.assertLogs(host.logger, level='ERROR'))
+                host._sweep_downloads_to_staging()   # must not raise
+            self.assertTrue(any('could not list' in m for m in cm.output))
+
+    def test_per_file_failure_does_not_abort_whole_sweep(self):
+        # If os.replace fails on one file the rest still get a chance.
+        with tempfile.TemporaryDirectory() as tmp:
+            downloads = os.path.join(tmp, 'downloads')
+            staging   = os.path.join(tmp, 'staging')
+            os.makedirs(downloads)
+            Path(downloads, 'a.mhtml').write_text('x')
+            Path(downloads, 'b.mhtml').write_text('y')
+
+            real_replace = os.replace
+            def flaky_replace(src, dst):
+                if src.endswith('a.mhtml'):
+                    raise OSError('boom')
+                return real_replace(src, dst)
+
+            with contextlib.ExitStack() as stack:
+                for p in self._patch_dirs(downloads, staging):
+                    stack.enter_context(p)
+                stack.enter_context(patch('os.replace', side_effect=flaky_replace))
+                host._sweep_downloads_to_staging()
+            # b moved despite a's failure
+            self.assertTrue(os.path.exists(os.path.join(staging, 'b.mhtml')))
+
+
+class TestMainCallsSweep(unittest.TestCase):
+    """Verify host.main() actually invokes the sweep — both that tag
+    invocations move files and that query invocations don't."""
+
+    def _call_main_with_dirs(self, message, tmp, downloads, staging):
+        out_buf = io.BytesIO()
+        mock_stdout = MagicMock(); mock_stdout.buffer = out_buf
+        mock_stdin  = MagicMock(); mock_stdin.buffer  = io.BytesIO(_frame(message))
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(patch('sys.stdin',  mock_stdin))
+            stack.enter_context(patch('sys.stdout', mock_stdout))
+            stack.enter_context(patch.object(host, 'LOG_DIR', tmp))
+            stack.enter_context(patch.object(host, 'DB_FILE',
+                                             os.path.join(tmp, 'visits.db')))
+            stack.enter_context(patch.object(host, 'DOWNLOADS_SNAPSHOTS_DIR', downloads))
+            stack.enter_context(patch.object(host, 'STAGING_SNAPSHOTS_DIR',   staging))
+            host.main()
+        out_buf.seek(0)
+        return _unframe(out_buf.read())
+
+    def test_tag_invocation_relocates_pending_download(self):
+        # End-to-end wiring: a snapshot that Chrome has just dropped in
+        # Downloads must be in staging by the time main() returns.
+        with tempfile.TemporaryDirectory() as tmp:
+            downloads = os.path.join(tmp, 'downloads')
+            staging   = os.path.join(tmp, 'staging')
+            os.makedirs(downloads)
+            Path(downloads, 'abc.mhtml').write_text('snapshot')
+            resp = self._call_main_with_dirs(
+                {'timestamp': 'ts', 'url': 'https://example.com',
+                 'title': 'Example', 'tag': 'read',
+                 'filename': 'browser-visit-snapshots/abc.mhtml'},
+                tmp, downloads, staging,
+            )
+            self.assertEqual(resp['status'], 'ok')
+            self.assertFalse(os.path.exists(os.path.join(downloads, 'abc.mhtml')))
+            self.assertTrue(os.path.exists(os.path.join(staging, 'abc.mhtml')))
+
+    def test_query_invocation_does_not_sweep(self):
+        # The query path is read-only and must not move anything.  A
+        # background sweep on every query would race against an in-flight
+        # download whose native message hasn't arrived yet.
+        with tempfile.TemporaryDirectory() as tmp:
+            downloads = os.path.join(tmp, 'downloads')
+            staging   = os.path.join(tmp, 'staging')
+            os.makedirs(downloads)
+            Path(downloads, 'pending.mhtml').write_text('pending')
+            resp = self._call_main_with_dirs(
+                {'action': 'query', 'url': 'https://example.com'},
+                tmp, downloads, staging,
+            )
+            self.assertEqual(resp['status'], 'ok')
+            self.assertTrue(os.path.exists(os.path.join(downloads, 'pending.mhtml')))
+            self.assertFalse(os.path.exists(os.path.join(staging, 'pending.mhtml')))
+
+    def test_orphaned_download_recovered_on_next_invocation(self):
+        # Motivating scenario: a prior host.py crash left a snapshot
+        # stranded in Downloads.  The next write invocation — even for
+        # an unrelated URL — sweeps it to staging where the launchd
+        # mover can reach it.
+        with tempfile.TemporaryDirectory() as tmp:
+            downloads = os.path.join(tmp, 'downloads')
+            staging   = os.path.join(tmp, 'staging')
+            os.makedirs(downloads)
+            Path(downloads, 'orphan-from-prior-crash.mhtml').write_text('x')
+            resp = self._call_main_with_dirs(
+                {'timestamp': 'ts', 'url': 'https://other.com',
+                 'title': 'Unrelated visit'},
+                tmp, downloads, staging,
+            )
+            self.assertEqual(resp['status'], 'ok')
+            self.assertTrue(os.path.exists(
+                os.path.join(staging, 'orphan-from-prior-crash.mhtml')))
+
+    def test_sweep_failure_does_not_abort_main(self):
+        # If the sweep can't operate (e.g. the staging path is a file
+        # rather than a dir, so os.makedirs fails) the rest of main() —
+        # DB write, log write, response — must still complete.  The
+        # sweep's internal best-effort handling is what enforces this;
+        # this test pins it end-to-end.
+        with tempfile.TemporaryDirectory() as tmp:
+            downloads = os.path.join(tmp, 'downloads')
+            staging   = os.path.join(tmp, 'staging')   # created as a *file*
+            os.makedirs(downloads)
+            Path(downloads, 'abc.mhtml').write_text('snapshot')
+            Path(staging).write_text('not a directory')
+
+            resp = self._call_main_with_dirs(
+                {'timestamp': 'ts', 'url': 'https://example.com',
+                 'title': 'Example'},
+                tmp, downloads, staging,
+            )
+            self.assertEqual(resp['status'], 'ok')
+            # DB write succeeded despite the broken staging path.
+            conn = sqlite3.connect(os.path.join(tmp, 'visits.db'))
+            n = conn.execute("SELECT COUNT(*) FROM visits").fetchone()[0]
+            conn.close()
+        self.assertEqual(n, 1)
+
+
+# ---------------------------------------------------------------------------
 # Integration: run host.py as a subprocess (mirrors Chrome's usage)
 # ---------------------------------------------------------------------------
 
@@ -1150,6 +1402,10 @@ class TestIntegration(unittest.TestCase):
         env['BVL_LOG_DIR']  = tmp
         env['BVL_DB_FILE']  = os.path.join(tmp, 'visits.db')
         env['BVL_HOST_LOG'] = os.path.join(tmp, 'host.log')
+        # Isolate the snapshot dirs so the sweep doesn't touch the user's
+        # real ~/Downloads/browser-visit-snapshots or staging dir.
+        env['BVL_DOWNLOADS_SNAPSHOTS_DIR'] = os.path.join(tmp, 'downloads')
+        env['BVL_STAGING_SNAPSHOTS_DIR']   = os.path.join(tmp, 'staging')
 
         result = subprocess.run(
             [sys.executable, HOST_PY],
@@ -1607,8 +1863,9 @@ class TestIntegration(unittest.TestCase):
                 'SELECT filename, directory FROM read_events WHERE url = ?', (url,)
             ).fetchone()
             conn.close()
+            staging_dir = os.path.join(tmp, 'staging')
         self.assertEqual(row[0], 'abc.mhtml')
-        self.assertEqual(row[1], host.DOWNLOADS_SNAPSHOTS_DIR)
+        self.assertEqual(row[1], staging_dir)
 
     def test_tag_message_stores_basename_filename_in_skimmed_events(self):
         url = 'https://example.com'
@@ -1623,8 +1880,9 @@ class TestIntegration(unittest.TestCase):
                 'SELECT filename, directory FROM skimmed_events WHERE url = ?', (url,)
             ).fetchone()
             conn.close()
+            staging_dir = os.path.join(tmp, 'staging')
         self.assertEqual(row[0], 'def.pdf')
-        self.assertEqual(row[1], host.DOWNLOADS_SNAPSHOTS_DIR)
+        self.assertEqual(row[1], staging_dir)
 
     def test_query_returns_filename_and_directory_in_read_event(self):
         url = 'https://example.com'
@@ -1635,9 +1893,10 @@ class TestIntegration(unittest.TestCase):
                 {'timestamp': 'ts-read', 'url': url, 'title': 'Example',
                  'tag': 'read', 'filename': 'browser-visit-snapshots/snap.mhtml'}, tmp)
             resp = self._invoke({'action': 'query', 'url': url}, tmp)
+            staging_dir = os.path.join(tmp, 'staging')
         self.assertEqual(resp['record']['read'], [
             {'timestamp': 'ts-read', 'filename': 'snap.mhtml',
-             'directory': host.DOWNLOADS_SNAPSHOTS_DIR},
+             'directory': staging_dir},
         ])
 
     def test_query_does_not_write_log(self):

--- a/browser-visit-logger/tests/test_shell_wrappers.py
+++ b/browser-visit-logger/tests/test_shell_wrappers.py
@@ -161,7 +161,7 @@ class TestWrapperForwarding(unittest.TestCase):
             env['BVL_HOST_LOG']  = os.path.join(tmp, 'host.log')
             env['BVL_MOVER_LOG'] = os.path.join(tmp, 'mover.log')
             env['BVL_DB_FILE']   = os.path.join(tmp, 'visits.db')
-            env['BVL_DOWNLOADS_SNAPSHOTS_DIR'] = os.path.join(tmp, 'dl')
+            env['BVL_STAGING_SNAPSHOTS_DIR'] = os.path.join(tmp, 'staging')
             # Drop a per-day log so --log has something to delete.
             Path(tmp, 'browser-visits-2026-01-15.log').touch()
             result = subprocess.run(

--- a/browser-visit-logger/tests/test_snapshot_mover.py
+++ b/browser-visit-logger/tests/test_snapshot_mover.py
@@ -5,7 +5,7 @@ Each test sets up an isolated triplet of (source_dir, dest_dir, db_file)
 under a temporary directory, then patches both `host` and `snapshot_mover`
 module-level constants to point at it.
 
-The mover scans the Downloads filesystem rather than querying the DB, so
+The mover scans the staging directory rather than querying the DB, so
 tests create source files with the permanent datetime-prefixed filename that
 host.py would have assigned at record time.
 
@@ -57,7 +57,7 @@ class _MoverTestBase(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         self.addCleanup(self.tmp.cleanup)
 
-        self.source_dir = os.path.join(self.tmp.name, 'downloads')
+        self.source_dir = os.path.join(self.tmp.name, 'staging')
         self.dest_dir   = os.path.join(self.tmp.name, 'icloud')
         self.log_dir    = os.path.join(self.tmp.name, 'logs')
         self.db_file    = os.path.join(self.tmp.name, 'visits.db')
@@ -66,11 +66,11 @@ class _MoverTestBase(unittest.TestCase):
         # dest_dir intentionally NOT created — main() should create the root
 
         for module, attrs in (
-            (host,            {'DOWNLOADS_SNAPSHOTS_DIR': self.source_dir,
+            (host,            {'STAGING_SNAPSHOTS_DIR': self.source_dir,
                                'ICLOUD_SNAPSHOTS_DIR':    self.dest_dir,
                                'LOG_DIR':                 self.log_dir,
                                'DB_FILE':                 self.db_file}),
-            (snapshot_mover,  {'DOWNLOADS_SNAPSHOTS_DIR': self.source_dir,
+            (snapshot_mover,  {'STAGING_SNAPSHOTS_DIR': self.source_dir,
                                'ICLOUD_SNAPSHOTS_DIR':    self.dest_dir,
                                'LOG_DIR':                 self.log_dir,
                                'DB_FILE':                 self.db_file}),
@@ -231,8 +231,8 @@ class TestMovePass(_MoverTestBase):
         self.assertTrue(os.path.exists(os.path.join(ds3, pf3)))
 
     def test_moves_file_even_without_db_row(self):
-        # A file in Downloads with no corresponding DB row (e.g., the host.py
-        # message was lost) should still be moved to clean up Downloads.
+        # A file in the staging dir with no corresponding DB row (e.g., the
+        # host.py message was lost) should still be moved to clean up staging.
         prefixed = _snap(ISO_TS1, 'no-db-row.mhtml')
         src = os.path.join(self.source_dir, prefixed)
         Path(src).write_bytes(b'data')
@@ -311,8 +311,8 @@ class TestMovePass(_MoverTestBase):
         conn.commit()
         conn.close()
 
-        # A straggler shows up in Downloads with a date prefix matching the
-        # already-sealed day.
+        # A straggler shows up in the staging dir with a date prefix matching
+        # the already-sealed day.
         self._make_event('read_events', 'https://new.com', ISO_TS1, 'new.mhtml',
                          age_seconds=700)
 
@@ -420,7 +420,7 @@ class TestIdempotency(_MoverTestBase):
                          age_seconds=700)
         date_subdir, _ = self._dest_info(prefixed)
         snapshot_mover.main()
-        snapshot_mover.main()   # source gone — nothing left in Downloads
+        snapshot_mover.main()   # source gone — nothing left in staging
         self.assertTrue(os.path.exists(os.path.join(date_subdir, prefixed)))
         self.assertFalse(os.path.exists(os.path.join(self.source_dir, prefixed)))
         self.assertEqual(self._row('read_events', 'https://a.com'),
@@ -428,7 +428,7 @@ class TestIdempotency(_MoverTestBase):
 
     def test_retry_cleans_up_source_when_db_already_says_icloud(self):
         # Simulate: prior run did copy + DB update but crashed before unlinking.
-        # Source still in Downloads; DB already says iCloud.
+        # Source still in staging; DB already says iCloud.
         prefixed = _snap(ISO_TS1, 'a.mhtml')
         self._make_event('read_events', 'https://a.com', ISO_TS1, 'a.mhtml',
                          age_seconds=700)
@@ -449,7 +449,7 @@ class TestIdempotency(_MoverTestBase):
                          (prefixed, date_subdir))
 
     def test_retry_recovers_from_crash_between_copy_and_db_update(self):
-        # Source exists, dest already exists (from prior copy), DB still says Downloads.
+        # Source exists, dest already exists (from prior copy), DB still says staging.
         # Next run should overwrite the dest (safe, same data), update DB, unlink source.
         prefixed = _snap(ISO_TS1, 'a.mhtml')
         self._make_event('read_events', 'https://a.com', ISO_TS1, 'a.mhtml',
@@ -472,7 +472,7 @@ class TestIdempotency(_MoverTestBase):
 
     def test_skips_file_with_unrecognized_name_format(self):
         # Files whose names don't match the snapshot format are left in
-        # Downloads (not moved), ERROR-logged, and recorded as an
+        # the staging dir (not moved), ERROR-logged, and recorded as an
         # 'invalid_filename' mover_errors row so the user is notified.
         stray = os.path.join(self.source_dir, 'random-file.mhtml')
         Path(stray).write_bytes(b'x')
@@ -496,7 +496,7 @@ class TestIdempotency(_MoverTestBase):
 
     def test_move_pass_clears_invalid_filename_error_when_stray_removed(self):
         # Pre-seed an invalid_filename row for a path that no longer exists
-        # in Downloads.  The move-pass reconcile should clear it.
+        # in the staging dir.  The move-pass reconcile should clear it.
         gone = os.path.join(self.source_dir, 'never-existed.mhtml')
         conn = sqlite3.connect(self.db_file)
         snapshot_mover._record_error(
@@ -514,7 +514,7 @@ class TestIdempotency(_MoverTestBase):
         conn.close()
         self.assertEqual(count, 0)
 
-    def test_skips_subdirectory_entries_in_downloads(self):
+    def test_skips_subdirectory_entries_in_staging(self):
         os.makedirs(os.path.join(self.source_dir, 'subdir'))
         snapshot_mover.main()
         self.assertEqual(os.listdir(self.dest_dir), [])
@@ -543,12 +543,12 @@ class TestEdgeCases(_MoverTestBase):
         snapshot_mover.main()   # should not raise
         self.assertTrue(os.path.isdir(self.dest_dir))
 
-    def test_downloads_dir_absent_is_a_noop(self):
+    def test_staging_dir_absent_is_a_noop(self):
         os.rmdir(self.source_dir)   # empty, safe to remove
         snapshot_mover.main()       # should not raise
         self.assertTrue(os.path.isdir(self.dest_dir))
 
-    def test_copy_failure_leaves_source_in_downloads(self):
+    def test_copy_failure_leaves_source_in_staging(self):
         prefixed = _snap(ISO_TS1, 'a.mhtml')
         self._make_event('read_events', 'https://a.com', ISO_TS1, 'a.mhtml',
                          age_seconds=700)
@@ -1359,7 +1359,7 @@ class TestErrorRecording(unittest.TestCase):
 
     def test_is_immediate_invalid_filename(self):
         # Same single-shot reasoning for the date-subdir case (which is
-        # what classification has to cover for both Downloads and date-dir
+        # what classification has to cover for both staging and date-dir
         # variants of this op).
         self.assertTrue(snapshot_mover._is_immediate(
             'invalid_filename', ValueError('synthetic')))
@@ -1846,8 +1846,8 @@ class TestErrorWiring(_MoverTestBase):
         self.assertTrue(any(op == 'rewrite_manifest' and target == date_subdir
                             for op, target in rows))
 
-    def test_invalid_filename_in_downloads_notifies_on_first_occurrence(self):
-        # Stray non-snapshot file in Downloads.  After one main() run, the
+    def test_invalid_filename_in_staging_notifies_on_first_occurrence(self):
+        # Stray non-snapshot file in the staging dir.  After one main() run, the
         # row should be marked notified=1 (escalated immediately because
         # 'invalid_filename' is now classified as immediate).
         stray = os.path.join(self.source_dir, 'random.bin')
@@ -1943,7 +1943,7 @@ class TestCli(unittest.TestCase):
     def setUp(self):
         self._saved = {
             name: getattr(snapshot_mover, name)
-            for name in ('DOWNLOADS_SNAPSHOTS_DIR', 'ICLOUD_SNAPSHOTS_DIR',
+            for name in ('STAGING_SNAPSHOTS_DIR', 'ICLOUD_SNAPSHOTS_DIR',
                          'DB_FILE', 'MIN_AGE_SECONDS', 'MOVER_ERROR_THRESHOLD')
         }
         self._saved_level = snapshot_mover.logger.level
@@ -1988,7 +1988,7 @@ class TestCli(unittest.TestCase):
             '--error-threshold', '7',
         ])
         snapshot_mover._apply_args(ns)
-        self.assertEqual(snapshot_mover.DOWNLOADS_SNAPSHOTS_DIR, '/tmp/src')
+        self.assertEqual(snapshot_mover.STAGING_SNAPSHOTS_DIR, '/tmp/src')
         self.assertEqual(snapshot_mover.ICLOUD_SNAPSHOTS_DIR,    '/tmp/dst')
         self.assertEqual(snapshot_mover.DB_FILE,                 '/tmp/test.db')
         self.assertEqual(snapshot_mover.MIN_AGE_SECONDS,         5)
@@ -2021,7 +2021,7 @@ class TestCli(unittest.TestCase):
             db_file    = os.path.join(tmp, 'visits.db')
             os.makedirs(source_dir)
 
-            with patch.object(host, 'DOWNLOADS_SNAPSHOTS_DIR', source_dir), \
+            with patch.object(host, 'STAGING_SNAPSHOTS_DIR', source_dir), \
                  patch.object(host, 'ICLOUD_SNAPSHOTS_DIR',    dest_dir):
                 conn = sqlite3.connect(db_file)
                 host.ensure_db(conn)
@@ -2138,10 +2138,10 @@ class TestErrorCli(unittest.TestCase):
 
     def test_show_errors_skips_move_and_seal_pass(self):
         # Even with sources present that would normally be moved, --show-errors
-        # must not run the move pass.  Use a temp Downloads dir with one file
+        # must not run the move pass.  Use a temp staging dir with one file
         # and a non-existent dest to make any move attempt visible.
         snapshot_mover.DB_FILE = self.db_file
-        src = os.path.join(self.tmp.name, 'downloads')
+        src = os.path.join(self.tmp.name, 'staging')
         os.makedirs(src)
         Path(src, '2024-01-15T10-00-00Z-x.mhtml').write_bytes(b'data')
         captured = io.StringIO()

--- a/browser-visit-logger/tests/test_visits_rebuilder.py
+++ b/browser-visit-logger/tests/test_visits_rebuilder.py
@@ -619,7 +619,7 @@ class TestRehydrateFilesystem(unittest.TestCase):
             conn = sqlite3.connect(db)
             try:
                 stats = vr.rehydrate_filesystem(
-                    conn, icloud, host.DOWNLOADS_SNAPSHOTS_DIR)
+                    conn, icloud, host.STAGING_SNAPSHOTS_DIR)
                 rows = dict(conn.execute(
                     'SELECT date, sealed FROM snapshots ORDER BY date'
                 ).fetchall())
@@ -644,7 +644,7 @@ class TestRehydrateFilesystem(unittest.TestCase):
                            filename=good_unsealed)
             try:
                 stats = vr.rehydrate_filesystem(
-                    conn, icloud, host.DOWNLOADS_SNAPSHOTS_DIR)
+                    conn, icloud, host.STAGING_SNAPSHOTS_DIR)
                 read_dir = conn.execute(
                     'SELECT directory FROM read_events WHERE url = ?',
                     ('https://a.com',)
@@ -678,7 +678,7 @@ class TestRehydrateFilesystem(unittest.TestCase):
             conn.commit()
             try:
                 vr.rehydrate_filesystem(
-                    conn, icloud, host.DOWNLOADS_SNAPSHOTS_DIR)
+                    conn, icloud, host.STAGING_SNAPSHOTS_DIR)
                 row = conn.execute(
                     'SELECT directory FROM read_events WHERE url = ?',
                     ('https://a.com',)
@@ -701,7 +701,7 @@ class TestRehydrateFilesystem(unittest.TestCase):
             conn = sqlite3.connect(db)
             try:
                 stats = vr.rehydrate_filesystem(
-                    conn, icloud, host.DOWNLOADS_SNAPSHOTS_DIR)
+                    conn, icloud, host.STAGING_SNAPSHOTS_DIR)
                 rows = conn.execute(
                     'SELECT date FROM snapshots ORDER BY date'
                 ).fetchall()
@@ -717,7 +717,7 @@ class TestRehydrateFilesystem(unittest.TestCase):
             try:
                 stats = vr.rehydrate_filesystem(
                     conn, os.path.join(tmp, 'no-such-icloud'),
-                    host.DOWNLOADS_SNAPSHOTS_DIR)
+                    host.STAGING_SNAPSHOTS_DIR)
                 n = conn.execute('SELECT COUNT(*) FROM snapshots').fetchone()[0]
             finally:
                 conn.close()
@@ -741,7 +741,7 @@ class TestRehydrateFilesystem(unittest.TestCase):
             conn = sqlite3.connect(db)
             try:
                 stats = vr.rehydrate_filesystem(
-                    conn, icloud, host.DOWNLOADS_SNAPSHOTS_DIR)
+                    conn, icloud, host.STAGING_SNAPSHOTS_DIR)
             finally:
                 conn.close()
         # Log file is not counted as a file_without_events.
@@ -791,7 +791,7 @@ class _CLIBase(unittest.TestCase):
         # cli() mutates host.* and snapshot_mover.* globals; restore them so
         # one test doesn't pollute the next.
         saved = (
-            host.DOWNLOADS_SNAPSHOTS_DIR, host.DB_FILE, host.LOG_DIR,
+            host.STAGING_SNAPSHOTS_DIR, host.DB_FILE, host.LOG_DIR,
             snapshot_mover.ICLOUD_SNAPSHOTS_DIR, snapshot_mover.LOG_DIR,
         )
         buf = io.StringIO()
@@ -799,7 +799,7 @@ class _CLIBase(unittest.TestCase):
             with redirect_stdout(buf):
                 rc = vr.cli(args)
         finally:
-            (host.DOWNLOADS_SNAPSHOTS_DIR, host.DB_FILE, host.LOG_DIR,
+            (host.STAGING_SNAPSHOTS_DIR, host.DB_FILE, host.LOG_DIR,
              snapshot_mover.ICLOUD_SNAPSHOTS_DIR, snapshot_mover.LOG_DIR) = saved
         return rc, buf.getvalue()
 
@@ -1036,7 +1036,7 @@ class TestEndToEnd(unittest.TestCase):
 
         with patch.object(host, 'LOG_DIR', log_dir), \
              patch.object(host, 'DB_FILE', db_path), \
-             patch.object(host, 'DOWNLOADS_SNAPSHOTS_DIR', src), \
+             patch.object(host, 'STAGING_SNAPSHOTS_DIR', src), \
              patch.object(sys, 'stdin',  stdin), \
              patch.object(sys, 'stdout', stdout):
             host.main()
@@ -1099,13 +1099,13 @@ class TestEndToEnd(unittest.TestCase):
 
             # Run a mover + seal pass against these paths.
             saved = (
-                snapshot_mover.DOWNLOADS_SNAPSHOTS_DIR,
+                snapshot_mover.STAGING_SNAPSHOTS_DIR,
                 snapshot_mover.ICLOUD_SNAPSHOTS_DIR,
                 snapshot_mover.LOG_DIR,
                 snapshot_mover.DB_FILE,
             )
             try:
-                snapshot_mover.DOWNLOADS_SNAPSHOTS_DIR = src
+                snapshot_mover.STAGING_SNAPSHOTS_DIR = src
                 snapshot_mover.ICLOUD_SNAPSHOTS_DIR    = dest
                 snapshot_mover.LOG_DIR                 = log_dir
                 snapshot_mover.DB_FILE                 = db
@@ -1117,7 +1117,7 @@ class TestEndToEnd(unittest.TestCase):
                 snapshot_mover._orphan_log_merge_pass(conn)
                 conn.close()
             finally:
-                (snapshot_mover.DOWNLOADS_SNAPSHOTS_DIR,
+                (snapshot_mover.STAGING_SNAPSHOTS_DIR,
                  snapshot_mover.ICLOUD_SNAPSHOTS_DIR,
                  snapshot_mover.LOG_DIR,
                  snapshot_mover.DB_FILE) = saved
@@ -1126,14 +1126,14 @@ class TestEndToEnd(unittest.TestCase):
             before = self._snapshot_tables(db)
             os.unlink(db)
 
-            saved2 = (host.DOWNLOADS_SNAPSHOTS_DIR, host.DB_FILE, host.LOG_DIR,
+            saved2 = (host.STAGING_SNAPSHOTS_DIR, host.DB_FILE, host.LOG_DIR,
                       snapshot_mover.ICLOUD_SNAPSHOTS_DIR,
                       snapshot_mover.LOG_DIR)
             try:
                 rc = vr.cli(['--log-dir', log_dir, '--db', db,
                              '--source', src, '--dest', dest])
             finally:
-                (host.DOWNLOADS_SNAPSHOTS_DIR, host.DB_FILE, host.LOG_DIR,
+                (host.STAGING_SNAPSHOTS_DIR, host.DB_FILE, host.LOG_DIR,
                  snapshot_mover.ICLOUD_SNAPSHOTS_DIR,
                  snapshot_mover.LOG_DIR) = saved2
             self.assertEqual(rc, 0)


### PR DESCRIPTION
## Summary

- Native host now relocates each Chrome snapshot out of `~/Downloads/browser-visit-snapshots/` into `~/Library/Application Support/browser-visit-logger/inbox/` before any DB/log writes; the periodic mover reads from the staging dir and never touches Downloads.
- Sweep runs on every write invocation, so files orphaned by a prior `host.py` crash self-heal on the user's next page action.
- Renamed `DOWNLOADS_SNAPSHOTS_DIR` → `STAGING_SNAPSHOTS_DIR` (and the matching `BVL_*` env var) across host, mover, rebuilder, reset, README, and tests.

## Why

The mover runs under launchd. macOS TCC denies launchd-spawned processes access to `~/Downloads` (the protected location), and there is no way to grant launchd that access through System Settings — the responsible process for TCC lookups is launchd itself, not the `python3` it spawns. Result: every mover tick was failing with `[Errno 1] Operation not permitted` on `~/Downloads/browser-visit-snapshots`, leaving tagged snapshots permanently stranded there.

`host.py` is spawned by Chrome via native messaging and inherits Chrome's TCC grant for Downloads, so it can read the directory. This change uses that one Chrome-spawned hop to escape Downloads' TCC bubble. The mover then operates entirely on a non-protected location.

## Notes for the reviewer

- Order of operations in `main()` matters: sweep → log/DB writes. The sweep is best-effort internally (catches `OSError` on `makedirs`, `listdir`, and per-file `replace`), so failures don't block tagging.
- Sweep is unfiltered — it moves every file in `~/Downloads/browser-visit-snapshots/`, not just snapshot-pattern names. Non-conforming files arriving in staging surface as `invalid_filename` errors via the existing mover machinery, so this stays visible rather than silently lossy.
- Query (`action: query`) skips the sweep — pinned by a test, since a sweep on the read path would race against in-flight downloads whose native message hasn't arrived yet.
- 12 new tests in `test_host.py` (`TestSweepDownloadsToStaging` + `TestMainCallsSweep`); 100% line coverage retained across `native-host/`.

## One-time migration on existing installs

Snapshots already stranded in `~/Downloads/browser-visit-snapshots/` get picked up by the next host invocation's sweep. For existing event rows whose `directory` column still points at the old Downloads path, run:

```bash
sqlite3 ~/browser-visits.db <<SQL
UPDATE read_events    SET directory = '\$HOME/Library/Application Support/browser-visit-logger/inbox'
  WHERE directory = '\$HOME/Downloads/browser-visit-snapshots';
UPDATE skimmed_events SET directory = '\$HOME/Library/Application Support/browser-visit-logger/inbox'
  WHERE directory = '\$HOME/Downloads/browser-visit-snapshots';
DELETE FROM mover_errors WHERE target LIKE '\$HOME/Downloads/browser-visit-snapshots%';
SQL
```

## Test plan

- [ ] \`pytest tests/\` — 418 passed, 100% line coverage on \`native-host/\`.
- [ ] Manually tag a page as "read" or "skimmed", confirm the file lands in \`~/Library/Application Support/browser-visit-logger/inbox/\` and the events row's \`directory\` column matches.
- [ ] Wait for the next mover tick (or run \`snapshot_mover.py\` manually); confirm the snapshot reaches \`~/Documents/browser-visit-logger/snapshots/<date>/\` and the events row updates.
- [ ] \`snapshot_mover.py --show-errors\` reports no pending errors after a few cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)