### PR TITLE
Add browser-visit-mcp/ MCP server for read-only SQL access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .claude/
 .coverage
 .pytest_cache/
+__pycache__/
+browser-visit-mcp/.venv/
+browser-visit-mcp/*.egg-info/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "browser-visits": {
+      "command": "/Users/theimer/projects/hello-world/browser-visit-mcp/.venv/bin/python",
+      "args": [
+        "/Users/theimer/projects/hello-world/browser-visit-mcp/server.py"
+      ]
+    }
+  }
+}

--- a/browser-visit-mcp/README.md
+++ b/browser-visit-mcp/README.md
@@ -1,0 +1,111 @@
+# Browser Visit MCP
+
+A local [Model Context Protocol](https://modelcontextprotocol.io/)
+server that exposes **read-only SQL access** to the SQLite database
+produced by the sibling
+[`browser-visit-logger/`](../browser-visit-logger/) Chrome extension.
+
+It's a read-only consumer of the schema (`visits`, `read_events`,
+`skimmed_events`, `snapshots`, `mover_errors`) — no Python imports
+cross the directory boundary, so this project can be vendored
+independently.
+
+## Tools
+
+| Tool | Input | Output |
+|------|-------|--------|
+| `query` | `sql: string`, optional `max_rows: int` (default 1000, hard cap 10000) | `{columns, rows, row_count, truncated}` |
+| `schema` | — | `{tables, ddl}` — concatenated `CREATE TABLE` / `CREATE INDEX` |
+
+### Read-only safety
+
+Defense in depth:
+
+1. The SQLite connection is opened with `mode=ro` via URI — the OS
+   refuses writes.
+2. The SQL string is parsed before execution. Exactly one statement
+   is allowed; the leading keyword must be `SELECT`, `WITH`,
+   `EXPLAIN`, or `PRAGMA`. `PRAGMA` is restricted to a safelist of
+   introspection commands (`table_info`, `index_list`, `index_info`,
+   `foreign_key_list`, `database_list`, `table_xinfo`).
+
+A 30 s watchdog interrupts runaway queries.
+
+## Install
+
+```bash
+cd browser-visit-mcp
+pip install -e .         # installs `mcp[cli]>=1.0`
+```
+
+Python 3.10+. No other runtime dependencies.
+
+## Run
+
+```bash
+# Default DB at ~/browser-visits.db (override via BVL_DB_FILE or --db).
+python3 server.py
+
+# Point at a test DB.
+python3 server.py --db /tmp/test.db
+BVL_DB_FILE=/tmp/test.db python3 server.py
+```
+
+The server speaks MCP over stdio — it is meant to be launched by an
+MCP client, not used interactively.
+
+### Inspector
+
+```bash
+npx @modelcontextprotocol/inspector python3 server.py
+```
+
+### Claude Code
+
+This repo ships an `.mcp.json` at the repo root that defines the
+`browser-visits` server scoped to this project — open the repo in
+Claude Code and approve the server on first prompt (or set
+`enableAllProjectMcpServers: true` in your personal settings to
+auto-approve). The definition uses absolute paths into
+`browser-visit-mcp/.venv/`, so make sure you've run `pip install -e .`
+inside that venv first.
+
+To point at a different DB, add an `env` block to the entry in
+`.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "browser-visits": {
+      "command": ".../browser-visit-mcp/.venv/bin/python",
+      "args": [".../browser-visit-mcp/server.py"],
+      "env": { "BVL_DB_FILE": "/path/to/visits.db" }
+    }
+  }
+}
+```
+
+## Tests
+
+```bash
+pip install pytest
+pytest tests/
+```
+
+The tests seed a temp DB from
+`../browser-visit-logger/schema.sql` and exercise the validation
+helper, the query path (including row-cap truncation), and the schema
+introspection tool.
+
+## Project layout
+
+```
+browser-visit-mcp/
+├── server.py                 # MCP server (FastMCP + sqlite3)
+├── browser_visits_mcp.sh     # stdio wrapper for MCP clients
+├── pyproject.toml
+├── tests/
+│   ├── conftest.py
+│   └── test_server.py
+└── README.md
+```

--- a/browser-visit-mcp/README.md
+++ b/browser-visit-mcp/README.md
@@ -33,22 +33,35 @@ A 30 s watchdog interrupts runaway queries.
 
 ## Install
 
+Requires Python 3.10+ (the `mcp` SDK refuses older Pythons; the
+project is developed against 3.13). No other runtime dependencies.
+
+The project assumes a venv at `browser-visit-mcp/.venv/` — that's where
+the `.mcp.json` at the repo root expects to find the interpreter. The
+venv is gitignored, so you create it once per checkout:
+
 ```bash
 cd browser-visit-mcp
-pip install -e .         # installs `mcp[cli]>=1.0`
+python3.13 -m venv .venv          # or python3.10 / 3.11 / 3.12
+source .venv/bin/activate         # activate so `pip` and `python` mean the venv's
+pip install -e .                  # installs `mcp[cli]>=1.0` + this package
 ```
 
-Python 3.10+. No other runtime dependencies.
+If you'd rather not activate, you can run `pip` directly with the
+venv's path: `.venv/bin/pip install -e .` — equivalent.
 
 ## Run
 
+With the venv activated (`source .venv/bin/activate`), or by invoking
+the venv's interpreter directly:
+
 ```bash
 # Default DB at ~/browser-visits.db (override via BVL_DB_FILE or --db).
-python3 server.py
+python server.py
 
 # Point at a test DB.
-python3 server.py --db /tmp/test.db
-BVL_DB_FILE=/tmp/test.db python3 server.py
+python server.py --db /tmp/test.db
+BVL_DB_FILE=/tmp/test.db python server.py
 ```
 
 The server speaks MCP over stdio — it is meant to be launched by an
@@ -57,7 +70,7 @@ MCP client, not used interactively.
 ### Inspector
 
 ```bash
-npx @modelcontextprotocol/inspector python3 server.py
+npx @modelcontextprotocol/inspector .venv/bin/python server.py
 ```
 
 ### Claude Code
@@ -87,10 +100,14 @@ To point at a different DB, add an `env` block to the entry in
 
 ## Tests
 
+With the venv activated:
+
 ```bash
-pip install pytest
-pytest tests/
+pip install pytest pytest-cov
+pytest tests/ --cov=server --cov-report=term-missing
 ```
+
+37 tests, 100% line coverage on `server.py`.
 
 The tests seed a temp DB from
 `../browser-visit-logger/schema.sql` and exercise the validation

--- a/browser-visit-mcp/browser_visits_mcp.sh
+++ b/browser-visit-mcp/browser_visits_mcp.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Thin wrapper: launches the MCP server with the bundled Python script.
+# Forwards all arguments verbatim.  Use as the `command` for an MCP
+# client (Claude Code / Claude Desktop) that expects a single
+# executable on PATH.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "${DIR}/server.py" "$@"

--- a/browser-visit-mcp/pyproject.toml
+++ b/browser-visit-mcp/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "browser-visit-mcp"
+version = "0.1.0"
+description = "MCP server exposing read-only SQL access to the browser-visits SQLite database."
+requires-python = ">=3.10"
+dependencies = [
+    "mcp[cli]>=1.0",
+]
+
+[project.scripts]
+browser-visit-mcp = "server:main"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = ["server"]

--- a/browser-visit-mcp/server.py
+++ b/browser-visit-mcp/server.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""
+server.py — MCP server exposing read-only SQL access to the browser-visits DB.
+
+Provides two tools:
+
+  * ``query``  — run an arbitrary read-only SQL statement and return
+                 columns + rows as JSON.
+  * ``schema`` — return the DDL of the database so the model can write
+                 well-formed queries without guessing column names.
+
+Read-only is enforced at two layers:
+
+  1. The SQLite connection is opened with ``mode=ro`` via URI.
+  2. The SQL string is validated before execution — exactly one
+     statement, leading keyword in {SELECT, WITH, EXPLAIN, PRAGMA},
+     and PRAGMAs are limited to a safelist of introspection ones.
+
+This is a read-only consumer of the database produced by the sibling
+``browser-visit-logger`` project; it imports nothing from sibling
+projects.
+
+Usage (stdio MCP transport):
+    python3 server.py
+    BVL_DB_FILE=/tmp/test.db python3 server.py
+    python3 server.py --db /tmp/test.db
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sqlite3
+import threading
+from typing import Any
+
+
+HOME = os.path.expanduser('~')
+DB_FILE = os.environ.get('BVL_DB_FILE', os.path.join(HOME, 'browser-visits.db'))
+
+DEFAULT_MAX_ROWS = 1000
+HARD_MAX_ROWS = 10000
+DEFAULT_TIMEOUT_S = 30.0
+
+_PRAGMA_SAFELIST = frozenset({
+    'table_info',
+    'index_list',
+    'index_info',
+    'foreign_key_list',
+    'database_list',
+    'table_xinfo',
+})
+
+_LEADING_KEYWORDS = frozenset({'SELECT', 'WITH', 'EXPLAIN', 'PRAGMA'})
+
+# Matches the FIRST keyword (letters/underscore) after leading whitespace
+# in a stripped, comment-free SQL string.
+_FIRST_TOKEN = re.compile(r'^\s*([A-Za-z_]+)')
+
+# Matches an inline ``--`` line comment to end-of-line and ``/* ... */``
+# block comments.  Used by ``_strip_comments`` before validation.
+_LINE_COMMENT  = re.compile(r'--[^\n]*')
+_BLOCK_COMMENT = re.compile(r'/\*.*?\*/', re.DOTALL)
+
+# String literal: single-quoted, with '' as an embedded quote.
+_STRING_LITERAL = re.compile(r"'(?:[^']|'')*'")
+
+
+def _strip_comments(sql: str) -> str:
+    return _BLOCK_COMMENT.sub(' ', _LINE_COMMENT.sub('', sql))
+
+
+def _statement_count(sql: str) -> int:
+    """Count top-level statements by counting non-string ``;`` chars.
+
+    Replaces string literals with spaces of equal length so semicolons
+    inside strings don't confuse the count.  A trailing ``;`` after the
+    last real statement is allowed (does not increase the count).
+    """
+    masked = _STRING_LITERAL.sub(lambda m: ' ' * (m.end() - m.start()), sql)
+    # split on ';' and discard a trailing empty/whitespace-only chunk
+    parts = masked.split(';')
+    if parts and not parts[-1].strip():
+        parts = parts[:-1]
+    return len([p for p in parts if p.strip()])
+
+
+def _validate_readonly_sql(sql: str) -> None:
+    """Raise ``ValueError`` if ``sql`` is not a single read-only statement.
+
+    Rules:
+      * exactly one statement (trailing semicolon allowed),
+      * leading keyword is SELECT / WITH / EXPLAIN / PRAGMA,
+      * PRAGMA target must be in the introspection safelist.
+    """
+    if not sql or not sql.strip():
+        raise ValueError('SQL is empty')
+
+    stripped = _strip_comments(sql)
+
+    n = _statement_count(stripped)
+    if n == 0:
+        raise ValueError('SQL contains no statements')
+    if n > 1:
+        raise ValueError('Multiple statements are not allowed')
+
+    m = _FIRST_TOKEN.match(stripped)
+    if not m:
+        raise ValueError('Could not identify leading SQL keyword')
+    keyword = m.group(1).upper()
+    if keyword not in _LEADING_KEYWORDS:
+        raise ValueError(
+            f'Statement must start with one of '
+            f'{sorted(_LEADING_KEYWORDS)}; got {keyword!r}'
+        )
+
+    if keyword == 'PRAGMA':
+        # capture the pragma name after PRAGMA: e.g. "PRAGMA table_info(visits)"
+        pm = re.match(r'\s*PRAGMA\s+([A-Za-z_]+)', stripped, re.IGNORECASE)
+        if not pm:
+            raise ValueError('PRAGMA missing target')
+        pragma = pm.group(1).lower()
+        if pragma not in _PRAGMA_SAFELIST:
+            raise ValueError(
+                f'PRAGMA {pragma!r} is not in the read-only safelist '
+                f'({sorted(_PRAGMA_SAFELIST)})'
+            )
+
+
+def _open_ro(db_path: str) -> sqlite3.Connection:
+    """Open ``db_path`` in read-only mode.
+
+    Uses the SQLite URI form so the OS-level open is also read-only —
+    even a misbehaving statement that bypasses validation will fail at
+    the SQLite layer.
+    """
+    if not os.path.exists(db_path):
+        raise FileNotFoundError(f'Database not found: {db_path}')
+    uri = f'file:{db_path}?mode=ro'
+    return sqlite3.connect(uri, uri=True, isolation_level=None)
+
+
+def _run_with_timeout(
+    conn: sqlite3.Connection, sql: str, timeout_s: float
+) -> sqlite3.Cursor:
+    """Execute ``sql``; interrupt the connection if it exceeds ``timeout_s``.
+
+    ``conn.interrupt()`` is the only thread-safe operation on a
+    connection, which is why we use a watchdog timer rather than
+    running the query itself on a worker thread.
+    """
+    timer = threading.Timer(timeout_s, conn.interrupt)
+    timer.daemon = True
+    timer.start()
+    try:
+        return conn.execute(sql)
+    finally:
+        timer.cancel()
+
+
+def _do_query(db_path: str, sql: str, max_rows: int) -> dict[str, Any]:
+    _validate_readonly_sql(sql)
+    if max_rows < 1:
+        raise ValueError('max_rows must be >= 1')
+    if max_rows > HARD_MAX_ROWS:
+        max_rows = HARD_MAX_ROWS
+
+    conn = _open_ro(db_path)
+    try:
+        cur = _run_with_timeout(conn, sql, DEFAULT_TIMEOUT_S)
+        columns = [d[0] for d in (cur.description or [])]
+        # fetch one past the cap so we can flag truncation
+        rows = cur.fetchmany(max_rows + 1)
+        truncated = len(rows) > max_rows
+        if truncated:
+            rows = rows[:max_rows]
+        return {
+            'columns': columns,
+            'rows': [list(r) for r in rows],
+            'row_count': len(rows),
+            'truncated': truncated,
+        }
+    finally:
+        conn.close()
+
+
+def _do_schema(db_path: str) -> dict[str, Any]:
+    conn = _open_ro(db_path)
+    try:
+        rows = list(conn.execute(
+            "SELECT type, name, sql FROM sqlite_master "
+            "WHERE type IN ('table', 'index') "
+            "  AND name NOT LIKE 'sqlite_%' "
+            "ORDER BY type, name"
+        ))
+    finally:
+        conn.close()
+    tables = [name for typ, name, _ in rows if typ == 'table']
+    ddl = '\n\n'.join(s for _, _, s in rows if s)
+    return {
+        'tables': tables,
+        'ddl': ddl,
+    }
+
+
+def _build_server(db_path: str):
+    # Imported lazily so the pure helpers (and unit tests) don't require
+    # the `mcp` SDK to be installed.
+    from mcp.server.fastmcp import FastMCP
+
+    mcp = FastMCP('browser-visits')
+
+    @mcp.tool()
+    def query(sql: str, max_rows: int = DEFAULT_MAX_ROWS) -> dict[str, Any]:
+        """Run a read-only SQL statement against the browser-visits DB.
+
+        Only ``SELECT`` / ``WITH`` / ``EXPLAIN`` and a small safelist of
+        introspection ``PRAGMA``s are allowed.  Multi-statement input is
+        rejected.  Returns at most ``max_rows`` rows (default 1000, hard
+        cap 10000); ``truncated`` is true if more rows were available.
+        """
+        return _do_query(db_path, sql, max_rows)
+
+    @mcp.tool()
+    def schema() -> dict[str, Any]:
+        """Return the DDL of the browser-visits DB.
+
+        Output:
+          - ``tables``: list of table names
+          - ``ddl``:    concatenated ``CREATE TABLE`` / ``CREATE INDEX``
+                        statements
+        """
+        return _do_schema(db_path)
+
+    return mcp
+
+
+def _parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog='browser-visit-mcp',
+        description='MCP server exposing read-only SQL access to the '
+                    'browser-visits SQLite database.',
+    )
+    p.add_argument('--db', metavar='FILE', default=DB_FILE,
+                   help=f'visits database path (default {DB_FILE})')
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = _parse_args(argv)
+    mcp = _build_server(args.db)
+    mcp.run(transport='stdio')
+    return 0
+
+
+if __name__ == '__main__':  # pragma: no cover
+    raise SystemExit(main())

--- a/browser-visit-mcp/tests/conftest.py
+++ b/browser-visit-mcp/tests/conftest.py
@@ -1,0 +1,52 @@
+"""pytest config for browser-visit-mcp.
+
+Adds the parent directory to sys.path so ``import server`` works from
+any test file, and provides a ``seeded_db`` fixture that builds a
+temporary SQLite DB from the canonical ``schema.sql`` shipped with
+``browser-visit-logger``.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+_SCHEMA_SQL = _HERE.parent.parent / 'browser-visit-logger' / 'schema.sql'
+
+
+def _load_schema(conn: sqlite3.Connection) -> None:
+    ddl = _SCHEMA_SQL.read_text()
+    # The schema uses a sentinel for the snapshots dir default; any
+    # non-empty placeholder works for tests since we don't insert into
+    # the event tables without specifying ``directory`` ourselves.
+    ddl = ddl.replace('__BVL_DOWNLOADS_SNAPSHOTS_DIR__', '/tmp/bvl-test')
+    conn.executescript(ddl)
+
+
+@pytest.fixture
+def seeded_db(tmp_path) -> str:
+    """Return the path to a temp SQLite DB seeded with the real schema
+    and a handful of representative rows."""
+    db = tmp_path / 'visits.db'
+    conn = sqlite3.connect(db)
+    try:
+        _load_schema(conn)
+        conn.executemany(
+            "INSERT INTO visits (url, timestamp, title, of_interest, read, skimmed) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                ('https://a.example/',  '2026-05-01T12:00:00Z', 'Alpha',  'star', 0, 0),
+                ('https://b.example/',  '2026-05-02T12:00:00Z', 'Beta',   'star', 0, 2),
+                ('https://c.example/',  '2026-05-03T12:00:00Z', 'Gamma',  None,   1, 0),
+                ('https://d.example/',  '2026-05-04T12:00:00Z', 'Delta',  'star', 1, 1),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return str(db)

--- a/browser-visit-mcp/tests/test_server.py
+++ b/browser-visit-mcp/tests/test_server.py
@@ -1,0 +1,193 @@
+"""Tests for browser-visit-mcp server.
+
+We exercise the underlying ``_do_query`` / ``_do_schema`` helpers
+directly rather than spinning up the MCP transport — the MCP layer is
+a thin wrapper, and the SDK has its own tests.  The validation helper
+``_validate_readonly_sql`` is also tested in isolation since it is the
+primary safety mechanism.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+import server
+
+
+# ---------------------------------------------------------------------------
+# _validate_readonly_sql
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('sql', [
+    'SELECT 1',
+    'select * from visits',
+    '  SELECT url FROM visits;  ',
+    'WITH x AS (SELECT 1) SELECT * FROM x',
+    'EXPLAIN SELECT * FROM visits',
+    'PRAGMA table_info(visits)',
+    '-- comment\nSELECT 1',
+    '/* hi */ SELECT 1',
+    "SELECT 'a;b' FROM visits",  # semicolon inside a string literal
+])
+def test_validate_accepts_readonly(sql):
+    server._validate_readonly_sql(sql)
+
+
+@pytest.mark.parametrize('sql', [
+    '',
+    '   ',
+    'INSERT INTO visits VALUES (1)',
+    'UPDATE visits SET read = 1',
+    'DELETE FROM visits',
+    'DROP TABLE visits',
+    'ATTACH DATABASE "x" AS y',
+    'CREATE TABLE t (x INT)',
+    'SELECT 1; SELECT 2',
+    'SELECT 1; DROP TABLE visits',
+    'PRAGMA writable_schema = 1',
+    'PRAGMA journal_mode = WAL',
+    'VACUUM',
+])
+def test_validate_rejects_writes_and_multi(sql):
+    with pytest.raises(ValueError):
+        server._validate_readonly_sql(sql)
+
+
+@pytest.mark.parametrize('sql,fragment', [
+    # n == 0 after comment stripping (line 104)
+    ('-- just a comment\n-- another',   'no statements'),
+    # n == 1 but leading token isn't a word (line 110)
+    ('123 not really sql',              'leading SQL keyword'),
+    # PRAGMA without a target (line 122)
+    ('PRAGMA',                          'PRAGMA missing target'),
+])
+def test_validate_specific_error_paths(sql, fragment):
+    """Cover each distinct error-message branch in the validator."""
+    with pytest.raises(ValueError, match=fragment):
+        server._validate_readonly_sql(sql)
+
+
+# ---------------------------------------------------------------------------
+# _do_query
+# ---------------------------------------------------------------------------
+
+def test_query_returns_columns_and_rows(seeded_db):
+    out = server._do_query(seeded_db,
+                           'SELECT url, title FROM visits ORDER BY url', 100)
+    assert out['columns'] == ['url', 'title']
+    assert out['row_count'] == 4
+    assert out['truncated'] is False
+    assert out['rows'][0] == ['https://a.example/', 'Alpha']
+
+
+def test_query_truncates_at_max_rows(seeded_db):
+    out = server._do_query(seeded_db, 'SELECT url FROM visits', max_rows=2)
+    assert out['row_count'] == 2
+    assert out['truncated'] is True
+
+
+def test_query_rejects_write_statement(seeded_db):
+    with pytest.raises(ValueError):
+        server._do_query(seeded_db,
+                         "INSERT INTO visits (url, timestamp) "
+                         "VALUES ('x', 'y')", 100)
+
+
+def test_query_ro_connection_blocks_writes_even_if_validation_bypassed(seeded_db):
+    # Sanity: even reaching SQLite with a write would be refused because
+    # the connection is opened with mode=ro.
+    conn = server._open_ro(seeded_db)
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("INSERT INTO visits (url, timestamp) "
+                         "VALUES ('z', 'now')")
+    finally:
+        conn.close()
+
+
+def test_query_missing_db(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        server._do_query(str(tmp_path / 'nope.db'), 'SELECT 1', 100)
+
+
+def test_query_invalid_max_rows(seeded_db):
+    with pytest.raises(ValueError):
+        server._do_query(seeded_db, 'SELECT 1', max_rows=0)
+
+
+def test_query_hard_cap_applies(seeded_db, monkeypatch):
+    # Ask for more than HARD_MAX_ROWS; result row_count stays bounded.
+    monkeypatch.setattr(server, 'HARD_MAX_ROWS', 2)
+    out = server._do_query(seeded_db, 'SELECT url FROM visits', max_rows=999)
+    assert out['row_count'] == 2
+    assert out['truncated'] is True
+
+
+# ---------------------------------------------------------------------------
+# _do_schema
+# ---------------------------------------------------------------------------
+
+def test_schema_lists_all_tables(seeded_db):
+    out = server._do_schema(seeded_db)
+    assert set(out['tables']) == {
+        'visits', 'read_events', 'skimmed_events',
+        'snapshots', 'mover_errors',
+    }
+    assert 'CREATE TABLE' in out['ddl']
+    assert 'visits' in out['ddl']
+
+
+# ---------------------------------------------------------------------------
+# MCP server wiring: _build_server, _parse_args, main
+# ---------------------------------------------------------------------------
+
+def test_build_server_registers_tools_that_dispatch_correctly(seeded_db):
+    """The FastMCP wrapper should expose `query` and `schema` tools whose
+    bodies delegate to the underlying helpers we already cover above.
+
+    Tools are registered via the @mcp.tool() decorator; FastMCP stashes
+    them in ``_tool_manager._tools[name].fn``.  Invoking those closures
+    is what makes the wrapper body (and the lazy `mcp` import) reachable
+    by line coverage.
+    """
+    mcp = server._build_server(seeded_db)
+    tools = mcp._tool_manager._tools
+    assert set(tools) == {'query', 'schema'}
+
+    # `query` closure: hits _do_query and returns the same shape.
+    query_fn = tools['query'].fn
+    out = query_fn(sql='SELECT url FROM visits ORDER BY url')
+    assert out['columns'] == ['url']
+    assert out['rows'][0] == ['https://a.example/']
+
+    # `schema` closure: hits _do_schema.
+    schema_fn = tools['schema'].fn
+    sch = schema_fn()
+    assert 'visits' in sch['tables']
+
+
+def test_parse_args_defaults_to_db_file_env():
+    args = server._parse_args([])
+    assert args.db == server.DB_FILE
+
+
+def test_parse_args_db_override():
+    args = server._parse_args(['--db', '/tmp/other.db'])
+    assert args.db == '/tmp/other.db'
+
+
+def test_main_invokes_mcp_run(monkeypatch, seeded_db):
+    """main() builds the server and calls mcp.run; we mock .run so we
+    don't actually spawn a stdio loop in the test process."""
+    called = {}
+
+    def fake_run(self, transport):
+        called['transport'] = transport
+
+    from mcp.server.fastmcp import FastMCP
+    monkeypatch.setattr(FastMCP, 'run', fake_run)
+
+    rc = server.main(['--db', seeded_db])
+    assert rc == 0
+    assert called == {'transport': 'stdio'}


### PR DESCRIPTION
## Summary

- Adds `browser-visit-mcp/` — a local MCP server that exposes the browser-visits SQLite DB to MCP clients via two tools: `query` (run a read-only SQL statement and get columns+rows JSON back) and `schema` (return DDL). Lets an LLM answer ad-hoc questions about browsing history without bespoke report code.
- Read-only enforced at two layers: SQLite opened with `mode=ro` URI, and SQL validated before execution (single statement; leading keyword in `SELECT`/`WITH`/`EXPLAIN`/safelisted `PRAGMA`). 30s watchdog interrupts runaway queries; configurable row cap (default 1000, hard 10000).
- Registers the server project-locally via a top-level `.mcp.json` — Claude Code picks it up automatically when this repo is opened.
- Sibling project to `browser-visit-logger` and `browser-visit-tools`; pure read-only consumer with no cross-project Python imports.

## Test plan

- [x] `pytest tests/ --cov=server` — 37 tests passing, 100% line coverage on `server.py`
- [x] Manual smoke via MCP from Claude Code: `schema` returns all 5 tables; `query` against live `~/browser-visits.db` returns real rows
- [ ] After merge: recreate the venv at `browser-visit-mcp/.venv/` on master (paths in `.mcp.json` already point there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)