### PR TITLE
Fix stale .mcp.json paths after repo rename

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,9 @@
 {
   "mcpServers": {
     "browser-visits": {
-      "command": "/Users/theimer/projects/hello-world/browser-visit-mcp/.venv/bin/python",
+      "command": "/Users/theimer/projects/browser-visit-logger/browser-visit-mcp/.venv/bin/python",
       "args": [
-        "/Users/theimer/projects/hello-world/browser-visit-mcp/server.py"
+        "/Users/theimer/projects/browser-visit-logger/browser-visit-mcp/server.py"
       ]
     }
   }


### PR DESCRIPTION
The browser-visits MCP server entry still pointed at /Users/theimer/projects/hello-world/, the project's previous name, so Claude Code couldn't launch it from this checkout. Repoint both the command and args at /Users/theimer/projects/browser-visit-logger/.