### PR TITLE
Refresh icon on SPA navigations; always show First-visited in popup

### DIFF
--- a/browser-visit-logger/extension/background.js
+++ b/browser-visit-logger/extension/background.js
@@ -111,7 +111,7 @@ function flushVisit(tabId) {
   });
 }
 
-chrome.webNavigation.onCompleted.addListener((details) => {
+function handleNavigation(details) {
   // Only log main frame navigations, not iframes
   if (details.frameId !== 0) return;
 
@@ -142,7 +142,13 @@ chrome.webNavigation.onCompleted.addListener((details) => {
     const timerId = setTimeout(() => flushVisit(details.tabId), TITLE_FLUSH_TIMEOUT_MS);
     pendingVisits.set(details.tabId, { url: details.url, title, timestamp, timerId });
   });
-});
+}
+
+chrome.webNavigation.onCompleted.addListener(handleNavigation);
+// SPA navigations (pushState/replaceState) and hash-only changes don't fire
+// onCompleted; register here so the icon recolors and the visit is logged.
+chrome.webNavigation.onHistoryStateUpdated.addListener(handleNavigation);
+chrome.webNavigation.onReferenceFragmentUpdated.addListener(handleNavigation);
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (!changeInfo.title) return;

--- a/browser-visit-logger/extension/popup.js
+++ b/browser-visit-logger/extension/popup.js
@@ -23,16 +23,17 @@ function formatTs(iso) {
  * Does nothing if record is null (URL not yet in the database).
  */
 function showVisitInfo(record) {
-  if (!record) return;
+  // First visited: prefer the recorded DB timestamp; fall back to now when the
+  // page hasn't been logged yet (e.g. the popup is opened immediately after
+  // navigating, before the host has written the visit row).
+  const firstVisited = (record && record.timestamp) || new Date().toISOString();
 
   const rows = [
-    { label: 'First visited', value: formatTs(record.timestamp) },
-    { label: '★ Of Interest', value: record.of_interest ? '' : null },
-    ...(record.read || []).map((r) => ({ label: '✓ Read', value: formatTs(r.timestamp) })),
-    ...(record.skimmed || []).map((r) => ({ label: '~ Skimmed', value: formatTs(r.timestamp) })),
+    { label: 'First visited', value: formatTs(firstVisited) },
+    { label: '★ Of Interest', value: record && record.of_interest ? '' : null },
+    ...((record && record.read)    || []).map((r) => ({ label: '✓ Read',    value: formatTs(r.timestamp) })),
+    ...((record && record.skimmed) || []).map((r) => ({ label: '~ Skimmed', value: formatTs(r.timestamp) })),
   ].filter((r) => r.value !== null);
-
-  if (rows.length === 0) return;
 
   document.getElementById('visit-rows').innerHTML = rows
     .map((r) =>

--- a/browser-visit-logger/tests/background.test.js
+++ b/browser-visit-logger/tests/background.test.js
@@ -21,6 +21,8 @@ const mockSendNativeMessage = jest.fn();
 const mockQueryNativeMessage = jest.fn();
 const mockTabsGet           = jest.fn();
 const addNavListener        = jest.fn();
+const addHistoryStateListener = jest.fn();
+const addReferenceFragmentListener = jest.fn();
 const addTabUpdateListener  = jest.fn();
 const addTabActivatedListener = jest.fn();
 const addMessageListener    = jest.fn();
@@ -114,7 +116,9 @@ function buildChromeMock() {
       onMessage: { addListener: addMessageListener },
     },
     webNavigation: {
-      onCompleted: { addListener: addNavListener },
+      onCompleted:                { addListener: addNavListener },
+      onHistoryStateUpdated:      { addListener: addHistoryStateListener },
+      onReferenceFragmentUpdated: { addListener: addReferenceFragmentListener },
     },
     tabs: {
       get:         mockTabsGet,
@@ -138,7 +142,7 @@ function buildChromeMock() {
 // Load a fresh copy of background.js before every test
 // (jest.resetModules() clears the module cache so pendingVisits starts empty)
 // ---------------------------------------------------------------------------
-let navHandler, tabUpdateHandler, tabActivatedHandler, messageHandler;
+let navHandler, historyStateHandler, referenceFragmentHandler, tabUpdateHandler, tabActivatedHandler, messageHandler;
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -148,6 +152,8 @@ beforeEach(() => {
   mockQueryNativeMessage.mockClear();
   mockTabsGet.mockClear();
   addNavListener.mockClear();
+  addHistoryStateListener.mockClear();
+  addReferenceFragmentListener.mockClear();
   addTabUpdateListener.mockClear();
   addTabActivatedListener.mockClear();
   addMessageListener.mockClear();
@@ -166,7 +172,9 @@ beforeEach(() => {
   jest.resetModules();
   require('../extension/background');
 
-  navHandler          = addNavListener.mock.calls[0][0];
+  navHandler                = addNavListener.mock.calls[0][0];
+  historyStateHandler       = addHistoryStateListener.mock.calls[0][0];
+  referenceFragmentHandler  = addReferenceFragmentListener.mock.calls[0][0];
   tabUpdateHandler    = addTabUpdateListener.mock.calls[0][0];
   tabActivatedHandler = addTabActivatedListener.mock.calls[0][0];
   messageHandler      = addMessageListener.mock.calls[0][0];
@@ -198,6 +206,16 @@ describe('listener registration', () => {
   test('registers a webNavigation.onCompleted listener', () => {
     expect(addNavListener).toHaveBeenCalledTimes(1);
     expect(typeof navHandler).toBe('function');
+  });
+
+  test('registers a webNavigation.onHistoryStateUpdated listener', () => {
+    expect(addHistoryStateListener).toHaveBeenCalledTimes(1);
+    expect(typeof historyStateHandler).toBe('function');
+  });
+
+  test('registers a webNavigation.onReferenceFragmentUpdated listener', () => {
+    expect(addReferenceFragmentListener).toHaveBeenCalledTimes(1);
+    expect(typeof referenceFragmentHandler).toBe('function');
   });
 
   test('registers a tabs.onUpdated listener', () => {
@@ -254,6 +272,30 @@ describe('isTitleMeaningful (indirect)', () => {
 // ---------------------------------------------------------------------------
 // Navigation event — immediate flush path
 // ---------------------------------------------------------------------------
+describe('SPA navigations log visits too', () => {
+  test('onHistoryStateUpdated with a real title flushes a visit immediately', () => {
+    tabReturns('Example Domain');
+    historyStateHandler({ frameId: 0, tabId: 1, url: 'https://example.com/' });
+    expect(mockSendNativeMessage).toHaveBeenCalledTimes(1);
+    const msg = mockSendNativeMessage.mock.calls[0][1];
+    expect(msg.url).toBe('https://example.com/');
+    expect(msg.title).toBe('Example Domain');
+  });
+
+  test('onReferenceFragmentUpdated with a real title flushes a visit immediately', () => {
+    tabReturns('Example Domain');
+    referenceFragmentHandler({ frameId: 0, tabId: 1, url: 'https://example.com/#about' });
+    expect(mockSendNativeMessage).toHaveBeenCalledTimes(1);
+    expect(mockSendNativeMessage.mock.calls[0][1].url).toBe('https://example.com/#about');
+  });
+
+  test('SPA iframe navigation is ignored', () => {
+    tabReturns('Example Domain');
+    historyStateHandler({ frameId: 1, tabId: 1, url: 'https://example.com/' });
+    expect(mockSendNativeMessage).not.toHaveBeenCalled();
+  });
+});
+
 describe('webNavigation.onCompleted — immediate flush', () => {
   test('ignores iframe navigations (frameId !== 0)', () => {
     navHandler({ frameId: 1, tabId: 1, url: 'https://example.com/' });
@@ -1004,6 +1046,31 @@ describe('address-bar icon coloring', () => {
       navHandler({ frameId: 1, tabId: 3, url: URL });
       expect(mockSetIcon).not.toHaveBeenCalled();
       expect(mockQueryNativeMessage).not.toHaveBeenCalled();
+    });
+
+    test('history-state SPA navigation refreshes the icon', () => {
+      mockTabsGet.mockImplementation((_tabId, cb) => cb({ title: 'Example Domain' }));
+      respondWith({ read: [], skimmed: [{ timestamp: 't' }], of_interest: null });
+
+      historyStateHandler({ frameId: 0, tabId: 4, url: URL });
+
+      expect(mockQueryNativeMessage).toHaveBeenCalledWith(
+        'com.browser.visit.logger',
+        { action: 'query', url: URL },
+        expect.any(Function),
+      );
+      expect(lastIconColor()).toBe(YELLOW);
+      expect(lastIconTabId()).toBe(4);
+    });
+
+    test('hash-only navigation refreshes the icon', () => {
+      mockTabsGet.mockImplementation((_tabId, cb) => cb({ title: 'Example Domain' }));
+      respondWith({ read: [], skimmed: [], of_interest: '1' });
+
+      referenceFragmentHandler({ frameId: 0, tabId: 5, url: URL });
+
+      expect(lastIconColor()).toBe(ORANGE);
+      expect(lastIconTabId()).toBe(5);
     });
   });
 

--- a/browser-visit-logger/tests/popup.test.js
+++ b/browser-visit-logger/tests/popup.test.js
@@ -124,11 +124,14 @@ beforeEach(() => {
 describe('formatTs', () => {
   const TAB = { id: 1, url: 'https://example.com/', title: 'Example' };
 
-  test('renders nothing when timestamp is null', async () => {
+  test('renders a First-visited row using the current time when record.timestamp is null', async () => {
     nativeReturns({ status: 'ok', record: { timestamp: null, of_interest: null, read: [], skimmed: []} });
     tabReturns(TAB);
     await loadPopup();
-    expect(document.querySelectorAll('.info-row').length).toBe(0);
+    const labels = [...document.querySelectorAll('.info-label')].map(el => el.textContent);
+    expect(labels).toEqual(['First visited']);
+    const valueEl = document.querySelector('.info-value');
+    expect(valueEl.textContent).toContain(String(new Date().getFullYear()));
   });
 
   test('renders a human-readable date string, not the raw ISO timestamp', async () => {
@@ -176,16 +179,20 @@ describe('showVisitInfo', () => {
     expect(document.getElementById('visit-info').style.display).toBe('block');
   });
 
-  test('leaves #visit-info hidden when record is null', async () => {
+  test('shows #visit-info with a First-visited row even when record is null', async () => {
     nativeReturns({ status: 'ok', record: null });
     await loadPopup();
-    expect(document.getElementById('visit-info').style.display).toBe('none');
+    expect(document.getElementById('visit-info').style.display).toBe('block');
+    const labels = [...document.querySelectorAll('.info-label')].map(el => el.textContent);
+    expect(labels).toEqual(['First visited']);
   });
 
-  test('leaves #visit-info hidden when all timestamps are null', async () => {
+  test('shows First-visited with the current time when all timestamps are null', async () => {
     nativeReturns({ status: 'ok', record: { timestamp: null, of_interest: null, read: [], skimmed: []} });
     await loadPopup();
-    expect(document.getElementById('visit-info').style.display).toBe('none');
+    expect(document.getElementById('visit-info').style.display).toBe('block');
+    const labels = [...document.querySelectorAll('.info-label')].map(el => el.textContent);
+    expect(labels).toEqual(['First visited']);
   });
 
   test('renders a row for each non-null timestamp', async () => {


### PR DESCRIPTION
## Summary
- Register `webNavigation.onHistoryStateUpdated` and `onReferenceFragmentUpdated` alongside `onCompleted` so the toolbar icon recolors (and the visit is logged) on SPA pushState/replaceState and hash-only navigations within the same tab.
- Always render the popup's "First visited" row — falling back to the current time when the host has no record yet — so the timestamp is visible before any tag is applied.

## Test plan
- [x] `npm test` — 122 jest tests pass; 100% coverage on `extension/background.js` and `extension/popup.js`.
- [x] `pytest tests/` in `browser-visit-logger/` — 170 tests pass.
- [ ] Manual: navigate within an SPA (e.g. GitHub repo → file) and confirm the icon recolors for the new URL.
- [ ] Manual: open the popup on a freshly-visited, untagged page and confirm "First visited" is shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)