### PR TITLE
Fix icon failing to recolor after marking a page

### DIFF
--- a/browser-visit-logger/extension/background.js
+++ b/browser-visit-logger/extension/background.js
@@ -51,23 +51,26 @@ function iconImageDataForColor(color) {
 }
 
 function setIconForTab(tabId, color) {
-  chrome.action.setIcon({ tabId, imageData: iconImageDataForColor(color) }, () => {
-    // Tab may have been closed between query and setIcon; ignore.
-    void chrome.runtime.lastError;
+  return new Promise((resolve) => {
+    chrome.action.setIcon({ tabId, imageData: iconImageDataForColor(color) }, () => {
+      // Tab may have been closed between query and setIcon; ignore.
+      void chrome.runtime.lastError;
+      resolve();
+    });
   });
 }
 
 function refreshIconForTab(tabId, url) {
   if (!url || !/^https?:/i.test(url)) {
-    setIconForTab(tabId, ICON_COLOR_GRAY);
-    return;
+    return setIconForTab(tabId, ICON_COLOR_GRAY);
   }
-  chrome.runtime.sendNativeMessage(NATIVE_HOST, { action: 'query', url }, (response) => {
-    if (chrome.runtime.lastError || !response || response.status !== 'ok') {
-      setIconForTab(tabId, ICON_COLOR_GRAY);
-      return;
-    }
-    setIconForTab(tabId, pickIconColor(response.record));
+  return new Promise((resolve) => {
+    chrome.runtime.sendNativeMessage(NATIVE_HOST, { action: 'query', url }, (response) => {
+      const color = (chrome.runtime.lastError || !response || response.status !== 'ok')
+        ? ICON_COLOR_GRAY
+        : pickIconColor(response.record);
+      setIconForTab(tabId, color).then(resolve);
+    });
   });
 }
 
@@ -189,8 +192,11 @@ function snapshotDatetimePrefix(isoTimestamp) {
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.type === 'refresh-icon') {
-    refreshIconForTab(msg.tabId, msg.url);
-    return false;
+    // Keep the SW alive until the native-host query completes and setIcon has
+    // been called — otherwise the in-flight callback can be dropped on
+    // suspension and the icon never recolors.
+    refreshIconForTab(msg.tabId, msg.url).then(() => sendResponse({ status: 'ok' }));
+    return true;
   }
   if (msg.type !== 'tag-and-snapshot') return false;
 

--- a/browser-visit-logger/extension/popup.js
+++ b/browser-visit-logger/extension/popup.js
@@ -83,8 +83,15 @@ function setupButtons(tab) {
           showStatus('Error: ' + chrome.runtime.lastError.message);
           document.querySelectorAll('[data-tag]').forEach(b => { b.disabled = false; });
         } else if (response && response.status === 'ok') {
-          chrome.runtime.sendMessage({ type: 'refresh-icon', tabId: tab.id, url: tab.url });
-          window.close();
+          // Wait for the background to finish recoloring before tearing the
+          // popup down — closing first can drop the message in MV3.
+          chrome.runtime.sendMessage(
+            { type: 'refresh-icon', tabId: tab.id, url: tab.url },
+            () => {
+              void chrome.runtime.lastError;
+              window.close();
+            }
+          );
         } else {
           showStatus(response && response.message ? response.message : 'Write failed — check host log.');
           document.querySelectorAll('[data-tag]').forEach(b => { b.disabled = false; });

--- a/browser-visit-logger/tests/background.test.js
+++ b/browser-visit-logger/tests/background.test.js
@@ -1083,10 +1083,21 @@ describe('address-bar icon coloring', () => {
       expect(lastIconTabId()).toBe(12);
     });
 
-    test('returns false (synchronous handler, no async response)', () => {
-      respondWith(null);
-      const result = messageHandler({ type: 'refresh-icon', tabId: 1, url: URL }, {}, jest.fn());
-      expect(result).toBe(false);
+    test('returns true and acks via sendResponse once setIcon completes', async () => {
+      respondWith({ read: [], skimmed: [], of_interest: '1' });
+      const sendResponse = jest.fn();
+      const result = messageHandler({ type: 'refresh-icon', tabId: 9, url: URL }, {}, sendResponse);
+      // Channel must stay open until the async setIcon resolves; otherwise
+      // the service worker can suspend mid-flight and the icon never updates.
+      expect(result).toBe(true);
+      // sendResponse fires on the microtask queue after the setIcon callback.
+      // Flush microtasks so refreshIconForTab's promise chain resolves.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(sendResponse).toHaveBeenCalledWith({ status: 'ok' });
+      // And the icon was actually painted before the ack went out.
+      expect(lastIconColor()).toBe(ORANGE);
+      expect(lastIconTabId()).toBe(9);
     });
   });
 

--- a/browser-visit-logger/tests/popup.test.js
+++ b/browser-visit-logger/tests/popup.test.js
@@ -391,6 +391,9 @@ describe('setupButtons', () => {
     // Default: query succeeds with no record (so setupButtons is always called)
     tabReturns(TAB);
     nativeReturns({ status: 'ok', record: null });
+    // The popup now waits for the background's refresh-icon ack before
+    // closing — invoke the callback so window.close is reached.
+    mockSendMessage.mockImplementation((_msg, cb) => { if (cb) cb(); });
   });
 
   /**
@@ -468,10 +471,24 @@ describe('setupButtons', () => {
   test('on success, sends a refresh-icon message to the background', async () => {
     nativeReturns({ status: 'ok', record: null });
     mockSendMessage.mockClear();
+    mockSendMessage.mockImplementation((_msg, cb) => { if (cb) cb(); });
     await clickTag('of_interest');
     expect(mockSendMessage).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'refresh-icon', tabId: TAB.id, url: TAB.url }),
+      expect.any(Function),
     );
+  });
+
+  test('window.close is deferred until the background acks refresh-icon', async () => {
+    nativeReturns({ status: 'ok', record: null });
+    let ackCallback;
+    mockSendMessage.mockImplementation((_msg, cb) => { ackCallback = cb; });
+    await clickTag('of_interest');
+    // The native write has completed and refresh-icon has been sent, but the
+    // background hasn't responded yet — popup must still be alive.
+    expect(window.close).not.toHaveBeenCalled();
+    ackCallback();
+    expect(window.close).toHaveBeenCalled();
   });
 
   test('on error response, shows the error message and re-enables buttons', async () => {


### PR DESCRIPTION
Two MV3 races could swallow the post-tag icon refresh: the refresh-icon handler returned synchronously, so the service worker could suspend before the in-flight native query callback ran setIcon; and the popup called window.close() immediately after sendMessage, which could drop the message before Chrome dispatched it.

Promisify refreshIconForTab and keep the message channel open until setIcon completes, and defer window.close() until the background acks.