### PR TITLE
Retry icon refresh once instead of falling back to gray on error

### DIFF
--- a/browser-visit-logger/extension/background.js
+++ b/browser-visit-logger/extension/background.js
@@ -60,16 +60,45 @@ function setIconForTab(tabId, color) {
   });
 }
 
+const NATIVE_QUERY_RETRY_DELAY_MS = 300;
+
+// Extract the failure reason from a sendNativeMessage callback, or null if
+// the response was successful. A status-ok response with `record: null` is a
+// valid "no record" (untagged page) — *not* an error.
+function nativeQueryError(response) {
+  if (chrome.runtime.lastError) return chrome.runtime.lastError.message;
+  if (!response)                return 'no response';
+  if (response.status !== 'ok') return response.message || 'non-ok status';
+  return null;
+}
+
 function refreshIconForTab(tabId, url) {
   if (!url || !/^https?:/i.test(url)) {
     return setIconForTab(tabId, ICON_COLOR_GRAY);
   }
   return new Promise((resolve) => {
     chrome.runtime.sendNativeMessage(NATIVE_HOST, { action: 'query', url }, (response) => {
-      const color = (chrome.runtime.lastError || !response || response.status !== 'ok')
-        ? ICON_COLOR_GRAY
-        : pickIconColor(response.record);
-      setIconForTab(tabId, color).then(resolve);
+      const err = nativeQueryError(response);
+      if (!err) {
+        setIconForTab(tabId, pickIconColor(response.record)).then(resolve);
+        return;
+      }
+      // First query failed — usually a cold-start race right after Chrome
+      // relaunch (host not spawned yet) or a transient sqlite lock. Retry
+      // once before giving up; do NOT fall back to gray on error (that would
+      // actively mislabel a tagged page as untagged).
+      setTimeout(() => {
+        chrome.runtime.sendNativeMessage(NATIVE_HOST, { action: 'query', url }, (retry) => {
+          const err2 = nativeQueryError(retry);
+          if (!err2) {
+            setIconForTab(tabId, pickIconColor(retry.record)).then(resolve);
+            return;
+          }
+          console.warn('[BVL] icon refresh failed for', url, '—', err2);
+          // Leave the icon at whatever it is rather than clobbering to gray.
+          resolve();
+        });
+      }, NATIVE_QUERY_RETRY_DELAY_MS);
     });
   });
 }

--- a/browser-visit-logger/tests/background.test.js
+++ b/browser-visit-logger/tests/background.test.js
@@ -987,7 +987,32 @@ describe('address-bar icon coloring', () => {
       expect(lastIconColor()).toBe(GRAY);
     });
 
-    test('native query lastError → gray', () => {
+    test('transient native lastError → retries and applies the eventual color', async () => {
+      mockTabsGet.mockImplementation((_tabId, cb) => cb({ url: URL }));
+      let calls = 0;
+      mockQueryNativeMessage.mockImplementation((_host, _msg, cb) => {
+        calls += 1;
+        if (calls === 1) {
+          global.chrome.runtime.lastError = { message: 'host crashed' };
+          cb(undefined);
+          global.chrome.runtime.lastError = null;
+        } else {
+          cb({ status: 'ok', record: { read: [], skimmed: [], of_interest: '1' } });
+        }
+      });
+      tabActivatedHandler({ tabId: 9 });
+      // Drain the first query's microtasks, then fast-forward past the retry delay.
+      await Promise.resolve();
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(calls).toBe(2);
+      expect(lastIconColor()).toBe(ORANGE);
+      expect(lastIconTabId()).toBe(9);
+    });
+
+    test('persistent native lastError → leaves the icon untouched and warns', async () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
       mockTabsGet.mockImplementation((_tabId, cb) => cb({ url: URL }));
       mockQueryNativeMessage.mockImplementation((_host, _msg, cb) => {
         global.chrome.runtime.lastError = { message: 'host crashed' };
@@ -995,15 +1020,61 @@ describe('address-bar icon coloring', () => {
         global.chrome.runtime.lastError = null;
       });
       tabActivatedHandler({ tabId: 9 });
-      expect(lastIconColor()).toBe(GRAY);
+      await Promise.resolve();
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockSetIcon).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('[BVL]'), URL, '—', 'host crashed');
+      warn.mockRestore();
     });
 
-    test('native response with non-ok status → gray', () => {
+    test('non-ok status, then non-ok again → leaves the icon untouched', async () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
       mockTabsGet.mockImplementation((_tabId, cb) => cb({ url: URL }));
       mockQueryNativeMessage.mockImplementation((_h, _m, cb) =>
         cb({ status: 'error', message: 'db locked' }),
       );
       tabActivatedHandler({ tabId: 9 });
+      await Promise.resolve();
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockSetIcon).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('[BVL]'), URL, '—', 'db locked');
+      warn.mockRestore();
+    });
+
+    test('non-ok status without a message falls back to a generic error string', async () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      mockTabsGet.mockImplementation((_tabId, cb) => cb({ url: URL }));
+      mockQueryNativeMessage.mockImplementation((_h, _m, cb) => cb({ status: 'error' }));
+      tabActivatedHandler({ tabId: 9 });
+      await Promise.resolve();
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('[BVL]'), URL, '—', 'non-ok status');
+      warn.mockRestore();
+    });
+
+    test('missing response (no lastError) is treated as error and retried', async () => {
+      mockTabsGet.mockImplementation((_tabId, cb) => cb({ url: URL }));
+      let calls = 0;
+      mockQueryNativeMessage.mockImplementation((_host, _msg, cb) => {
+        calls += 1;
+        if (calls === 1) {
+          cb(undefined); // no lastError, no response
+        } else {
+          cb({ status: 'ok', record: null });
+        }
+      });
+      tabActivatedHandler({ tabId: 9 });
+      await Promise.resolve();
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(calls).toBe(2);
       expect(lastIconColor()).toBe(GRAY);
     });
   });


### PR DESCRIPTION
After a Chrome relaunch, the first sendNativeMessage that spawns the Swift host can fail transiently (cold-start race, sqlite briefly locked by snapshot_mover, etc). The old code silently set the icon to gray on any error, which actively mislabeled tagged pages as untagged.

Distinguish a successful empty record from a real query failure: on error, wait 300ms and retry once. If the retry also fails, log a warning and leave the icon at whatever it was rather than overwriting to gray.