### PR TITLE
Auto-apply of_interest when marking a page read or skimmed

### DIFF
--- a/browser-visit-logger/extension/background.js
+++ b/browser-visit-logger/extension/background.js
@@ -229,7 +229,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   }
   if (msg.type !== 'tag-and-snapshot') return false;
 
-  const { tabId, timestamp, url, title, tag } = msg;
+  const { tabId, timestamp, url, title, tag, alsoOfInterest } = msg;
 
   // Compute SHA-256 of the URL for a stable, deduplicated snapshot filename.
   const hashPromise = crypto.subtle
@@ -286,6 +286,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
               timestamp, url, title,
               tag,
               filename,
+              alsoOfInterest: !!alsoOfInterest,
             }, (response) => {
               if (chrome.runtime.lastError) {
                 sendResponse({ status: 'error', message: chrome.runtime.lastError.message });

--- a/browser-visit-logger/extension/popup.js
+++ b/browser-visit-logger/extension/popup.js
@@ -57,20 +57,22 @@ document.addEventListener('DOMContentLoaded', () => {
     // Query the native host for any existing record for this URL.
     chrome.runtime.sendNativeMessage(NATIVE_HOST, { action: 'query', url: tab.url },
       (response) => {
+        let alreadyOfInterest = false;
         // Ignore errors — the history section simply stays hidden.
         if (!chrome.runtime.lastError && response && response.status === 'ok') {
           showVisitInfo(response.record);
+          alreadyOfInterest = !!(response.record && response.record.of_interest);
         }
 
         // Set up tag buttons after the query returns (so the popup doesn't
         // flash in if the query is fast).
-        setupButtons(tab);
+        setupButtons(tab, alreadyOfInterest);
       }
     );
   });
 });
 
-function setupButtons(tab) {
+function setupButtons(tab, alreadyOfInterest) {
   document.querySelectorAll('[data-tag]').forEach((btn) => {
     btn.addEventListener('click', () => {
       document.querySelectorAll('[data-tag]').forEach(b => { b.disabled = true; });
@@ -101,12 +103,16 @@ function setupButtons(tab) {
       if (tag === 'read' || tag === 'skimmed') {
         showStatus('Saving snapshot\u2026');
         chrome.runtime.sendMessage({
-          type:      'tag-and-snapshot',
+          type:           'tag-and-snapshot',
           tag,
-          tabId:     tab.id,
+          tabId:          tab.id,
           timestamp,
-          url:       tab.url,
-          title:     tab.title || tab.url,
+          url:            tab.url,
+          title:          tab.title || tab.url,
+          // Marking a page read or skimmed implies it's of-interest.
+          // Tell the host to set of_interest in the same DB transaction
+          // when it isn't already set.
+          alsoOfInterest: !alreadyOfInterest,
         }, handleResponse);
       } else {
         chrome.runtime.sendNativeMessage(NATIVE_HOST, {

--- a/browser-visit-logger/swift/Sources/BVLHost/main.swift
+++ b/browser-visit-logger/swift/Sources/BVLHost/main.swift
@@ -121,6 +121,10 @@ let timestamp = (message["timestamp"] as? String ?? "").trimmingCharacters(in: .
 let title = message["title"] as? String ?? ""
 let tag = (message["tag"] as? String ?? "").trimmingCharacters(in: .whitespaces)
 let filename = (message["filename"] as? String ?? "").trimmingCharacters(in: .whitespaces)
+// When the popup marks a page "read" or "skimmed" on a URL that isn't
+// already of-interest, it asks the host to set of_interest in the same
+// transaction so both updates land atomically.
+let alsoOfInterest = (message["alsoOfInterest"] as? Bool) ?? false
 
 if url.isEmpty {
     writeError("url is required")
@@ -156,13 +160,29 @@ do {
     try db.run("""
         INSERT OR IGNORE INTO snapshots (date, sealed) VALUES (?, 0)
         """, [todayISO])
-    try Events.insertVisit(db, timestamp: timestamp, url: url, title: title)
-    if !tag.isEmpty {
-        try Events.tagVisit(db, url: url, tag: tag, timestamp: timestamp,
-                            filename: filename)
-        if (tag == "read" || tag == "skimmed") && !filename.isEmpty {
-            Archive.forTag(db, filename: filename, log: log)
+
+    // Wrap the visit + tag writes in a transaction so that the implicit
+    // of_interest update (when alsoOfInterest is set on a read/skimmed
+    // request) commits atomically with the read/skimmed event row.
+    try db.run("BEGIN")
+    do {
+        try Events.insertVisit(db, timestamp: timestamp, url: url, title: title)
+        if !tag.isEmpty {
+            try Events.tagVisit(db, url: url, tag: tag, timestamp: timestamp,
+                                filename: filename)
+            if alsoOfInterest && (tag == "read" || tag == "skimmed") {
+                try Events.tagVisit(db, url: url, tag: "of_interest",
+                                    timestamp: timestamp)
+            }
         }
+        try db.run("COMMIT")
+    } catch {
+        _ = try? db.run("ROLLBACK")
+        throw error
+    }
+
+    if !tag.isEmpty && (tag == "read" || tag == "skimmed") && !filename.isEmpty {
+        Archive.forTag(db, filename: filename, log: log)
     }
 } catch {
     log.error("SQLite write failed: \(error)")

--- a/browser-visit-logger/tests/background.test.js
+++ b/browser-visit-logger/tests/background.test.js
@@ -721,7 +721,22 @@ describe('tag-and-snapshot message handler', () => {
       {
         tag: 'read', url: 'https://example.com/', timestamp: baseMsg.timestamp, title: baseMsg.title,
         filename: `browser-visit-snapshots/2026-01-01T00-00-00Z-${MOCK_HEX_HASH}.mhtml`,
+        alsoOfInterest: false,
       },
+      expect.any(Function),
+    );
+  });
+
+  test('forwards alsoOfInterest:true to the native host when the popup sets it', async () => {
+    setupSuccessFlow({ downloadId: 42 });
+    messageHandler({ ...baseMsg, alsoOfInterest: true }, {}, jest.fn());
+    await flushPromises();
+
+    fireDownloadChanged({ id: 42, state: { current: 'complete' } });
+
+    expect(mockSendNativeMessage).toHaveBeenCalledWith(
+      'com.browser.visit.logger',
+      expect.objectContaining({ tag: 'read', alsoOfInterest: true }),
       expect.any(Function),
     );
   });
@@ -740,6 +755,7 @@ describe('tag-and-snapshot message handler', () => {
       {
         tag: 'skimmed', url: skimMsg.url, timestamp: skimMsg.timestamp, title: skimMsg.title,
         filename: `browser-visit-snapshots/2026-01-01T00-00-00Z-${MOCK_HEX_HASH}.mhtml`,
+        alsoOfInterest: false,
       },
       expect.any(Function),
     );

--- a/browser-visit-logger/tests/popup.test.js
+++ b/browser-visit-logger/tests/popup.test.js
@@ -449,6 +449,58 @@ describe('setupButtons', () => {
     expect(mockSendNativeMessage).not.toHaveBeenCalled();
   });
 
+  test('clicking "read" on a not-yet-of-interest URL sets alsoOfInterest:true', async () => {
+    nativeReturns({ status: 'ok', record: { timestamp: null, of_interest: null, read: [], skimmed: [] } });
+    await loadPopup();
+    mockSendMessage.mockClear();
+    mockSendMessage.mockImplementation((_msg, cb) => { if (cb) cb(); });
+    document.querySelector('[data-tag="read"]').click();
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'tag-and-snapshot', tag: 'read', alsoOfInterest: true }),
+      expect.any(Function),
+    );
+  });
+
+  test('clicking "skimmed" on a not-yet-of-interest URL sets alsoOfInterest:true', async () => {
+    nativeReturns({ status: 'ok', record: { timestamp: null, of_interest: null, read: [], skimmed: [] } });
+    await loadPopup();
+    mockSendMessage.mockClear();
+    mockSendMessage.mockImplementation((_msg, cb) => { if (cb) cb(); });
+    document.querySelector('[data-tag="skimmed"]').click();
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'tag-and-snapshot', tag: 'skimmed', alsoOfInterest: true }),
+      expect.any(Function),
+    );
+  });
+
+  test('clicking "read" on an already-of-interest URL sets alsoOfInterest:false', async () => {
+    nativeReturns({ status: 'ok', record: { timestamp: null, of_interest: true, read: [], skimmed: [] } });
+    await loadPopup();
+    mockSendMessage.mockClear();
+    mockSendMessage.mockImplementation((_msg, cb) => { if (cb) cb(); });
+    document.querySelector('[data-tag="read"]').click();
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'tag-and-snapshot', tag: 'read', alsoOfInterest: false }),
+      expect.any(Function),
+    );
+  });
+
+  test('when the query fails, read defaults to alsoOfInterest:true (treat as not-yet-of-interest)', async () => {
+    mockSendNativeMessage.mockImplementation((_host, _msg, cb) => {
+      global.chrome.runtime.lastError = { message: 'Host not found' };
+      cb(null);
+      global.chrome.runtime.lastError = null;
+    });
+    await loadPopup();
+    mockSendMessage.mockClear();
+    mockSendMessage.mockImplementation((_msg, cb) => { if (cb) cb(); });
+    document.querySelector('[data-tag="read"]').click();
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'tag-and-snapshot', tag: 'read', alsoOfInterest: true }),
+      expect.any(Function),
+    );
+  });
+
   test('buttons are disabled while a request is in flight', async () => {
     // Load popup with the default (ok) query so setupButtons is called
     await loadPopup();


### PR DESCRIPTION
The popup now forwards an alsoOfInterest flag on read/skimmed clicks when the URL isn't already of-interest. The Swift host applies both updates inside a single transaction so the implicit of_interest write lands atomically with the read/skimmed event row.