### PR TITLE
Multi-laptop sync: gRPC sync-server, laptop sync client, tooling, and 100%-covered tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,94 @@
 # Browser Visit projects
 
-Three related projects that share a local SQLite database of browser
-visit history.  Everything runs locally on your machine; nothing is
-sent anywhere.
+Four related projects that share a SQLite database of browser visit
+history, optionally synchronised across multiple laptops via an
+EC2-hosted gRPC service.
+
+The setup can run in either of two modes:
+
+- **Single-laptop** — extension → local DB + per-day TSV logs +
+  iCloud-synced snapshot archive.  No network.  Original design.
+- **Multi-laptop** — every laptop still writes locally as above, plus
+  pushes its log records to (and pulls peer records from) a gRPC
+  service running on a Linux VM.  The VM holds the canonical merged
+  DB, runs the verifier/snapshotter, and stores the unified snapshot
+  archive on Google Drive (accessible to laptops and the VM alike).
+  Each laptop's local DB converges to the union of all laptops'
+  activity within ~1 minute of any interaction.
+
+The architecture is described in detail in
+[plans/i-want-to-be-witty-nygaard.md](.claude/plans/i-want-to-be-witty-nygaard.md).
 
 ## [`browser-visit-logger/`](browser-visit-logger/)
 
-A Chrome extension and native-messaging host that records every page
-you visit to a local SQLite database and a per-day TSV log file, lets
-you tag pages of interest from a popup, and archives full-page
-snapshots (MHTML or PDF) into iCloud-synced daily folders sealed with
-a tab-delimited manifest once each day has passed.
+The Chrome extension and macOS native-messaging host that records
+every page you visit to `~/browser-visits.db` and to a per-day TSV
+log file, lets you tag pages of interest from a popup, and archives
+full-page snapshots (MHTML or PDF).  The address-bar icon turns
+gray / orange / yellow / green based on the current tab's tag state
+(untagged / of-interest / skimmed / read).
 
-The address-bar icon turns gray / orange / yellow / green based on the
-current tab's tag state (untagged / of-interest / skimmed / read).
+In multi-laptop mode, the native host (`BVLHost`) also fork-detaches
+a Python `sync_client.py` after responding to Chrome — that's what
+actually talks to the gRPC service.  Sync is debounced (default 60
+seconds since last attempt) and gated on
+`~/.browser-visit-logger/config.json` existing, so single-laptop
+installs are entirely unaffected.
+
+## [`browser-visit-sync-server/`](browser-visit-sync-server/)
+
+The Go gRPC service that runs on the EC2 Linux VM.  Three RPCs:
+
+- **`PushLogs`** — receives log lines from a laptop, mirrors them
+  into `<log-root>/<machine_id>/browser-visits-YYYY-MM-DD.log`, and
+  replays each line into the canonical DB.
+- **`PullLogs`** — streams every peer machine's log lines past each
+  per-peer cursor the caller supplies.  The caller's own records are
+  never echoed back.
+- **`ExportDbSnapshot`** — runs `VACUUM INTO` and streams a
+  transactionally-consistent SQLite snapshot back to the caller.
+  Feeds `browser-visit-tools/db_diff.py`.
+
+Authentication is mTLS.  Each laptop has its own client cert; the
+server pins the cert SHA-256 to a `machine_id` via the
+`enrolled_machines.db` SQLite file (managed by
+`browser-visit-tools/enroll_machine.py`).  Identity spoofing is
+caught by a `CrossCheck(ctx, claimedID)` call on every RPC.
+
+Includes a full Docker Compose integration suite under
+[`browser-visit-sync-server/test/`](browser-visit-sync-server/test/);
+see that directory's README for the venv + `make test-integration`
+workflow.
 
 ## [`browser-visit-tools/`](browser-visit-tools/)
 
-Standalone read-only consumers of the database the logger produces.
-Currently:
+Standalone scripts that consume the database or operate on the
+multi-laptop setup itself:
 
 - **`reading_list.py`** — generates a reading list of every URL
-  tagged of_interest but not yet read, split into "Unread URLs that
-  have been skimmed" and "Unread URLs" tables.  HTML by default
-  (self-contained, openable in a browser); pass `--format markdown`
-  for Markdown.
+  tagged of_interest but not yet read.  HTML by default, Markdown
+  via `--format markdown`.
+- **`db_diff.py`** — compares two `browser-visits.db` files (e.g.
+  laptop vs. VM snapshot) and reports per-table presence and value
+  differences.  Counter columns can be ignored via
+  `--ignore-counters`.
+- **`fetch_vm_snapshot.py`** — gRPC client that calls
+  `ExportDbSnapshot` and writes the bytes to a local file.  Composes
+  with `db_diff.py`.
+- **`enroll_machine.py`** — admin tool, run on the VM.  Inserts a
+  `(machine_id, cert_sha256)` row into `enrolled_machines.db`.
+- **`migrate_icloud_to_gdrive.py`** — one-time migration of the
+  historical iCloud snapshot archive to a Google Drive folder, with
+  SHA-256 verification and DB-path rewrites.  Idempotent.
+- **`install_laptop.sh`** — orchestrates a laptop install for the
+  multi-laptop setup (runs the legacy uninstaller, then upstream
+  `install.sh`, then writes the machine config).
+- **`uninstall_laptop_legacy.sh`** — removes the legacy
+  snapshot-verifier LaunchAgent (the verifier moves to the VM in
+  multi-laptop mode).  Idempotent; never touches user data.
 
-These tools depend only on the DB schema, not on logger code, so the
-directories can be developed and vendored independently.
+The read-only tools depend only on the DB schema; the sync-related
+tools depend on the gRPC stubs the sync-server emits.
 
 ## [`browser-visit-mcp/`](browser-visit-mcp/)
 
@@ -40,7 +101,74 @@ write well-formed queries).  Read-only is enforced both by opening
 SQLite with `mode=ro` and by validating each statement before
 execution.
 
-Like the tools project, this is a pure read-only consumer of the
-schema — no Python imports cross the directory boundary.  A
-`.mcp.json` at the repo root registers the server project-locally so
-Claude Code picks it up automatically when this repo is opened.
+A `.mcp.json` at the repo root registers the server project-locally
+so Claude Code picks it up automatically.
+
+## End-to-end data flow (multi-laptop mode)
+
+```
+Chrome (laptop A)               Chrome (laptop B)
+   │ navigation/tag                │ navigation/tag
+   ▼                               ▼
+BVLHost                          BVLHost
+   │ append local log line          │
+   │ INSERT/UPDATE local DB         │
+   │ archive snapshot → Google Drive│
+   │ fork sync_client.py            │
+   ▼                               ▼
+sync_client.py ──── gRPC ────► browser-visit-sync-server (EC2 VM)
+   PushLogs (new local lines)         │
+   PullLogs (cursors for every peer)  │
+   ▲                                  │
+   │  replay into local DB    ◄───────┘  apply lines to canonical DB
+   │  mirror to ~/browser-visits-peers/<peer>/
+   ▼
+Chrome stays unaware; address-bar icon refresh
+sees the updated counters on next query.
+
+Snapshots ride independently via Google Drive's own sync (Drive
+mounted on both laptops and the VM).  The VM-side verifier
+periodically seals completed days and writes MANIFEST.tsv files.
+```
+
+Everything that runs on the laptop side keeps working in
+single-laptop mode if `~/.browser-visit-logger/config.json` doesn't
+exist; the sync hook in `BVLHost` short-circuits, and the local DB +
+local logs + local snapshot archive remain authoritative.
+
+## Testing & development
+
+Each project owns its own test suite and a `Makefile` that wraps it.
+The Python suites build a throwaway, gitignored virtualenv
+(`.venv-test/` or `test/.venv/`) on first run, so your system Python is
+never modified.
+
+| Project | Command | What it needs | Coverage |
+|---|---|---|---|
+| `browser-visit-logger` (Python) | `make test-py` | python3 | 225 tests, 100% (gated) |
+| `browser-visit-logger` (JS) | `make test-js` | node/npm | 131 tests, 100% |
+| `browser-visit-tools` | `make test` | python3 | 85 tests, 100% (gated) |
+| `browser-visit-sync-server` (Go unit) | `make cover` | go 1.22+, protoc | 94–100% per package¹ |
+| `browser-visit-sync-server` (integration) | `make test-integration` | Docker | 7 end-to-end tests |
+| `browser-visit-mcp` | `pytest` | python3 | see its README |
+
+¹ Go residuals are `main()` (a process entrypoint) plus unreachable
+defensive error branches; generated protobuf code is excluded by
+convention.
+
+**Key assumptions baked into the tests and tooling:**
+
+- **Tests never touch production data.** Every suite routes I/O to a
+  temp dir, and the Python `conftest.py` files additionally force all
+  `BVL_*` paths to a throwaway sandbox before import as a safety net.
+  `setdefault` is used, so an intentionally exported `BVL_*` value
+  still wins.
+- **`go` and `protoc` are only needed to build/test the sync-server
+  outside Docker.** The Docker image (and the integration suite that
+  builds it) install them internally; `grpcio` is faked in unit tests.
+- **The macOS system Python redirects bytecode to
+  `~/Library/Caches/com.apple.python/`** (`sys.pycache_prefix`), so a
+  hand-edit that seems ignored may be a stale `.pyc` there, not beside
+  the source.
+- **Single-laptop mode is the default**; multi-laptop behavior only
+  activates once `~/.browser-visit-logger/config.json` exists.

--- a/browser-visit-logger/.gitignore
+++ b/browser-visit-logger/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 __pycache__/
 *.pyc
 .pytest_cache/
+.venv-test/
 native-host/generated_key.pem
 extension/manifest.json
 .coverage

--- a/browser-visit-logger/Makefile
+++ b/browser-visit-logger/Makefile
@@ -1,0 +1,47 @@
+.PHONY: test test-py test-js test-swift venv swift clean clean-venv
+
+# Python venv for the pytest suite, colocated and gitignored.  Created
+# on first `make test-py`; reused afterward.  The host's system Python
+# is never touched.  Mirrors browser-visit-sync-server/Makefile.
+VENV       := .venv-test
+VENV_BIN   := $(VENV)/bin
+VENV_PY    := $(VENV_BIN)/python
+VENV_PIP   := $(VENV_BIN)/pip
+VENV_STAMP := $(VENV)/.installed
+
+# Run everything: Python + JS.  (Swift is built separately via `make
+# swift`; there's no XCTest target — see swift/Package.swift.)
+test: test-py test-js
+
+venv: $(VENV_STAMP)
+
+$(VENV_STAMP): requirements-test.txt
+	python3 -m venv $(VENV)
+	$(VENV_PIP) install --upgrade pip
+	$(VENV_PIP) install -r requirements-test.txt pytest-cov
+	touch $(VENV_STAMP)
+
+# Python suite with coverage over every native-host module, including
+# the multi-laptop sync_client.  --cov-fail-under makes a regression a
+# hard failure.
+test-py: venv
+	$(VENV_PY) -m pytest tests/ \
+		--cov=native-host \
+		--cov-report=term-missing --cov-fail-under=100
+
+# JS suite (extension service worker + popup) with coverage.
+test-js:
+	npm install
+	npm test -- --coverage
+
+# Build the Swift binaries (release).  Required before the shell
+# wrappers (verify_snapshot_directory etc.) and the Swift-dependent
+# Python tests will run.
+swift:
+	cd swift && swift build -c release
+
+clean:
+	rm -rf .pytest_cache .coverage coverage
+
+clean-venv:
+	rm -rf $(VENV)

--- a/browser-visit-logger/README.md
+++ b/browser-visit-logger/README.md
@@ -6,7 +6,10 @@ pages of interest from a popup, and archives full-page snapshots (MHTML
 or PDF) into iCloud-synced daily folders sealed by a tab-delimited
 manifest once each day has passed.
 
-Everything runs locally on your machine. Nothing is sent anywhere.
+Everything runs locally by default.  An **optional multi-laptop sync
+mode** ([covered below](#multi-laptop-sync-mode)) layers a gRPC
+client on top so several laptops can share state via a central EC2
+service; with multi-laptop mode disabled, nothing is sent anywhere.
 
 ---
 
@@ -60,7 +63,11 @@ clicking Allow grants it for the lifetime of the app's signature.
 | `~/Library/Application Support/browser-visit-logger/BrowserVisitLoggerHost.app/` | Code-signed app bundle wrapping the Swift `BVLHost` Mach-O binary (Chrome's native-messaging host) |
 | `~/Library/Application Support/browser-visit-logger/BrowserVisitLoggerVerifier.app/` | Code-signed app bundle wrapping the Swift `BVLVerifier` Mach-O binary (daily background agent) |
 | `~/Downloads/browser-visit-snapshots/` | Chrome's drop point — `BVLHost` archives files away on every tag, the verifier sweeps stragglers daily |
-| `~/Documents/browser-visit-logger/snapshots/<YYYY-MM-DD>/` | Sealed daily archive: read-only snapshot files + read-only `MANIFEST.tsv` + read-only `browser-visits-<YYYY-MM-DD>.log` |
+| `~/Documents/browser-visit-logger/snapshots/<YYYY-MM-DD>/` | Sealed daily archive: read-only snapshot files + read-only `MANIFEST.tsv` + read-only `browser-visits-<YYYY-MM-DD>.log` (single-laptop default; multi-laptop mode points the archive at Google Drive instead) |
+| `~/.browser-visit-logger/config.json` | Machine config (multi-laptop mode only).  Records `machine_id` + optional `sync_server` endpoint.  Presence of this file is what gates the sync hook in `BVLHost` |
+| `~/.browser-visit-logger/tls/` | mTLS material (multi-laptop mode only): `client.crt`, `client.key`, `server-ca.crt` |
+| `~/.browser-visit-logger/sync.lock` | flock acquired by `sync_client.py` so back-to-back Chrome events don't spawn overlapping syncs |
+| `~/browser-visits-peers/<machine_id>/browser-visits-<YYYY-MM-DD>.log` | Local mirror of peer machines' logs, written by `sync_client.py` on pull |
 
 All paths can be overridden via `BVL_*` environment variables — see
 [Configuration](#configuration).
@@ -94,8 +101,8 @@ snapshots (
 
 mover_errors (
     key        TEXT PRIMARY KEY,               -- '<op>:<target>'
-    operation  TEXT NOT NULL,                  -- 'move'|'seal'|'rewrite_manifest'|'top_level'
-    target     TEXT NOT NULL,                  -- file path / date dir
+    operation  TEXT NOT NULL,                  -- 'move'|'seal'|'rewrite_manifest'|'top_level'|'sync_push'|'sync_pull'|'sync_handshake'
+    target     TEXT NOT NULL,                  -- file path / date dir / VM endpoint
     message    TEXT NOT NULL,                  -- last exception message
     first_seen TEXT NOT NULL,
     last_seen  TEXT NOT NULL,
@@ -103,7 +110,23 @@ mover_errors (
     notified   INTEGER NOT NULL DEFAULT 0,
     immediate  INTEGER NOT NULL DEFAULT 0
 )
+
+sync_state (                                   -- multi-laptop mode only
+    machine_id            TEXT PRIMARY KEY,    -- this laptop or any peer
+    cursor_log_date       TEXT NOT NULL DEFAULT '',
+    cursor_line_offset    INTEGER NOT NULL DEFAULT 0,
+    last_sync_attempt_at  TEXT NOT NULL DEFAULT '',
+    last_sync_success_at  TEXT NOT NULL DEFAULT '',
+    last_error            TEXT NOT NULL DEFAULT ''
+)
 ```
+
+`sync_state` holds one row per machine the VM has told us about
+(including this laptop).  The cursor is the high-water mark of log
+records produced by `machine_id` that this laptop has confirmed are
+at the VM — for the self row, "successfully pushed and acked"; for
+peer rows, "successfully pulled and applied locally".  See
+[Multi-laptop sync mode](#multi-laptop-sync-mode).
 
 The `visits` / `*_events` tables are owned by `BVLHost`; the `snapshots`
 and `mover_errors` tables are co-owned by `BVLHost` and `BVLVerifier`.
@@ -562,6 +585,87 @@ for the full design.
 
 ---
 
+## Multi-laptop sync mode
+
+Optional layer that lets several laptops share their browsing state
+through a central gRPC service ([`browser-visit-sync-server/`](../browser-visit-sync-server/))
+running on an EC2 Linux VM.  Each laptop's local DB and local logs
+continue to work exactly as in single-laptop mode; the sync layer
+just makes the local DB converge to the union of every laptop's
+activity within ~1 minute of any interaction.
+
+**How to turn it on:**
+
+1. Set up the sync server on EC2 (see
+   [`browser-visit-sync-server/README.md`](../browser-visit-sync-server/README.md)).
+2. Mint a client cert for this laptop, signed by the same CA the
+   server trusts.  Drop `client.crt`, `client.key`, and
+   `server-ca.crt` into `~/.browser-visit-logger/tls/` (mode 0600).
+3. Run [`browser-visit-tools/install_laptop.sh`](../browser-visit-tools/install_laptop.sh).
+   It removes the legacy verifier LaunchAgent (verification lives on
+   the VM now), re-runs the upstream `install.sh`, and writes
+   `~/.browser-visit-logger/config.json` with this laptop's
+   `machine_id` (derived from `scutil --get LocalHostName`) and the
+   sync-server endpoint.
+4. On the VM, enroll the laptop:
+   ```
+   python3 enroll_machine.py --db enrolled_machines.db \
+     --machine-id <id-printed-by-install_laptop.sh> --cert client.crt
+   ```
+5. (Optional) migrate the historical iCloud snapshot archive into
+   Google Drive with
+   [`browser-visit-tools/migrate_icloud_to_gdrive.py`](../browser-visit-tools/migrate_icloud_to_gdrive.py).
+6. Trigger any Chrome → extension interaction.  The Swift host
+   responds to Chrome, then fork-detaches `sync_client.py`; the
+   first run pushes any backlog and pulls peer history.
+
+**How sync runs:**
+
+`BVLHost` (the Chrome native-messaging host) checks for
+`~/.browser-visit-logger/config.json` right after writing its
+response to Chrome.  If present, it `/bin/sh -c 'nohup python3
+sync_client.py … &'` — fork+detach so Chrome isn't blocked on the
+network round-trip.  `sync_client.py` itself:
+
+1. Acquires `~/.browser-visit-logger/sync.lock` (flock) — drops out
+   immediately if another sync is already running.
+2. Reads `sync_state.last_sync_attempt_at` for this machine_id;
+   skips if within `BVL_SYNC_INTERVAL_SECONDS` (default 60).
+3. Bumps `last_sync_attempt_at`.
+4. Walks local log files past the self cursor and `PushLogs` them
+   to the server in batches of 500 lines.  Advances the self cursor
+   on each ack.
+5. Sends every `sync_state` row to the server as a `PeerCursor`;
+   server streams every peer's lines past those cursors.  For each
+   returned chunk: append to `~/browser-visits-peers/<peer>/…log`
+   and replay into the local DB via the same code path BVLHost uses
+   for local events.  Bump each peer's cursor.
+6. Records failures into `mover_errors` keyed by `(sync_push |
+   sync_pull | sync_handshake, <endpoint>)` so the existing
+   threshold-based escalation (Notification Center via the verifier
+   pattern) surfaces persistent breakage to the user.
+
+**What the laptop side no longer does in multi-laptop mode:**
+
+- The `snapshot_verifier` LaunchAgent is not installed (and
+  `install_laptop.sh` removes any leftover from a single-laptop
+  install).  Sealing, manifest verification, and cross-day
+  reconciliation all run on the VM now.
+- The synchronous archive in `BVLHost`'s tag path still moves
+  files from `~/Downloads/browser-visit-snapshots/` to the archive
+  dir — but the archive dir defaults to a Google Drive mount path
+  instead of iCloud Documents.  Drive sync ferries the files to
+  the VM.
+
+**Falling back to single-laptop mode:**
+
+Delete `~/.browser-visit-logger/config.json`.  `BVLHost` will skip
+the sync spawn immediately on its next invocation.  The local DB +
+local logs + local snapshot archive are unchanged and remain
+authoritative.
+
+---
+
 ## When something goes wrong
 
 Both `host.py` (synchronous archive at tag time) and the verifier
@@ -682,29 +786,65 @@ env vars; env vars override defaults.
 | `BVL_VERIFIER_LOG` | `~/browser-visits-verifier.log` | reset (verifier writes via LaunchAgent stdout/stderr) |
 | `BVL_DB_FILE` | `~/browser-visits.db` | host, verifier, sealer, rebuilder, reset |
 | `BVL_DOWNLOADS_SNAPSHOTS_DIR` | `~/Downloads/browser-visit-snapshots` | host (synchronous archive source), verifier (sweep source), reset |
-| `BVL_ICLOUD_SNAPSHOTS_DIR` | `~/Documents/browser-visit-logger/snapshots` | host, verifier, sealer, rebuilder |
+| `BVL_GDRIVE_SNAPSHOTS_DIR` | `~/Library/CloudStorage/GoogleDrive/My Drive/browser-visit-logger/snapshots` | host (multi-laptop archive destination); preferred over the legacy name below |
+| `BVL_ICLOUD_SNAPSHOTS_DIR` | (same default as above, when `BVL_GDRIVE_SNAPSHOTS_DIR` unset) | host, verifier, sealer, rebuilder — alias retained for backwards compat |
 | `BVL_MOVER_MIN_AGE_SECONDS` | `60` | verifier (sweep age threshold) |
-| `BVL_MOVER_ERROR_THRESHOLD` | `3` | verifier (consecutive failures before persistent-error notification) |
+| `BVL_MOVER_ERROR_THRESHOLD` | `3` | verifier + sync_client (consecutive failures before persistent-error notification) |
+| `BVL_CONFIG_DIR` | `~/.browser-visit-logger` | host, sync_client (machine config + mTLS dir) |
+| `BVL_PEER_LOGS_DIR` | `~/browser-visits-peers` | sync_client (local mirror of pulled peer logs) |
+| `BVL_SYNC_SERVER` | (from `config.json`) | sync_client (override the configured endpoint) |
+| `BVL_SYNC_INTERVAL_SECONDS` | `60` | sync_client (debounce — minimum gap between successive sync attempts) |
+| `BVL_MACHINE_ID` | (from `config.json`) | host, sync_client (override the sanitised hostname; mainly for tests + recovery) |
+| `BVL_SYNC_CLIENT_SCRIPT` | (bundled path, else dev fallback) | host (path to `sync_client.py`; override for tests) |
+| `BVL_PYTHON` | `python3` | host (interpreter used to spawn `sync_client.py`) |
 
 ---
 
 ## Development
 
-```bash
-# Python tests (host, mover, sealer)
-pip install -r requirements-test.txt
-python3 -m pytest tests/ -v
+A `Makefile` wraps the test suites.  The Python target builds a
+throwaway virtualenv under `.venv-test/` on first run (gitignored) and
+installs `requirements-test.txt` into it, so the host's system Python
+is never touched:
 
-# Coverage report
-python3 -m pytest tests/ --cov=native-host --cov-report=term-missing
+```bash
+# Python tests (host, mover, sealer, sync_client) — venv auto-created,
+# gated at 100% line coverage (--cov-fail-under=100)
+make test-py
 
 # JS tests (background, popup) with coverage
-npm install
-npm test -- --coverage
+make test-js
+
+# Both
+make test
+
+# Build the Swift release binaries (needed by the shell wrappers and
+# the Swift-dependent paths); there is no XCTest target — see below
+make swift
 ```
 
-The full suite is 165 Python + 115 JS tests, with 100% line/branch
-coverage on every shipped module.
+The full suite is **225 Python + 131 JS tests, 100% line/branch
+coverage** on every shipped module (including `sync_client.py`).  Each
+Makefile Python target enforces the 100% floor, so a coverage
+regression fails the build.
+
+**Test isolation / production-data safety.** Tests never read or write
+real user data.  Every test routes its file/DB I/O to a temp dir
+(`tmp_path` / `tempfile`), and `tests/conftest.py` additionally forces
+all `BVL_*` paths to a throwaway sandbox *before* any module import —
+so even a test that forgets to isolate falls back to the sandbox, never
+`~`.  (`setdefault` is used, so an intentionally exported `BVL_*` value
+still wins.)
+
+> **macOS note:** this Python build redirects bytecode caching via
+> `sys.pycache_prefix` to `~/Library/Caches/com.apple.python/`.  If you
+> ever hand-edit a `native-host/*.py` and see a stale result, clear that
+> cache dir — `__pycache__` won't be next to the source.
+
+There is no Swift unit-test target (XCTest isn't available with the
+standalone Command Line Tools).  The Swift code paths are covered
+indirectly by the Python suite (same DB schema + on-disk artifacts) and
+by `install.sh`'s end-to-end native-messaging smoke test.
 
 ### Project layout
 
@@ -727,17 +867,20 @@ browser-visit-logger/
 │   ├── snapshot_mover.py                   # Seal / orphan-merge helpers used by sealer
 │   ├── snapshot_sealer.py                  # Manual sealer CLI (Python)
 │   ├── visits_rebuilder.py                 # DB rebuilder (log replay + FS rehydrate)
+│   ├── sync_client.py                      # Multi-laptop sync subprocess (gRPC push/pull)
 │   ├── com.browser.visit.logger.json       # Chrome native-messaging manifest template
 │   └── com.browser.visit.logger.snapshot_verifier.plist.template
-├── tests/                                  # Python (pytest) + JS (jest)
+├── tests/                                  # Python (pytest) + JS (jest); conftest.py sandboxes BVL_* paths
 ├── install.sh                              # Builds Swift binaries, materializes & signs .app bundles
+├── Makefile                                # test-py / test-js / test / swift / venv targets
 ├── reset.py
 ├── seal_snapshot_directory                 # Bash wrapper → snapshot_sealer.py
 ├── verify_snapshot_directory               # Bash wrapper → swift/.build/release/BVLVerifier
 ├── reset_visits_data                       # Bash wrapper → reset.py
 ├── rebuild_visits_data                     # Bash wrapper → visits_rebuilder.py
 ├── package.json                            # JS test deps + jest config
-└── requirements-test.txt                   # Python test deps
+├── requirements-test.txt                   # Python test deps
+└── .venv-test/                             # test virtualenv (gitignored, auto-created by `make test-py`)
 ```
 
 On macOS, `install.sh` additionally materializes:

--- a/browser-visit-logger/native-host/sync_client.py
+++ b/browser-visit-logger/native-host/sync_client.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""
+sync_client.py — One-shot sync subprocess for a laptop.
+
+Spawned (detached) by BVLHost after it finishes responding to Chrome.
+Two RPCs to the EC2 sync-server:
+
+  1. PushLogs — every local log line past the self-cursor.
+  2. PullLogs — every peer log line past each peer-cursor.
+
+Cursor state lives in the `sync_state` table of ``~/browser-visits.db``;
+peer log mirrors land under ``~/browser-visits-peers/<peer>/``.
+
+This file is the laptop-side companion to ``browser-visit-sync-server/``.
+Authentication is mTLS (or insecure for local dev).
+
+Concurrency: a flock on ``~/.browser-visit-logger/sync.lock`` prevents
+overlapping invocations.
+
+Error surfacing: failures are recorded in the existing ``mover_errors``
+table with ``operation IN ('sync_push','sync_pull','sync_handshake')``.
+The existing escalation pattern (BVL_MOVER_ERROR_THRESHOLD →
+NotificationCenter via the host's Notify path) handles user-visible
+alerts; this script just upserts the rows.
+
+This module is intentionally importable but normally invoked via
+``python3 -m browser_visit_logger.sync_client`` (see __main__ at bottom).
+"""
+
+import argparse
+import datetime
+import errno
+import fcntl
+import json
+import logging
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+
+HOME = os.path.expanduser('~')
+CONFIG_DIR = os.environ.get('BVL_CONFIG_DIR', os.path.join(HOME, '.browser-visit-logger'))
+CONFIG_FILE = os.path.join(CONFIG_DIR, 'config.json')
+DB_FILE = os.environ.get('BVL_DB_FILE', os.path.join(HOME, 'browser-visits.db'))
+LOG_DIR = os.environ.get('BVL_LOG_DIR', HOME)
+PEER_LOGS_DIR = os.environ.get('BVL_PEER_LOGS_DIR',
+                               os.path.join(HOME, 'browser-visits-peers'))
+LOCK_FILE = os.path.join(CONFIG_DIR, 'sync.lock')
+TLS_DIR = os.path.join(CONFIG_DIR, 'tls')
+SYNC_INTERVAL_SECONDS = int(os.environ.get('BVL_SYNC_INTERVAL_SECONDS', '60'))
+
+
+log = logging.getLogger('bvl.sync')
+
+
+# ----------------------------------------------------------------- config
+
+def load_config() -> dict:
+    try:
+        with open(CONFIG_FILE) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+
+
+def machine_id_from_config() -> Optional[str]:
+    env = os.environ.get('BVL_MACHINE_ID')
+    if env:
+        return env
+    return load_config().get('machine_id')
+
+
+def server_endpoint() -> Optional[str]:
+    return os.environ.get('BVL_SYNC_SERVER') or load_config().get('sync_server')
+
+
+# ----------------------------------------------------------------- db
+
+def open_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_FILE)
+    # The visits / event tables are normally created by BVLHost before
+    # sync ever runs, but ensure them here too so sync_client is
+    # self-contained (e.g. a sync triggered before the first tag, or a
+    # standalone test).  All idempotent.
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS visits (
+            url         TEXT PRIMARY KEY,
+            timestamp   TEXT NOT NULL,
+            title       TEXT NOT NULL DEFAULT '',
+            of_interest TEXT,
+            read        INTEGER NOT NULL DEFAULT 0,
+            skimmed     INTEGER NOT NULL DEFAULT 0
+        )
+    """)
+    for tbl in ('read_events', 'skimmed_events'):
+        conn.execute(f"""
+            CREATE TABLE IF NOT EXISTS {tbl} (
+                url       TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                filename  TEXT NOT NULL DEFAULT '',
+                directory TEXT NOT NULL DEFAULT '',
+                PRIMARY KEY (url, timestamp)
+            )
+        """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS sync_state (
+            machine_id            TEXT PRIMARY KEY,
+            cursor_log_date       TEXT NOT NULL DEFAULT '',
+            cursor_line_offset    INTEGER NOT NULL DEFAULT 0,
+            last_sync_attempt_at  TEXT NOT NULL DEFAULT '',
+            last_sync_success_at  TEXT NOT NULL DEFAULT '',
+            last_error            TEXT NOT NULL DEFAULT ''
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS mover_errors (
+            key        TEXT PRIMARY KEY,
+            operation  TEXT NOT NULL,
+            target     TEXT NOT NULL,
+            message    TEXT NOT NULL,
+            first_seen TEXT NOT NULL,
+            last_seen  TEXT NOT NULL,
+            attempts   INTEGER NOT NULL DEFAULT 1,
+            notified   INTEGER NOT NULL DEFAULT 0,
+            immediate  INTEGER NOT NULL DEFAULT 0
+        )
+    """)
+    return conn
+
+
+def get_cursor(conn, machine_id: str) -> Tuple[str, int]:
+    row = conn.execute(
+        "SELECT cursor_log_date, cursor_line_offset FROM sync_state "
+        "WHERE machine_id = ?", (machine_id,)).fetchone()
+    if row is None:
+        return '', -1
+    # cursor_line_offset is NOT NULL, so row[1] is always an int here.
+    return row[0] or '', row[1]
+
+
+def set_cursor(conn, machine_id: str, date: str, offset: int) -> None:
+    conn.execute("""
+        INSERT INTO sync_state (machine_id, cursor_log_date, cursor_line_offset, last_sync_success_at)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT(machine_id) DO UPDATE SET
+            cursor_log_date = excluded.cursor_log_date,
+            cursor_line_offset = excluded.cursor_line_offset,
+            last_sync_success_at = excluded.last_sync_success_at
+    """, (machine_id, date, offset, _now_iso()))
+
+
+def mark_attempt(conn, machine_id: str, error: Optional[str]) -> None:
+    conn.execute("""
+        INSERT INTO sync_state (machine_id, last_sync_attempt_at, last_error)
+        VALUES (?, ?, ?)
+        ON CONFLICT(machine_id) DO UPDATE SET
+            last_sync_attempt_at = excluded.last_sync_attempt_at,
+            last_error = excluded.last_error
+    """, (machine_id, _now_iso(), error or ''))
+
+
+def should_skip(conn, machine_id: str) -> bool:
+    row = conn.execute(
+        "SELECT last_sync_attempt_at FROM sync_state WHERE machine_id = ?",
+        (machine_id,)).fetchone()
+    if not row or not row[0]:
+        return False
+    try:
+        last = datetime.datetime.fromisoformat(row[0])
+    except ValueError:
+        return False
+    delta = datetime.datetime.now(datetime.timezone.utc) - last
+    return delta.total_seconds() < SYNC_INTERVAL_SECONDS
+
+
+def record_error(conn, operation: str, target: str, message: str,
+                 immediate: bool = False) -> None:
+    key = f"{operation}|{target}"
+    now = _now_iso()
+    conn.execute("""
+        INSERT INTO mover_errors (key, operation, target, message, first_seen, last_seen, attempts, immediate)
+        VALUES (?, ?, ?, ?, ?, ?, 1, ?)
+        ON CONFLICT(key) DO UPDATE SET
+            message = excluded.message,
+            last_seen = excluded.last_seen,
+            attempts = mover_errors.attempts + 1,
+            immediate = MAX(mover_errors.immediate, excluded.immediate)
+    """, (key, operation, target, message, now, now, 1 if immediate else 0))
+
+
+def clear_error(conn, operation: str, target: str) -> None:
+    conn.execute("DELETE FROM mover_errors WHERE key = ?",
+                 (f"{operation}|{target}",))
+
+
+# ----------------------------------------------------------------- logs
+
+_LOG_RE = __import__('re').compile(r'^browser-visits-(\d{4}-\d{2}-\d{2})\.log$')
+
+
+def list_local_log_dates() -> List[str]:
+    if not os.path.isdir(LOG_DIR):
+        return []
+    out = []
+    for name in os.listdir(LOG_DIR):
+        m = _LOG_RE.match(name)
+        if m:
+            out.append(m.group(1))
+    out.sort()
+    return out
+
+
+def read_log_lines_after(date: str, after_offset: int) -> Iterable[Tuple[int, str]]:
+    path = os.path.join(LOG_DIR, f'browser-visits-{date}.log')
+    if not os.path.isfile(path):
+        return
+    with open(path, encoding='utf-8') as f:
+        for i, raw in enumerate(f):
+            if i <= after_offset:
+                continue
+            yield i, raw.rstrip('\n')
+
+
+def append_peer_line(peer: str, date: str, raw: str) -> None:
+    d = os.path.join(PEER_LOGS_DIR, peer)
+    os.makedirs(d, exist_ok=True)
+    path = os.path.join(d, f'browser-visits-{date}.log')
+    with open(path, 'a', encoding='utf-8') as f:
+        f.write(raw + '\n')
+
+
+# ----------------------------------------------------------------- replay
+
+def replay_into_db(conn, raw: str) -> None:
+    """Apply one TSV log line to the local DB. Mirrors visits_rebuilder.py."""
+    fields = raw.split('\t')
+    if len(fields) == 2:
+        return  # result line — ignore
+    if len(fields) < 4:
+        return
+    _record_id, timestamp, url, title = fields[0], fields[1], fields[2], fields[3]
+    conn.execute(
+        "INSERT OR IGNORE INTO visits (url, timestamp, title) VALUES (?, ?, ?)",
+        (url, timestamp, title))
+    if len(fields) == 4:
+        return
+    tag = fields[4]
+    if tag == 'of_interest':
+        conn.execute("UPDATE visits SET of_interest = '1' WHERE url = ?", (url,))
+        return
+    if tag in ('read', 'skimmed') and len(fields) >= 6:
+        filename = fields[5]
+        events_table = f'{tag}_events'
+        conn.execute(
+            f"INSERT OR IGNORE INTO {events_table} (url, timestamp, filename) VALUES (?, ?, ?)",
+            (url, timestamp, filename))
+        conn.execute(f"UPDATE visits SET {tag} = {tag} + 1 WHERE url = ?", (url,))
+
+
+# ----------------------------------------------------------------- grpc
+
+def _load_stubs():
+    here = os.path.dirname(os.path.abspath(__file__))
+    gen = os.path.normpath(os.path.join(
+        here, '..', '..', 'browser-visit-sync-server', 'gen', 'syncpb_py'))
+    if gen not in sys.path:
+        sys.path.insert(0, gen)
+    import importlib
+    try:
+        sync_pb2 = importlib.import_module('sync_pb2')
+        sync_pb2_grpc = importlib.import_module('sync_pb2_grpc')
+        import grpc
+    except ImportError as e:
+        raise RuntimeError(
+            f"grpc stubs not available: {e}. Run `make proto-py` in browser-visit-sync-server/.")
+    return sync_pb2, sync_pb2_grpc, grpc
+
+
+def build_channel(endpoint: str, insecure: bool):
+    sync_pb2, sync_pb2_grpc, grpc = _load_stubs()
+    if insecure:
+        return grpc.insecure_channel(endpoint), sync_pb2, sync_pb2_grpc
+    cert = Path(TLS_DIR, 'client.crt').read_bytes()
+    key = Path(TLS_DIR, 'client.key').read_bytes()
+    ca = Path(TLS_DIR, 'server-ca.crt').read_bytes()
+    creds = grpc.ssl_channel_credentials(
+        root_certificates=ca, private_key=key, certificate_chain=cert)
+    return grpc.secure_channel(endpoint, creds), sync_pb2, sync_pb2_grpc
+
+
+# ----------------------------------------------------------------- sync
+
+def do_push(conn, channel, sync_pb2, sync_pb2_grpc, machine_id: str, endpoint: str) -> None:
+    stub = sync_pb2_grpc.BrowserVisitSyncStub(channel)
+    cur_date, cur_off = get_cursor(conn, machine_id)
+    local_dates = list_local_log_dates()
+    dates = [d for d in local_dates if d >= cur_date] if cur_date else local_dates
+    pb_lines = []
+    last_date, last_off = cur_date, cur_off
+    for d in dates:
+        start_off = cur_off if d == cur_date else -1
+        for off, raw in read_log_lines_after(d, start_off):
+            pb_lines.append(sync_pb2.LogLine(date=d, line_offset=off, raw_line=raw))
+            last_date, last_off = d, off
+            if len(pb_lines) >= 500:
+                _send_push(stub, sync_pb2, machine_id, pb_lines, endpoint, conn)
+                pb_lines = []
+    if pb_lines:
+        _send_push(stub, sync_pb2, machine_id, pb_lines, endpoint, conn)
+    if (last_date, last_off) != (cur_date, cur_off):
+        set_cursor(conn, machine_id, last_date, last_off)
+
+
+def _send_push(stub, sync_pb2, machine_id, pb_lines, endpoint, conn):
+    req = sync_pb2.PushLogsRequest(machine_id=machine_id, lines=pb_lines)
+    try:
+        stub.PushLogs(req, timeout=30)
+        clear_error(conn, 'sync_push', endpoint)
+    except Exception as e:
+        record_error(conn, 'sync_push', endpoint, str(e),
+                     immediate=_is_auth_error(e))
+        raise
+
+
+def do_pull(conn, channel, sync_pb2, sync_pb2_grpc, machine_id: str, endpoint: str) -> None:
+    stub = sync_pb2_grpc.BrowserVisitSyncStub(channel)
+    cursors = []
+    for row in conn.execute(
+            "SELECT machine_id, cursor_log_date, cursor_line_offset FROM sync_state"):
+        cursors.append(sync_pb2.PeerCursor(
+            peer_machine_id=row[0], date=row[1] or '',
+            line_offset=row[2] if row[2] is not None else -1))
+    req = sync_pb2.PullLogsRequest(machine_id=machine_id, cursors=cursors)
+    try:
+        for chunk in stub.PullLogs(req, timeout=120):
+            peer = chunk.peer_machine_id
+            last_date, last_off = get_cursor(conn, peer)
+            for line in chunk.lines:
+                append_peer_line(peer, line.date, line.raw_line)
+                replay_into_db(conn, line.raw_line)
+                last_date, last_off = line.date, line.line_offset
+            set_cursor(conn, peer, last_date, last_off)
+        clear_error(conn, 'sync_pull', endpoint)
+    except Exception as e:
+        record_error(conn, 'sync_pull', endpoint, str(e),
+                     immediate=_is_auth_error(e))
+        raise
+
+
+def _is_auth_error(e: Exception) -> bool:
+    s = str(e).lower()
+    return 'unauthenticated' in s or 'permission_denied' in s or 'certificate' in s
+
+
+# ----------------------------------------------------------------- lock
+
+class FileLock:
+    def __init__(self, path: str):
+        self.path = path
+        self.fd = None
+
+    def __enter__(self):
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        self.fd = os.open(self.path, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(self.fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as e:
+            os.close(self.fd)
+            self.fd = None
+            if e.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
+                raise SystemExit(0)  # another sync is already running
+            raise
+        return self
+
+    def __exit__(self, *args):
+        if self.fd is not None:
+            fcntl.flock(self.fd, fcntl.LOCK_UN)
+            os.close(self.fd)
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+# ----------------------------------------------------------------- main
+
+def main(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--insecure', action='store_true',
+                        help='disable TLS (local dev only)')
+    parser.add_argument('--force', action='store_true',
+                        help='skip the SYNC_INTERVAL_SECONDS debounce')
+    parser.add_argument('--server',
+                        help='override sync server endpoint (host:port)')
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO,
+                        format='%(asctime)s sync_client %(levelname)s %(message)s')
+
+    machine_id = machine_id_from_config()
+    if not machine_id:
+        log.error("no machine_id configured; run install_laptop.sh first")
+        return 2
+    endpoint = args.server or server_endpoint()
+    if not endpoint:
+        log.info("no sync_server configured; nothing to do")
+        return 0
+
+    with FileLock(LOCK_FILE):
+        conn = open_db()
+        try:
+            if not args.force and should_skip(conn, machine_id):
+                log.info("last sync attempt was < %ds ago; skipping",
+                         SYNC_INTERVAL_SECONDS)
+                return 0
+            mark_attempt(conn, machine_id, error=None)
+            conn.commit()
+
+            try:
+                channel, sync_pb2, sync_pb2_grpc = build_channel(
+                    endpoint, args.insecure)
+            except Exception as e:
+                mark_attempt(conn, machine_id, error=str(e))
+                record_error(conn, 'sync_handshake', endpoint, str(e),
+                             immediate=True)
+                conn.commit()
+                log.error("handshake failed: %s", e)
+                return 1
+
+            try:
+                do_push(conn, channel, sync_pb2, sync_pb2_grpc,
+                        machine_id, endpoint)
+                conn.commit()
+                do_pull(conn, channel, sync_pb2, sync_pb2_grpc,
+                        machine_id, endpoint)
+                conn.commit()
+                mark_attempt(conn, machine_id, error=None)
+                conn.commit()
+                log.info("sync ok")
+            except Exception as e:
+                mark_attempt(conn, machine_id, error=str(e))
+                conn.commit()
+                log.error("sync failed: %s", e)
+                return 1
+        finally:
+            conn.close()
+    return 0
+
+
+if __name__ == '__main__':  # pragma: no cover
+    sys.exit(main(sys.argv[1:]))

--- a/browser-visit-logger/schema.sql
+++ b/browser-visit-logger/schema.sql
@@ -60,3 +60,20 @@ CREATE TABLE IF NOT EXISTS mover_errors (
     notified   INTEGER NOT NULL DEFAULT 0,
     immediate  INTEGER NOT NULL DEFAULT 0
 );
+
+-- Per-peer sync cursors. One row per laptop the VM has told us about
+-- (including this laptop). The cursor is the high-water mark of log
+-- records produced by machine_id that this laptop has confirmed are
+-- present at the VM:
+--   * Row whose machine_id == our own: how far through our local log
+--     we've successfully pushed and the VM has acked.
+--   * Other rows: how far through that peer's log we've pulled and
+--     applied locally.
+CREATE TABLE IF NOT EXISTS sync_state (
+    machine_id            TEXT PRIMARY KEY,
+    cursor_log_date       TEXT NOT NULL DEFAULT '',
+    cursor_line_offset    INTEGER NOT NULL DEFAULT 0,
+    last_sync_attempt_at  TEXT NOT NULL DEFAULT '',
+    last_sync_success_at  TEXT NOT NULL DEFAULT '',
+    last_error            TEXT NOT NULL DEFAULT ''
+);

--- a/browser-visit-logger/swift/Sources/BVLCore/Paths.swift
+++ b/browser-visit-logger/swift/Sources/BVLCore/Paths.swift
@@ -35,18 +35,132 @@ public enum Paths {
                 .appendingPathComponent("Downloads/browser-visit-snapshots"))
     }
 
-    public static var icloudSnapshotsDir: String {
-        env("BVL_ICLOUD_SNAPSHOTS_DIR",
-            (home as NSString)
-                .appendingPathComponent("Documents/browser-visit-logger/snapshots"))
+    /// Archive root for read/skimmed snapshots.  Historically this
+    /// pointed at an iCloud-backed Documents subdir; the multi-laptop
+    /// architecture moves it to a Google Drive folder accessible from
+    /// both the laptops and the EC2 VM.  `BVL_GDRIVE_SNAPSHOTS_DIR` is
+    /// the preferred env var; `BVL_ICLOUD_SNAPSHOTS_DIR` is honored as
+    /// an alias for backwards compatibility with existing installs and
+    /// tests.
+    public static var archiveSnapshotsDir: String {
+        if let v = ProcessInfo.processInfo.environment["BVL_GDRIVE_SNAPSHOTS_DIR"] {
+            return v
+        }
+        if let v = ProcessInfo.processInfo.environment["BVL_ICLOUD_SNAPSHOTS_DIR"] {
+            return v
+        }
+        return (home as NSString).appendingPathComponent(
+            "Library/CloudStorage/GoogleDrive/My Drive/browser-visit-logger/snapshots")
     }
+
+    /// Deprecated alias; new code should call `archiveSnapshotsDir`.
+    /// Retained because external Swift callers may still reference it
+    /// during the transition.
+    public static var icloudSnapshotsDir: String { archiveSnapshotsDir }
 
     public static var moverErrorThreshold: Int {
         Int(env("BVL_MOVER_ERROR_THRESHOLD", "3")) ?? 3
     }
 
+    /// Per-laptop config directory (machine ID, mTLS cert/key, sync
+    /// endpoint config).  Kept out of `home` directly so it survives
+    /// reinstalls and is easy to back up.
+    public static var configDir: String {
+        env("BVL_CONFIG_DIR",
+            (home as NSString).appendingPathComponent(".browser-visit-logger"))
+    }
+
+    /// JSON file holding the laptop's machine identity (first observed
+    /// hostname, ISO timestamp it was assigned).  Touched once at first
+    /// run, read every invocation.
+    public static var machineConfigFile: String {
+        (configDir as NSString).appendingPathComponent("config.json")
+    }
+
+    /// Local mirror of peer machines' log files, populated by BVLSync
+    /// on pull.  Mirrors the VM's `<vm-log-root>/<machine_id>/` layout.
+    public static var peerLogsDir: String {
+        env("BVL_PEER_LOGS_DIR",
+            (home as NSString).appendingPathComponent("browser-visits-peers"))
+    }
+
+    /// Machine identifier embedded in this laptop's log filenames and
+    /// sent on every gRPC sync RPC.  Resolution order:
+    ///   1. `BVL_MACHINE_ID` env var (for tests + recovery).
+    ///   2. `machine_id` field in `machineConfigFile`.
+    ///   3. macOS `LocalHostName` (sanitised), persisted to the config
+    ///      file on first run.
+    public static func machineId() -> String {
+        if let env = ProcessInfo.processInfo.environment["BVL_MACHINE_ID"],
+           !env.isEmpty {
+            return sanitiseMachineId(env)
+        }
+        if let fromConfig = readMachineIdFromConfig() {
+            return fromConfig
+        }
+        let host = currentHostName()
+        let sanitised = sanitiseMachineId(host)
+        // Persist on first observation so a later rename doesn't split
+        // identity.  Failure to persist is non-fatal — we'll re-derive
+        // from hostname next time, and the user will see a warning in
+        // the host log if hostnames diverge.
+        try? persistMachineId(sanitised)
+        return sanitised
+    }
+
+    private static func currentHostName() -> String {
+        // ProcessInfo.processInfo.hostName has been observed to return
+        // ".local"-suffixed values that depend on DHCP; LocalHostName
+        // via Host.current() is the user-visible Sharing name.  Fall
+        // back to gethostname if both are empty.
+        let names = Host.current().localizedName ?? Host.current().name ?? ""
+        if !names.isEmpty {
+            return names
+        }
+        let info = ProcessInfo.processInfo.hostName
+        if !info.isEmpty { return info }
+        return "unknown-host"
+    }
+
+    private static func sanitiseMachineId(_ raw: String) -> String {
+        let allowed = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-")
+        let mapped = raw.map { allowed.contains($0) ? $0 : "-" }
+        let collapsed = String(mapped).replacingOccurrences(
+            of: "--", with: "-", options: .regularExpression)
+        let trimmed = collapsed.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        return trimmed.isEmpty ? "unknown-host" : trimmed
+    }
+
+    private static func readMachineIdFromConfig() -> String? {
+        let path = machineConfigFile
+        guard let data = FileManager.default.contents(atPath: path) else {
+            return nil
+        }
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let id = obj["machine_id"] as? String,
+              !id.isEmpty
+        else { return nil }
+        return sanitiseMachineId(id)
+    }
+
+    private static func persistMachineId(_ id: String) throws {
+        try FileManager.default.createDirectory(
+            atPath: configDir, withIntermediateDirectories: true)
+        let fm = ISO8601DateFormatter()
+        let payload: [String: Any] = [
+            "machine_id": id,
+            "assigned_at": fm.string(from: Date()),
+        ]
+        let data = try JSONSerialization.data(
+            withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: URL(fileURLWithPath: machineConfigFile))
+    }
+
     /// Per-day visit log filename for a UTC date, e.g.
-    /// "browser-visits-2026-04-30.log".
+    /// "browser-visits-2026-04-30.log".  The laptop's own logs keep
+    /// the historical (unprefixed) filename because the machine ID is
+    /// implicit on disk.  Cross-machine storage (VM mirror, local peer
+    /// mirror) encodes the machine ID in the parent directory instead.
     public static func logFilename(for dateISO: String) -> String {
         "browser-visits-\(dateISO).log"
     }
@@ -54,6 +168,14 @@ public enum Paths {
     /// Absolute path of the per-day visit log inside `logDir`.
     public static func logPath(for dateISO: String) -> String {
         (logDir as NSString).appendingPathComponent(logFilename(for: dateISO))
+    }
+
+    /// Absolute path of a peer machine's day log in the local mirror.
+    /// Layout matches the VM side: `<peerLogsDir>/<machine_id>/<filename>`.
+    public static func peerLogPath(machineId: String, dateISO: String) -> String {
+        let mid = sanitiseMachineId(machineId)
+        let dir = (peerLogsDir as NSString).appendingPathComponent(mid)
+        return (dir as NSString).appendingPathComponent(logFilename(for: dateISO))
     }
 
     /// Marker file written when we can't reach Notification Center.

--- a/browser-visit-logger/swift/Sources/BVLCore/Schema.swift
+++ b/browser-visit-logger/swift/Sources/BVLCore/Schema.swift
@@ -45,6 +45,22 @@ public enum Schema {
         """)
     }
 
+    /// Create the sync_state table if absent.  One row per laptop the
+    /// VM has told us about (including this laptop).  See schema.sql
+    /// for column semantics.
+    public static func ensureSyncStateTable(_ db: Database) throws {
+        try db.execute("""
+            CREATE TABLE IF NOT EXISTS sync_state (
+                machine_id            TEXT PRIMARY KEY,
+                cursor_log_date       TEXT NOT NULL DEFAULT '',
+                cursor_line_offset    INTEGER NOT NULL DEFAULT 0,
+                last_sync_attempt_at  TEXT NOT NULL DEFAULT '',
+                last_sync_success_at  TEXT NOT NULL DEFAULT '',
+                last_error            TEXT NOT NULL DEFAULT ''
+            )
+        """)
+    }
+
     /// Create the mover_errors table if absent.
     public static func ensureMoverErrorsTable(_ db: Database) throws {
         try db.execute("""

--- a/browser-visit-logger/swift/Sources/BVLHost/main.swift
+++ b/browser-visit-logger/swift/Sources/BVLHost/main.swift
@@ -77,6 +77,61 @@ func recordToDict(_ record: VisitRecord) -> [String: Any] {
 
 let validTags: Set<String> = ["of_interest", "read", "skimmed"]
 
+// MARK: - sync spawn
+
+/// Opportunistic background sync: if the laptop is configured for the
+/// multi-machine setup, fork a detached `sync_client.py`.  Caller must
+/// invoke this AFTER writing the native-messaging response to stdout
+/// (we don't want to delay Chrome).
+func maybeSpawnSync() {
+    let configPath = Paths.machineConfigFile
+    guard FileManager.default.fileExists(atPath: configPath) else { return }
+
+    let scriptPath: String
+    if let override = ProcessInfo.processInfo.environment["BVL_SYNC_CLIENT_SCRIPT"] {
+        scriptPath = override
+    } else {
+        scriptPath = defaultSyncClientPath()
+    }
+    guard FileManager.default.fileExists(atPath: scriptPath) else {
+        log.debug("sync_client.py not found at \(scriptPath); skipping spawn")
+        return
+    }
+
+    let python = ProcessInfo.processInfo.environment["BVL_PYTHON"] ?? "python3"
+    let escaped = scriptPath.replacingOccurrences(of: "'", with: "'\\''")
+    let cmd = "nohup \(python) '\(escaped)' >/dev/null 2>&1 &"
+    let proc = Process()
+    proc.launchPath = "/bin/sh"
+    proc.arguments = ["-c", cmd]
+    proc.standardInput = FileHandle.nullDevice
+    proc.standardOutput = FileHandle.nullDevice
+    proc.standardError = FileHandle.nullDevice
+    do {
+        try proc.run()
+        // The `&` inside the /bin/sh backgrounded sync_client.py; this
+        // proc exits quickly on its own.
+    } catch {
+        log.error("Failed to spawn sync_client: \(error)")
+    }
+}
+
+/// Bundle layout (install.sh):
+///   .../BrowserVisitLoggerHost.app/Contents/MacOS/BVLHost
+///   .../BrowserVisitLoggerHost.app/Contents/Resources/native-host/sync_client.py
+func defaultSyncClientPath() -> String {
+    let arg0 = CommandLine.arguments[0]
+    let macosDir = (arg0 as NSString).deletingLastPathComponent
+    let contents = (macosDir as NSString).deletingLastPathComponent
+    let bundleScript = (contents as NSString)
+        .appendingPathComponent("Resources/native-host/sync_client.py")
+    if FileManager.default.fileExists(atPath: bundleScript) {
+        return bundleScript
+    }
+    return (Paths.home as NSString)
+        .appendingPathComponent("projects/browser-visit-logger/native-host/sync_client.py")
+}
+
 // MARK: - Main
 
 let message: [String: Any]
@@ -206,4 +261,10 @@ if errors.isEmpty {
 } else {
     writeError(errors)
 }
+
+// Opportunistic background sync: if the laptop is configured for the
+// multi-machine setup, fork a detached sync_client.py.  Already-sent
+// response means Chrome isn't blocked on this.
+maybeSpawnSync()
+
 exit(0)

--- a/browser-visit-logger/tests/conftest.py
+++ b/browser-visit-logger/tests/conftest.py
@@ -1,19 +1,51 @@
 """
 pytest configuration for browser-visit-logger tests.
 
-Sets BVL_HOST_LOG to a temp path before importing host so the RotatingFileHandler
-(which runs at module-import time) never writes to ~/browser-visits-host.log during
-the test run.  Then adds native-host/ to sys.path so `import host` resolves.
+Production-data safety net
+--------------------------
+Every BVL_* path is forced to a throwaway sandbox directory *before* any
+production module is imported.  The native-host modules read their path
+globals once at import time from ``os.environ.get('BVL_*', <~ default>)``
+— so unless the environment already points elsewhere, those defaults
+resolve to the developer's real home (``~/browser-visits.db`` etc.).
+
+Well-written tests still isolate themselves per-case (tmp_path /
+monkeypatch / unittest.mock).  This net only governs the *fallback*: if a
+test ever forgets to override a path, it lands in the sandbox instead of
+touching real user data.  `setdefault` is used so an intentionally
+exported BVL_* value (e.g. a developer pointing a run somewhere specific)
+still wins.
+
+The sandbox lives under the OS temp dir and is intentionally not cleaned
+up here — it only ever holds stray output from a mis-isolated test, and
+keeping it aids debugging.  It is never `~`.
 """
 import os
 import sys
 import tempfile
 from pathlib import Path
 
-# Redirect the host's internal log file away from ~ during tests.
-# Must be set before `import host` anywhere in the test session.
-_test_host_log = os.path.join(tempfile.gettempdir(), 'bvl-test-host.log')
-os.environ.setdefault('BVL_HOST_LOG', _test_host_log)
+# One sandbox root for the whole session.  Subdirs are pre-created for
+# the dir-typed vars so code that appends without mkdir still works.
+_SANDBOX = tempfile.mkdtemp(prefix='bvl-test-sandbox-')
+
+
+def _sub(name: str) -> str:
+    p = os.path.join(_SANDBOX, name)
+    os.makedirs(p, exist_ok=True)
+    return p
+
+
+# Must all be set before `import host` / `import snapshot_mover` /
+# `import sync_client` anywhere in the test session.
+os.environ.setdefault('BVL_HOST_LOG', os.path.join(_SANDBOX, 'host.log'))
+os.environ.setdefault('BVL_DB_FILE', os.path.join(_SANDBOX, 'browser-visits.db'))
+os.environ.setdefault('BVL_LOG_DIR', _sub('logs'))
+os.environ.setdefault('BVL_DOWNLOADS_SNAPSHOTS_DIR', _sub('downloads'))
+os.environ.setdefault('BVL_ICLOUD_SNAPSHOTS_DIR', _sub('icloud'))
+os.environ.setdefault('BVL_GDRIVE_SNAPSHOTS_DIR', _sub('gdrive'))
+os.environ.setdefault('BVL_CONFIG_DIR', _sub('config'))
+os.environ.setdefault('BVL_PEER_LOGS_DIR', _sub('peers'))
 
 # Make `import host` work from any test file.
 sys.path.insert(0, str(Path(__file__).parent.parent / 'native-host'))

--- a/browser-visit-logger/tests/test_schema_parity.py
+++ b/browser-visit-logger/tests/test_schema_parity.py
@@ -153,7 +153,7 @@ class TestSchemaParity(unittest.TestCase):
         # schema.sql.  Catches drift where someone adds a new Swift
         # table but forgets schema.sql.
         expected = {'visits', 'read_events', 'skimmed_events',
-                    'snapshots', 'mover_errors'}
+                    'snapshots', 'mover_errors', 'sync_state'}
         self.assertEqual(expected, set(self.sql_schema['tables']))
 
 

--- a/browser-visit-logger/tests/test_snapshot_mover.py
+++ b/browser-visit-logger/tests/test_snapshot_mover.py
@@ -468,6 +468,45 @@ class TestOrphanLogMergePass(_SealHelpersTestBase):
             "SELECT COUNT(*) FROM mover_errors").fetchone()[0]
         self.assertEqual(n, 0)
 
+    def test_non_matching_filename_skipped(self):
+        # Discriminating test: a valid past-day log sits alongside two
+        # non-log files.  The pass must backfill a snapshots row for the
+        # real log (proving it processes valid entries) and ignore the
+        # non-matching files (the regex-miss `continue`).  If the regex
+        # were broadened to match everything, the junk files would error
+        # or produce spurious rows and this would fail.
+        Path(self.log_dir, 'not-a-log.txt').write_text('x', encoding='utf-8')
+        Path(self.log_dir, 'browser-visits-host.log').write_text('x', encoding='utf-8')
+        Path(self.log_dir, snapshot_mover._log_filename_for(self.date)).write_text(
+            'real', encoding='utf-8')
+        with patch.object(snapshot_mover, '_today_utc',
+                          return_value=datetime.date(2099, 1, 1)):
+            snapshot_mover._orphan_log_merge_pass(self.conn)
+        rows = self.conn.execute(
+            "SELECT date FROM snapshots ORDER BY date").fetchall()
+        # Exactly the valid past-day log produced a row; junk ignored.
+        self.assertEqual(rows, [(self.date,)])
+
+    def test_today_and_future_logs_skipped(self):
+        # Discriminating test: a past-day log plus today's and a future
+        # day's log.  Only the past-day log should be backfilled — the
+        # date>=today `continue` skips the others (they're still being
+        # written).  If the comparison were inverted, today/future would
+        # be processed and this assertion would fail.
+        past = self.date  # 2024-01-15, well before the patched today
+        Path(self.log_dir, snapshot_mover._log_filename_for(past)).write_text(
+            'p', encoding='utf-8')
+        for d in ('2099-01-01', '2099-02-02'):  # today and future
+            Path(self.log_dir, snapshot_mover._log_filename_for(d)).write_text(
+                'x', encoding='utf-8')
+        with patch.object(snapshot_mover, '_today_utc',
+                          return_value=datetime.date(2099, 1, 1)):
+            snapshot_mover._orphan_log_merge_pass(self.conn)
+        rows = self.conn.execute(
+            "SELECT date FROM snapshots ORDER BY date").fetchall()
+        # Only the past day was reconciled.
+        self.assertEqual(rows, [(past,)])
+
     def test_race_orphan_appended_into_icloud_log_and_unlinked(self):
         # Set up: an iCloud log file already exists for a past date,
         # AND a fresh orphan with the same date sits in LOG_DIR.  The

--- a/browser-visit-logger/tests/test_snapshot_sealer.py
+++ b/browser-visit-logger/tests/test_snapshot_sealer.py
@@ -31,7 +31,12 @@ class _SealerTestBase(unittest.TestCase):
 
         self.dest_dir = os.path.join(self.tmp.name, 'icloud')
         self.db_file  = os.path.join(self.tmp.name, 'visits.db')
+        # Distinct from any 'logs' dir individual tests create for their
+        # own LOG_DIR patching — this one only exists to keep the
+        # default orphan-merge scan away from the developer's $HOME.
+        self.log_dir  = os.path.join(self.tmp.name, 'home-logs-isolated')
         os.makedirs(self.dest_dir)
+        os.makedirs(self.log_dir)
 
         # Initialize DB schema so sealing has somewhere to look up rows.
         # The snapshots table is owned by snapshot_mover, not host.
@@ -40,12 +45,17 @@ class _SealerTestBase(unittest.TestCase):
         snapshot_mover._ensure_snapshots_table(conn)
         conn.close()
 
-        # Save and later restore snapshot_mover module-level state that the
-        # sealer's CLI mutates (--db / --dest / --verbose).
+        # Save and later restore snapshot_mover module-level state.  The
+        # sealer's CLI mutates DB_FILE / ICLOUD_SNAPSHOTS_DIR (--db /
+        # --dest); LOG_DIR has no CLI flag and defaults to $HOME, so the
+        # orphan-log merge pass would otherwise scan the developer's real
+        # home dir and pull in live `browser-visits-<date>.log` files.
+        # Pin it to an isolated empty dir so seals stay hermetic.
         self._saved = {
             name: getattr(snapshot_mover, name)
-            for name in ('ICLOUD_SNAPSHOTS_DIR', 'DB_FILE')
+            for name in ('ICLOUD_SNAPSHOTS_DIR', 'DB_FILE', 'LOG_DIR')
         }
+        snapshot_mover.LOG_DIR = self.log_dir
         self._saved_log_level = snapshot_mover.logger.level
         self.addCleanup(self._restore)
 

--- a/browser-visit-logger/tests/test_sync_client.py
+++ b/browser-visit-logger/tests/test_sync_client.py
@@ -1,0 +1,539 @@
+"""Unit tests for native-host/sync_client.py (multi-laptop sync subprocess).
+
+The gRPC stubs are faked — no network, no generated protobuf code.
+Module-level path globals are pointed at a temp dir per test.
+"""
+import importlib
+import json
+import os
+import sqlite3
+import sys
+import types
+import datetime
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+NATIVE = os.path.normpath(os.path.join(HERE, '..', 'native-host'))
+if NATIVE not in sys.path:
+    sys.path.insert(0, NATIVE)
+
+import sync_client as sc  # noqa: E402
+
+
+# --------------------------------------------------------------- fixtures
+
+class Msg:
+    """Generic stand-in for a protobuf message: stores kwargs as attrs."""
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+class FakeSyncPb2:
+    LogLine = Msg
+    PushLogsRequest = Msg
+    PeerCursor = Msg
+    PullLogsRequest = Msg
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """Point all module globals at an isolated temp tree + fresh DB."""
+    db = str(tmp_path / 'visits.db')
+    log_dir = str(tmp_path / 'logs')
+    peers = str(tmp_path / 'peers')
+    cfg_dir = str(tmp_path / 'config')
+    os.makedirs(log_dir)
+    os.makedirs(cfg_dir)
+    monkeypatch.setattr(sc, 'DB_FILE', db)
+    monkeypatch.setattr(sc, 'LOG_DIR', log_dir)
+    monkeypatch.setattr(sc, 'PEER_LOGS_DIR', peers)
+    monkeypatch.setattr(sc, 'CONFIG_DIR', cfg_dir)
+    monkeypatch.setattr(sc, 'CONFIG_FILE', os.path.join(cfg_dir, 'config.json'))
+    monkeypatch.setattr(sc, 'LOCK_FILE', os.path.join(cfg_dir, 'sync.lock'))
+    monkeypatch.setattr(sc, 'TLS_DIR', str(tmp_path / 'tls'))
+    monkeypatch.setattr(sc, 'SYNC_INTERVAL_SECONDS', 60)
+    # Clear env that would shadow config lookups.
+    for k in ('BVL_MACHINE_ID', 'BVL_SYNC_SERVER'):
+        monkeypatch.delenv(k, raising=False)
+    return types.SimpleNamespace(
+        db=db, log_dir=log_dir, peers=peers, cfg_dir=cfg_dir, tmp=tmp_path)
+
+
+@pytest.fixture
+def conn(env):
+    c = sc.open_db()
+    yield c
+    c.close()
+
+
+# --------------------------------------------------------------- config
+
+def test_load_config_missing(env):
+    assert sc.load_config() == {}
+
+
+def test_load_config_present(env):
+    with open(sc.CONFIG_FILE, 'w') as f:
+        json.dump({'machine_id': 'm1', 'sync_server': 'h:1'}, f)
+    assert sc.load_config()['machine_id'] == 'm1'
+
+
+def test_machine_id_from_env(env, monkeypatch):
+    monkeypatch.setenv('BVL_MACHINE_ID', 'envid')
+    assert sc.machine_id_from_config() == 'envid'
+
+
+def test_machine_id_from_config_file(env):
+    with open(sc.CONFIG_FILE, 'w') as f:
+        json.dump({'machine_id': 'cfgid'}, f)
+    assert sc.machine_id_from_config() == 'cfgid'
+
+
+def test_machine_id_none(env):
+    assert sc.machine_id_from_config() is None
+
+
+def test_server_endpoint_env(env, monkeypatch):
+    monkeypatch.setenv('BVL_SYNC_SERVER', 'envhost:9')
+    assert sc.server_endpoint() == 'envhost:9'
+
+
+def test_server_endpoint_config(env):
+    with open(sc.CONFIG_FILE, 'w') as f:
+        json.dump({'sync_server': 'cfg:9'}, f)
+    assert sc.server_endpoint() == 'cfg:9'
+
+
+# --------------------------------------------------------------- db helpers
+
+def test_open_db_creates_tables(conn):
+    names = {r[0] for r in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'")}
+    assert {'sync_state', 'mover_errors'} <= names
+
+
+def test_cursor_roundtrip(conn):
+    assert sc.get_cursor(conn, 'm') == ('', -1)
+    sc.set_cursor(conn, 'm', '2026-05-21', 7)
+    assert sc.get_cursor(conn, 'm') == ('2026-05-21', 7)
+    # Update existing row (ON CONFLICT path).
+    sc.set_cursor(conn, 'm', '2026-05-22', 0)
+    assert sc.get_cursor(conn, 'm') == ('2026-05-22', 0)
+
+
+def test_mark_attempt_insert_and_update(conn):
+    sc.mark_attempt(conn, 'm', error=None)
+    row = conn.execute(
+        "SELECT last_error FROM sync_state WHERE machine_id='m'").fetchone()
+    assert row[0] == ''
+    sc.mark_attempt(conn, 'm', error='boom')
+    row = conn.execute(
+        "SELECT last_error FROM sync_state WHERE machine_id='m'").fetchone()
+    assert row[0] == 'boom'
+
+
+def test_should_skip(conn):
+    # No row → don't skip.
+    assert sc.should_skip(conn, 'm') is False
+    # Recent attempt → skip.
+    sc.mark_attempt(conn, 'm', None)
+    assert sc.should_skip(conn, 'm') is True
+
+
+def test_should_skip_old(conn):
+    old = (datetime.datetime.now(datetime.timezone.utc)
+           - datetime.timedelta(seconds=999)).isoformat()
+    conn.execute(
+        "INSERT INTO sync_state (machine_id, last_sync_attempt_at) VALUES ('m', ?)",
+        (old,))
+    assert sc.should_skip(conn, 'm') is False
+
+
+def test_should_skip_empty_timestamp(conn):
+    conn.execute(
+        "INSERT INTO sync_state (machine_id, last_sync_attempt_at) VALUES ('m', '')")
+    assert sc.should_skip(conn, 'm') is False
+
+
+def test_should_skip_bad_timestamp(conn):
+    conn.execute(
+        "INSERT INTO sync_state (machine_id, last_sync_attempt_at) VALUES ('m', 'not-a-date')")
+    assert sc.should_skip(conn, 'm') is False
+
+
+def test_record_and_clear_error(conn):
+    sc.record_error(conn, 'sync_push', 'h:1', 'msg1')
+    row = conn.execute("SELECT attempts, immediate FROM mover_errors").fetchone()
+    assert row == (1, 0)
+    # Second occurrence increments attempts, raises immediate via MAX.
+    sc.record_error(conn, 'sync_push', 'h:1', 'msg2', immediate=True)
+    row = conn.execute("SELECT attempts, immediate, message FROM mover_errors").fetchone()
+    assert row[0] == 2 and row[1] == 1 and row[2] == 'msg2'
+    sc.clear_error(conn, 'sync_push', 'h:1')
+    assert conn.execute("SELECT COUNT(*) FROM mover_errors").fetchone()[0] == 0
+
+
+# --------------------------------------------------------------- logs
+
+def test_list_local_log_dates(env):
+    # No matching files initially.
+    assert sc.list_local_log_dates() == []
+    for name in ('browser-visits-2026-05-21.log',
+                 'browser-visits-2026-05-20.log',
+                 'unrelated.txt'):
+        open(os.path.join(env.log_dir, name), 'w').close()
+    assert sc.list_local_log_dates() == ['2026-05-20', '2026-05-21']
+
+
+def test_list_local_log_dates_missing_dir(env, monkeypatch):
+    monkeypatch.setattr(sc, 'LOG_DIR', str(env.tmp / 'nope'))
+    assert sc.list_local_log_dates() == []
+
+
+def test_read_log_lines_after(env):
+    path = os.path.join(env.log_dir, 'browser-visits-2026-05-21.log')
+    with open(path, 'w') as f:
+        f.write('l0\nl1\nl2\n')
+    got = list(sc.read_log_lines_after('2026-05-21', 0))
+    assert got == [(1, 'l1'), (2, 'l2')]
+
+
+def test_read_log_lines_after_missing(env):
+    assert list(sc.read_log_lines_after('2026-05-21', -1)) == []
+
+
+def test_append_peer_line(env):
+    sc.append_peer_line('peerA', '2026-05-21', 'hello')
+    path = os.path.join(env.peers, 'peerA', 'browser-visits-2026-05-21.log')
+    with open(path) as f:
+        assert f.read() == 'hello\n'
+
+
+# --------------------------------------------------------------- replay
+
+def _visits(conn):
+    return conn.execute("SELECT url, read, skimmed, of_interest FROM visits").fetchall()
+
+
+def test_replay_result_line_ignored(conn):
+    sc.replay_into_db(conn, 'rid\tsuccess')
+    assert _visits(conn) == []
+
+
+def test_replay_too_few_fields(conn):
+    sc.replay_into_db(conn, 'a\tb\tc')  # 3 fields
+    assert _visits(conn) == []
+
+
+def test_replay_basic(conn):
+    sc.replay_into_db(conn, '\t'.join(['rid', 'ts', 'https://x', 'Title']))
+    assert _visits(conn) == [('https://x', 0, 0, None)]
+
+
+def test_replay_of_interest(conn):
+    sc.replay_into_db(conn, '\t'.join(['rid', 'ts', 'https://x', 'T', 'of_interest']))
+    assert _visits(conn)[0][3] == '1'
+
+
+def test_replay_read_and_skimmed(conn):
+    sc.replay_into_db(conn, '\t'.join(['rid', 't1', 'https://x', 'T', 'read', 'a.mhtml']))
+    sc.replay_into_db(conn, '\t'.join(['rid', 't2', 'https://x', 'T', 'skimmed', 'b.mhtml']))
+    row = conn.execute("SELECT read, skimmed FROM visits WHERE url='https://x'").fetchone()
+    assert row == (1, 1)
+
+
+def test_replay_five_fields_unknown_tag(conn):
+    # 5 fields, tag != of_interest → visit inserted, no flag.
+    sc.replay_into_db(conn, '\t'.join(['rid', 'ts', 'https://x', 'T', 'weird']))
+    assert _visits(conn)[0][3] is None
+
+
+# --------------------------------------------------------------- _is_auth_error
+
+@pytest.mark.parametrize('msg,expected', [
+    ('StatusCode.UNAUTHENTICATED', True),
+    ('permission_denied: nope', True),
+    ('bad certificate', True),
+    ('connection refused', False),
+])
+def test_is_auth_error(msg, expected):
+    assert sc._is_auth_error(Exception(msg)) is expected
+
+
+def test_now_iso():
+    assert sc._now_iso().endswith('+00:00')
+
+
+# --------------------------------------------------------------- stubs / channel
+
+def test_load_stubs_failure(env, monkeypatch):
+    # Ensure the fake modules aren't importable → ImportError → RuntimeError.
+    for m in ('sync_pb2', 'sync_pb2_grpc'):
+        monkeypatch.setitem(sys.modules, m, None)
+    with pytest.raises(RuntimeError, match='grpc stubs not available'):
+        sc._load_stubs()
+
+
+def test_load_stubs_success(env, monkeypatch):
+    fake_grpc = types.ModuleType('grpc')
+    monkeypatch.setitem(sys.modules, 'sync_pb2', FakeSyncPb2())
+    monkeypatch.setitem(sys.modules, 'sync_pb2_grpc', types.ModuleType('sync_pb2_grpc'))
+    monkeypatch.setitem(sys.modules, 'grpc', fake_grpc)
+    pb2, pb2_grpc, grpc = sc._load_stubs()
+    assert grpc is fake_grpc
+
+
+def _fake_grpc(monkeypatch):
+    fake = types.ModuleType('grpc')
+    fake.insecure_channel = lambda ep: ('insecure', ep)
+    fake.secure_channel = lambda ep, creds: ('secure', ep, creds)
+    fake.ssl_channel_credentials = lambda **kw: ('creds', kw)
+    return fake
+
+
+def test_build_channel_insecure(env, monkeypatch):
+    fake = _fake_grpc(monkeypatch)
+    monkeypatch.setattr(sc, '_load_stubs', lambda: (FakeSyncPb2(), object(), fake))
+    ch, pb2, pb2_grpc = sc.build_channel('h:1', insecure=True)
+    assert ch == ('insecure', 'h:1')
+
+
+def test_build_channel_secure(env, monkeypatch):
+    fake = _fake_grpc(monkeypatch)
+    monkeypatch.setattr(sc, '_load_stubs', lambda: (FakeSyncPb2(), object(), fake))
+    os.makedirs(sc.TLS_DIR)
+    for fn in ('client.crt', 'client.key', 'server-ca.crt'):
+        with open(os.path.join(sc.TLS_DIR, fn), 'wb') as f:
+            f.write(b'x')
+    ch, _, _ = sc.build_channel('h:1', insecure=False)
+    assert ch[0] == 'secure'
+
+
+# --------------------------------------------------------------- push / pull
+
+class FakeStub:
+    def __init__(self, channel):
+        self.pushes = []
+        self.push_raises = False
+        self.pull_chunks = []
+        self.pull_raises = None
+
+    def PushLogs(self, req, timeout=None):
+        if self.push_raises:
+            raise RuntimeError('push boom')
+        self.pushes.append(req)
+
+    def PullLogs(self, req, timeout=None):
+        if self.pull_raises:
+            raise self.pull_raises
+        return iter(self.pull_chunks)
+
+
+class FakeStubFactory:
+    def __init__(self, stub):
+        self._stub = stub
+
+    def BrowserVisitSyncStub(self, channel):
+        return self._stub
+
+
+def test_do_push_batches_and_sets_cursor(conn, env):
+    # 501 lines forces one mid-loop flush (>=500) plus a final flush.
+    path = os.path.join(env.log_dir, 'browser-visits-2026-05-21.log')
+    with open(path, 'w') as f:
+        for i in range(501):
+            f.write(f'line{i}\n')
+    stub = FakeStub(None)
+    sc.do_push(conn, None, FakeSyncPb2(), FakeStubFactory(stub),
+               'm', 'h:1')
+    # Two PushLogs calls: 500 + 1.
+    assert len(stub.pushes) == 2
+    assert sc.get_cursor(conn, 'm') == ('2026-05-21', 500)
+
+
+def test_do_push_with_existing_cursor(conn, env):
+    path = os.path.join(env.log_dir, 'browser-visits-2026-05-21.log')
+    with open(path, 'w') as f:
+        f.write('l0\nl1\n')
+    sc.set_cursor(conn, 'm', '2026-05-21', 0)  # already pushed l0
+    stub = FakeStub(None)
+    sc.do_push(conn, None, FakeSyncPb2(), FakeStubFactory(stub), 'm', 'h:1')
+    # Only l1 sent.
+    assert len(stub.pushes) == 1
+    assert len(stub.pushes[0].lines) == 1
+    assert sc.get_cursor(conn, 'm') == ('2026-05-21', 1)
+
+
+def test_do_push_nothing_to_send(conn, env):
+    # No logs → no push, cursor unchanged.
+    stub = FakeStub(None)
+    sc.do_push(conn, None, FakeSyncPb2(), FakeStubFactory(stub), 'm', 'h:1')
+    assert stub.pushes == []
+
+
+def test_send_push_records_error_and_raises(conn, env):
+    path = os.path.join(env.log_dir, 'browser-visits-2026-05-21.log')
+    with open(path, 'w') as f:
+        f.write('l0\n')
+    stub = FakeStub(None)
+    stub.push_raises = True
+    with pytest.raises(RuntimeError):
+        sc.do_push(conn, None, FakeSyncPb2(), FakeStubFactory(stub), 'm', 'h:1')
+    n = conn.execute(
+        "SELECT COUNT(*) FROM mover_errors WHERE operation='sync_push'").fetchone()[0]
+    assert n == 1
+
+
+def test_send_push_clears_error_on_success(conn, env):
+    sc.record_error(conn, 'sync_push', 'h:1', 'stale')
+    path = os.path.join(env.log_dir, 'browser-visits-2026-05-21.log')
+    with open(path, 'w') as f:
+        f.write('l0\n')
+    stub = FakeStub(None)
+    sc.do_push(conn, None, FakeSyncPb2(), FakeStubFactory(stub), 'm', 'h:1')
+    assert conn.execute("SELECT COUNT(*) FROM mover_errors").fetchone()[0] == 0
+
+
+def test_do_pull_applies_chunks(conn, env):
+    chunk = Msg(peer_machine_id='peerB', lines=[
+        Msg(date='2026-05-21', line_offset=0,
+            raw_line='\t'.join(['rid', 'ts', 'https://x', 'T'])),
+        Msg(date='2026-05-21', line_offset=1,
+            raw_line='\t'.join(['rid', 't2', 'https://x', 'T', 'read', 'a.mhtml'])),
+    ])
+    stub = FakeStub(None)
+    stub.pull_chunks = [chunk]
+    sc.do_pull(conn, None, FakeSyncPb2(), FakeStubFactory(stub), 'm', 'h:1')
+    # Replayed into DB.
+    row = conn.execute("SELECT read FROM visits WHERE url='https://x'").fetchone()
+    assert row[0] == 1
+    # Peer cursor advanced + mirror written.
+    assert sc.get_cursor(conn, 'peerB') == ('2026-05-21', 1)
+    mirror = os.path.join(env.peers, 'peerB', 'browser-visits-2026-05-21.log')
+    assert os.path.exists(mirror)
+
+
+def test_do_pull_sends_known_cursors(conn, env):
+    sc.set_cursor(conn, 'peerB', '2026-05-21', 3)
+    captured = {}
+    stub = FakeStub(None)
+
+    def pull(req, timeout=None):
+        captured['cursors'] = req.cursors
+        return iter([])
+    stub.PullLogs = pull
+    sc.do_pull(conn, None, FakeSyncPb2(), FakeStubFactory(stub), 'm', 'h:1')
+    assert any(c.peer_machine_id == 'peerB' for c in captured['cursors'])
+
+
+def test_do_pull_records_error(conn, env):
+    stub = FakeStub(None)
+    stub.pull_raises = RuntimeError('pull boom')
+    with pytest.raises(RuntimeError):
+        sc.do_pull(conn, None, FakeSyncPb2(), FakeStubFactory(stub), 'm', 'h:1')
+    n = conn.execute(
+        "SELECT COUNT(*) FROM mover_errors WHERE operation='sync_pull'").fetchone()[0]
+    assert n == 1
+
+
+# --------------------------------------------------------------- FileLock
+
+def test_filelock_acquire_release(env):
+    with sc.FileLock(sc.LOCK_FILE):
+        pass  # acquired + released without error
+
+
+def test_filelock_contended_exits(env):
+    held = sc.FileLock(sc.LOCK_FILE)
+    held.__enter__()
+    try:
+        with pytest.raises(SystemExit):
+            with sc.FileLock(sc.LOCK_FILE):
+                pass
+    finally:
+        held.__exit__()
+
+
+def test_filelock_other_oserror_propagates(env, monkeypatch):
+    import fcntl
+
+    def boom(fd, op):
+        raise OSError(99, 'unexpected')
+    monkeypatch.setattr(fcntl, 'flock', boom)
+    with pytest.raises(OSError):
+        with sc.FileLock(sc.LOCK_FILE):
+            pass
+
+
+# --------------------------------------------------------------- main
+
+def _patch_main_io(monkeypatch, stub, machine='m', endpoint='h:1'):
+    monkeypatch.setattr(sc, 'machine_id_from_config', lambda: machine)
+    monkeypatch.setattr(sc, 'server_endpoint', lambda: endpoint)
+    monkeypatch.setattr(sc, 'build_channel',
+                        lambda ep, insecure: (None, FakeSyncPb2(), FakeStubFactory(stub)))
+
+
+def test_main_no_machine_id(env, monkeypatch):
+    monkeypatch.setattr(sc, 'machine_id_from_config', lambda: None)
+    assert sc.main([]) == 2
+
+
+def test_main_no_endpoint(env, monkeypatch):
+    monkeypatch.setattr(sc, 'machine_id_from_config', lambda: 'm')
+    monkeypatch.setattr(sc, 'server_endpoint', lambda: None)
+    assert sc.main([]) == 0
+
+
+def test_main_skips_when_recent(env, monkeypatch):
+    stub = FakeStub(None)
+    _patch_main_io(monkeypatch, stub)
+    # Pre-seed a recent attempt so should_skip returns True.
+    c = sc.open_db()
+    sc.mark_attempt(c, 'm', None)
+    c.commit()
+    c.close()
+    assert sc.main([]) == 0
+    assert stub.pushes == []  # never got to push
+
+
+def test_main_success(env, monkeypatch):
+    stub = FakeStub(None)
+    _patch_main_io(monkeypatch, stub)
+    assert sc.main(['--force']) == 0
+
+
+def test_main_handshake_failure(env, monkeypatch):
+    monkeypatch.setattr(sc, 'machine_id_from_config', lambda: 'm')
+    monkeypatch.setattr(sc, 'server_endpoint', lambda: 'h:1')
+
+    def boom(ep, insecure):
+        raise RuntimeError('no route')
+    monkeypatch.setattr(sc, 'build_channel', boom)
+    assert sc.main(['--force']) == 1
+    c = sc.open_db()
+    n = c.execute(
+        "SELECT COUNT(*) FROM mover_errors WHERE operation='sync_handshake'").fetchone()[0]
+    c.close()
+    assert n == 1
+
+
+def test_main_sync_failure(env, monkeypatch):
+    stub = FakeStub(None)
+    stub.push_raises = True
+    _patch_main_io(monkeypatch, stub)
+    # Provide a local log so do_push attempts a send and fails.
+    with open(os.path.join(env.log_dir, 'browser-visits-2026-05-21.log'), 'w') as f:
+        f.write('l0\n')
+    assert sc.main(['--force']) == 1
+
+
+def test_main_server_arg_overrides(env, monkeypatch):
+    stub = FakeStub(None)
+    monkeypatch.setattr(sc, 'machine_id_from_config', lambda: 'm')
+    monkeypatch.setattr(sc, 'server_endpoint', lambda: None)  # no config endpoint
+    monkeypatch.setattr(sc, 'build_channel',
+                        lambda ep, insecure: (None, FakeSyncPb2(), FakeStubFactory(stub)))
+    # --server supplies the endpoint despite server_endpoint() → None.
+    assert sc.main(['--force', '--server', 'cli:1']) == 0
+

--- a/browser-visit-sync-server/.gitignore
+++ b/browser-visit-sync-server/.gitignore
@@ -1,0 +1,10 @@
+bin/
+gen/
+go.sum
+*.db
+*.crt
+*.key
+test/.venv/
+test/certs/
+test/state/
+.pytest_cache/

--- a/browser-visit-sync-server/Makefile
+++ b/browser-visit-sync-server/Makefile
@@ -1,0 +1,53 @@
+.PHONY: proto build test cover test-integration venv clean clean-venv
+
+PROTO_DIR := proto
+GEN_DIR   := gen/syncpb
+
+# Python venv for the integration suite.  Lives inside test/ so it's
+# colocated with what uses it; gitignored.  Auto-created on first
+# `make test-integration` so the user doesn't need to remember a
+# separate setup step.
+VENV       := test/.venv
+VENV_BIN   := $(VENV)/bin
+VENV_PY    := $(VENV_BIN)/python
+VENV_PIP   := $(VENV_BIN)/pip
+VENV_STAMP := $(VENV)/.installed
+
+proto:
+	mkdir -p $(GEN_DIR)
+	protoc \
+		-I $(PROTO_DIR) \
+		--go_out=$(GEN_DIR) --go_opt=paths=source_relative \
+		--go-grpc_out=$(GEN_DIR) --go-grpc_opt=paths=source_relative \
+		$(PROTO_DIR)/sync.proto
+
+build:
+	go build -o bin/sync-server ./cmd/sync-server
+
+test:
+	go test ./...
+
+# Per-package coverage over the hand-written packages.  Generated
+# protobuf bindings (gen/syncpb) are excluded by convention.
+cover:
+	go test $$(go list ./... | grep -v '/gen/syncpb') -cover
+
+# Idempotent: re-runs are fast (pip notices everything's already up
+# to date).  Rebuild the venv after editing test/requirements.txt by
+# running `make clean-venv test-integration`, or `make venv` alone.
+venv: $(VENV_STAMP)
+
+$(VENV_STAMP): test/requirements.txt
+	python3 -m venv $(VENV)
+	$(VENV_PIP) install --upgrade pip
+	$(VENV_PIP) install -r test/requirements.txt
+	touch $(VENV_STAMP)
+
+test-integration: venv
+	$(VENV_PY) -m pytest -v test
+
+clean:
+	rm -rf bin gen test/certs test/state
+
+clean-venv:
+	rm -rf $(VENV)

--- a/browser-visit-sync-server/README.md
+++ b/browser-visit-sync-server/README.md
@@ -1,0 +1,214 @@
+# browser-visit-sync-server
+
+Go gRPC service that runs on the EC2 Linux VM and acts as the
+canonical store for browser-visit log records produced by every
+enrolled laptop.  Pairs with `sync_client.py` on the laptop side
+(see [`browser-visit-logger/README.md`](../browser-visit-logger/README.md#multi-laptop-sync-mode)).
+
+## RPCs
+
+| RPC | Direction | Purpose |
+|---|---|---|
+| `PushLogs` | laptop → server | Mirror new log lines; replay each into the canonical DB.  Idempotent on `(machine_id, date, line_offset)`. |
+| `PullLogs` | server → laptop (stream) | Stream every peer's log lines past the per-peer cursors the caller supplies.  Caller's own records are never echoed back. |
+| `ExportDbSnapshot` | server → laptop (stream) | Stream a `VACUUM INTO`-produced SQLite snapshot of the canonical DB.  Used by `browser-visit-tools/db_diff.py`. |
+
+Authentication is mTLS.  Two interceptors run per call:
+
+1. **logmw** (outer) — logs one line per RPC with the cert-derived
+   caller, method, status, duration, and per-method details
+   (e.g. `lines=N` + `accepted_to=...` for `PushLogs`).  Outer so
+   it logs even when auth rejects.
+2. **auth** (inner) — extracts the peer's verified leaf cert,
+   SHA-256s it, looks it up in `enrolled_machines.db`, and binds
+   the resulting `machine_id` to the context.  Handlers then call
+   `auth.CrossCheck(ctx, req.GetMachineId())` to reject identity
+   spoofs (laptop A's cert claiming `machine_id="laptop-b"`).
+
+## Layout
+
+```
+proto/sync.proto              service definition (single source of truth)
+cmd/sync-server/main.go       entrypoint — flag parsing, TLS, server start
+cmd/sync-server/main_test.go  buildTLS unit tests
+internal/server/              gRPC handler methods + *_test.go
+internal/store/               per-machine log mirror + canonical DB + *_test.go
+internal/auth/                mTLS cert → machine_id binding + *_test.go
+internal/logmw/               per-RPC logging interceptor + *_test.go
+Makefile                      proto / build / test / cover / test-integration
+deploy/Dockerfile             multi-stage container build (protoc + go build)
+deploy/sync-server.service    systemd unit
+docker-compose.test.yml       brings up the server with test certs
+test/                         integration suite (see test/README.md)
+gen/syncpb/                   generated protobuf bindings (gitignored;
+                              produced by `make proto` or the Dockerfile)
+go.sum                        gitignored; produced by `go mod tidy`
+```
+
+For testability the package boundaries expose two small helpers used
+only by tests: `auth.ContextWithMachineID` (construct a context that
+looks like a successful mTLS pass) and `store.LogRoot()` (locate the
+on-disk mirror).
+
+## Storage layout on disk
+
+```
+<log-root>/
+  <machine_id>/
+    browser-visits-YYYY-MM-DD.log     # exact byte mirror of the laptop's log
+<db>                                   # canonical SQLite (visits, *_events, snapshots)
+<enrolled>                             # SQLite (machine_id, cert_sha256, enrolled_at)
+```
+
+Log files are append-only and never rewritten in place.  Idempotency
+of `PushLogs` is enforced by the caller-supplied
+`(machine_id, date, line_offset)` tuple — out-of-order or replayed
+pushes are deduplicated against the file's current line count.  A
+gap (offset beyond current count) is an error and the server returns
+`Internal: gap: ...`.
+
+## Generating protobuf bindings (host build)
+
+The Dockerfile does this for you automatically.  If you want to
+build the server outside Docker, install the toolchain once:
+
+```
+brew install protobuf go
+go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.4.0
+make proto       # produces gen/syncpb/sync.pb.go + sync_grpc.pb.go
+go mod tidy      # produces go.sum (also gitignored)
+make build       # → bin/sync-server
+```
+
+Built and tested with Go 1.22+ (the module's `go` directive) — a
+current toolchain (e.g. Go 1.26) works fine.
+
+## Unit tests
+
+Pure-Go tests, no Docker needed.  The SQLite driver is `modernc.org/sqlite`
+(pure Go, no cgo), so these run identically on macOS and Linux:
+
+```
+make proto && go mod tidy   # once, if gen/ + go.sum aren't present
+make cover                  # per-package coverage, excludes generated gen/syncpb
+# or: make test             # plain go test ./...
+```
+
+Coverage of the hand-written packages: `logmw` 100%, `auth` 98%,
+`server` 96%, `store` 94%, `cmd` (only `buildTLS`; `main()` is an
+untested process entrypoint).  The residual gaps are unreachable
+defensive error returns (`sql.Open`/`tx.Commit` failures, mid-stream
+read errors) and `main()` — see the repo's testing notes.  `gen/syncpb`
+(generated) is excluded by convention.
+
+## Run locally (no TLS, for development)
+
+```
+go run ./cmd/sync-server \
+  --listen :50051 \
+  --log-root /tmp/vm-logs \
+  --db /tmp/vm-browser-visits.db \
+  --enrolled /tmp/enrolled.db \
+  --insecure
+```
+
+In `--insecure` mode the auth interceptor is **not** installed, so
+handlers' `CrossCheck(ctx, machineID)` calls will fail.  Only useful
+for inspecting wire shapes; not a path you'd actually drive client
+RPCs through.
+
+## Run on EC2 (mTLS, enrolled machines only)
+
+```
+sync-server \
+  --listen :50443 \
+  --log-root /var/lib/browser-visit-sync/logs \
+  --db /var/lib/browser-visit-sync/browser-visits.db \
+  --enrolled /var/lib/browser-visit-sync/enrolled_machines.db \
+  --tls-cert /etc/browser-visit-sync/server.crt \
+  --tls-key  /etc/browser-visit-sync/server.key \
+  --tls-client-ca /etc/browser-visit-sync/clients-ca.crt
+```
+
+Use the bundled systemd unit
+[`deploy/sync-server.service`](deploy/sync-server.service) — it
+pins the user to `bvlsync`, restarts on failure, and confines
+filesystem writes to `/var/lib/browser-visit-sync/`.  The Dockerfile
+at [`deploy/Dockerfile`](deploy/Dockerfile) is a multi-stage build
+that produces a distroless `nonroot` image (~20 MB).
+
+TLS floor is **TLS 1.2** — pragmatic interop with macOS-system
+Python 3.9 (LibreSSL 2.8.3) that doesn't speak TLS 1.3.  mTLS is the
+actual auth boundary; the TLS version is just transport.  Bump to
+1.3 in [`cmd/sync-server/main.go`](cmd/sync-server/main.go) once
+every client speaks it.
+
+## Per-RPC logging
+
+The logmw interceptor writes one line per call to stderr (which
+`docker compose logs` and `journalctl -u sync-server` both capture).
+Format:
+
+```
+[caller=<machine_id|?>] <method> status=<code> dur=<duration> <details>
+```
+
+Examples from a real test run:
+
+```
+[caller=laptop-a] /bvl.sync.v1.BrowserVisitSync/PushLogs status=OK dur=2.151ms lines=4 dates=2026-05-21 accepted_to=2026-05-21:3
+[caller=laptop-b] /bvl.sync.v1.BrowserVisitSync/PullLogs status=OK dur=198µs (stream)
+[caller=?] /bvl.sync.v1.BrowserVisitSync/PushLogs status=PermissionDenied dur=124µs lines=1 dates=2026-05-21
+[caller=laptop-a] /bvl.sync.v1.BrowserVisitSync/PushLogs status=PermissionDenied dur=139µs lines=1 dates=2026-05-21
+```
+
+`[caller=?]` means the cert wasn't enrolled (auth rejected before
+binding any machine_id); a populated `[caller=...]` with
+`status=PermissionDenied` means the cert was enrolled but the
+request claimed a different machine_id (spoof attempt — `CrossCheck`
+caught it).
+
+## Enrolling a new laptop
+
+On the VM (or wherever you have the `enrolled_machines.db` file the
+server is configured to read):
+
+```
+python3 ../browser-visit-tools/enroll_machine.py \
+    --db /var/lib/browser-visit-sync/enrolled_machines.db \
+    --machine-id <id-printed-by-install_laptop.sh> \
+    --cert /path/to/that-laptop-client.crt
+```
+
+The script SHA-256s the cert's DER bytes and inserts a row.  At
+handshake time, the server's auth interceptor SHA-256s the peer's
+leaf cert and looks for the matching row — no match means
+`PermissionDenied` with no further detail (defense against
+enumeration).
+
+To list / revoke:
+```
+python3 ../browser-visit-tools/enroll_machine.py --db ... --list
+python3 ../browser-visit-tools/enroll_machine.py --db ... --machine-id X --revoke
+```
+
+## Integration tests
+
+Full Docker Compose suite under [`test/`](test/) — minted certs,
+seeded enrolled DB, pytest driver, 7 end-to-end scenarios.  See
+[`test/README.md`](test/README.md) for the workflow.  Short version:
+
+```
+make test-integration               # creates test/.venv on first run, ~15s
+```
+
+To poke at a live server:
+
+```
+BVL_TEST_KEEP_RUNNING=1 make test-integration         # leave stack up
+docker compose -f docker-compose.test.yml logs -f sync-server   # watch
+BVL_TEST_USE_EXISTING=1 test/.venv/bin/python -m pytest \
+    test/test_sync.py::test_push_pull_round_trip -v   # in another terminal
+docker compose -f docker-compose.test.yml down -v     # cleanup
+```

--- a/browser-visit-sync-server/cmd/sync-server/main.go
+++ b/browser-visit-sync-server/cmd/sync-server/main.go
@@ -1,0 +1,116 @@
+// sync-server is the gRPC service that mirrors laptop logs onto the
+// EC2 VM and replays them into the canonical browser-visits DB.
+//
+// See ../../README.md for deployment.
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"flag"
+	"log"
+	"net"
+	"os"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
+	syncpb "github.com/theimer/browser-visit-logger/browser-visit-sync-server/gen/syncpb"
+	"github.com/theimer/browser-visit-logger/browser-visit-sync-server/internal/auth"
+	"github.com/theimer/browser-visit-logger/browser-visit-sync-server/internal/logmw"
+	"github.com/theimer/browser-visit-logger/browser-visit-sync-server/internal/server"
+	"github.com/theimer/browser-visit-logger/browser-visit-sync-server/internal/store"
+)
+
+func main() {
+	var (
+		listen      = flag.String("listen", ":50443", "address to listen on")
+		logRoot     = flag.String("log-root", "/var/lib/browser-visit-sync/logs", "directory of per-machine log mirrors")
+		dbPath      = flag.String("db", "/var/lib/browser-visit-sync/browser-visits.db", "canonical SQLite DB path")
+		enrolledDB  = flag.String("enrolled", "/var/lib/browser-visit-sync/enrolled_machines.db", "SQLite DB of enrolled (machine_id, cert fingerprint) pairs")
+		tlsCert     = flag.String("tls-cert", "", "server cert PEM (omit with --insecure)")
+		tlsKey      = flag.String("tls-key", "", "server key PEM")
+		tlsClientCA = flag.String("tls-client-ca", "", "CA bundle that signs client certs")
+		insecure    = flag.Bool("insecure", false, "disable TLS; for local dev only")
+	)
+	flag.Parse()
+
+	st, err := store.Open(*logRoot, *dbPath)
+	if err != nil {
+		log.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	enroller, err := auth.OpenEnrolled(*enrolledDB)
+	if err != nil {
+		log.Fatalf("open enrolled DB: %v", err)
+	}
+	defer enroller.Close()
+
+	var opts []grpc.ServerOption
+	if *insecure {
+		log.Println("WARNING: running without TLS; do not use in production")
+		// Even in insecure mode we want per-request logs.  No auth
+		// interceptor here means handlers' CrossCheck calls will
+		// fail; insecure mode is for never-deployed local dev only.
+		opts = append(opts, grpc.ChainUnaryInterceptor(logmw.UnaryInterceptor()))
+		opts = append(opts, grpc.ChainStreamInterceptor(logmw.StreamInterceptor()))
+	} else {
+		creds, err := buildTLS(*tlsCert, *tlsKey, *tlsClientCA)
+		if err != nil {
+			log.Fatalf("build TLS creds: %v", err)
+		}
+		opts = append(opts, grpc.Creds(creds))
+		// Order matters: logmw must be the *outer* interceptor so it
+		// runs even when auth rejects.  Auth failures show up in the
+		// log as `[caller=?] ... status=PermissionDenied` (the
+		// context has no derived machine_id yet because auth never
+		// got a chance to populate it).  If auth succeeds, the
+		// authenticated id is in the context by the time the inner
+		// handler returns and logmw reads it for the log line.
+		opts = append(opts, grpc.ChainUnaryInterceptor(
+			logmw.UnaryInterceptor(),
+			auth.UnaryInterceptor(enroller),
+		))
+		opts = append(opts, grpc.ChainStreamInterceptor(
+			logmw.StreamInterceptor(),
+			auth.StreamInterceptor(enroller),
+		))
+	}
+
+	lis, err := net.Listen("tcp", *listen)
+	if err != nil {
+		log.Fatalf("listen: %v", err)
+	}
+
+	srv := grpc.NewServer(opts...)
+	syncpb.RegisterBrowserVisitSyncServer(srv, server.New(st))
+
+	log.Printf("sync-server listening on %s (insecure=%v)", *listen, *insecure)
+	if err := srv.Serve(lis); err != nil {
+		log.Fatalf("serve: %v", err)
+	}
+	_ = os.Stderr
+}
+
+func buildTLS(certPath, keyPath, caPath string) (credentials.TransportCredentials, error) {
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, err
+	}
+	pool := x509.NewCertPool()
+	caPEM, err := os.ReadFile(caPath)
+	if err != nil {
+		return nil, err
+	}
+	pool.AppendCertsFromPEM(caPEM)
+	return credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientCAs:    pool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		// TLS 1.2 floor: gives us interop with stdlib ssl on older
+		// macOS LibreSSL while keeping mTLS as the actual auth
+		// boundary.  Bump if we ever drop those clients.
+		MinVersion: tls.VersionTLS12,
+	}), nil
+}

--- a/browser-visit-sync-server/cmd/sync-server/main_test.go
+++ b/browser-visit-sync-server/cmd/sync-server/main_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writePEMKeyPair mints a self-signed cert + key and writes them as PEM
+// files, returning their paths.  Good enough for buildTLS, which only
+// needs LoadX509KeyPair to succeed and the CA file to parse.
+func writePEMKeyPair(t *testing.T, dir, name string) (certPath, keyPath string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: name},
+		NotBefore:    time.Unix(0, 0),
+		NotAfter:     time.Unix(1<<31-1, 0),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPath = filepath.Join(dir, name+".crt")
+	keyPath = filepath.Join(dir, name+".key")
+	writePEM(t, certPath, "CERTIFICATE", der)
+	writePEM(t, keyPath, "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(key))
+	return certPath, keyPath
+}
+
+func writePEM(t *testing.T, path, blockType string, der []byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := pem.Encode(f, &pem.Block{Type: blockType, Bytes: der}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildTLSSuccess(t *testing.T) {
+	dir := t.TempDir()
+	cert, key := writePEMKeyPair(t, dir, "server")
+	ca, _ := writePEMKeyPair(t, dir, "ca")
+	creds, err := buildTLS(cert, key, ca)
+	if err != nil {
+		t.Fatalf("buildTLS: %v", err)
+	}
+	if creds == nil {
+		t.Fatal("nil creds")
+	}
+}
+
+func TestBuildTLSMissingKeyPair(t *testing.T) {
+	dir := t.TempDir()
+	ca, _ := writePEMKeyPair(t, dir, "ca")
+	if _, err := buildTLS(filepath.Join(dir, "nope.crt"),
+		filepath.Join(dir, "nope.key"), ca); err == nil {
+		t.Fatal("expected LoadX509KeyPair error")
+	}
+}
+
+func TestBuildTLSMissingCA(t *testing.T) {
+	dir := t.TempDir()
+	cert, key := writePEMKeyPair(t, dir, "server")
+	if _, err := buildTLS(cert, key, filepath.Join(dir, "nope-ca.crt")); err == nil {
+		t.Fatal("expected CA read error")
+	}
+}

--- a/browser-visit-sync-server/deploy/Dockerfile
+++ b/browser-visit-sync-server/deploy/Dockerfile
@@ -1,0 +1,33 @@
+# Production server image.
+#
+# The protoc-generated bindings (gen/syncpb/) are intentionally not
+# committed.  The build stage installs protoc + the Go plugins and
+# runs `make proto` before `go build`, so the same source tree
+# produces the same artifact regardless of whether bindings happen
+# to be present on the host.
+FROM golang:1.22 AS build
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends protobuf-compiler ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+# Install codegen plugins into a fixed path so they're on PATH.
+ENV GOBIN=/usr/local/bin
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1 \
+ && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.4.0
+
+COPY . .
+# Generate proto bindings, then resolve transitive deps once both the
+# hand-written and the generated source files are present.  go.sum is
+# intentionally not committed; the lock comes from go.mod's `require`
+# block + go mod tidy.
+RUN make proto
+RUN go mod tidy
+RUN CGO_ENABLED=0 go build -o /out/sync-server ./cmd/sync-server
+
+FROM gcr.io/distroless/static:nonroot
+COPY --from=build /out/sync-server /usr/local/bin/sync-server
+USER nonroot:nonroot
+ENTRYPOINT ["/usr/local/bin/sync-server"]

--- a/browser-visit-sync-server/deploy/sync-server.service
+++ b/browser-visit-sync-server/deploy/sync-server.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Browser Visit Sync gRPC server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=bvlsync
+Group=bvlsync
+ExecStart=/usr/local/bin/sync-server \
+  --listen :50443 \
+  --log-root /var/lib/browser-visit-sync/logs \
+  --db /var/lib/browser-visit-sync/browser-visits.db \
+  --enrolled /var/lib/browser-visit-sync/enrolled_machines.db \
+  --tls-cert /etc/browser-visit-sync/server.crt \
+  --tls-key /etc/browser-visit-sync/server.key \
+  --tls-client-ca /etc/browser-visit-sync/clients-ca.crt
+Restart=on-failure
+RestartSec=5s
+ProtectSystem=strict
+ReadWritePaths=/var/lib/browser-visit-sync
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/browser-visit-sync-server/docker-compose.test.yml
+++ b/browser-visit-sync-server/docker-compose.test.yml
@@ -1,0 +1,61 @@
+# Integration-test stack.
+#
+# Brings up the gRPC server with mTLS using test-only certs minted by
+# test/gen-certs.sh.  The test driver runs on the host (Mac) and
+# connects to localhost:50443, which the container maps to its
+# internal 50443.  See test/README.md for `make test-integration`.
+
+services:
+  sync-server:
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile
+    image: bvl-sync-server:test
+    ports:
+      - "50443:50443"
+    volumes:
+      - ./test/certs:/certs:ro
+      - bvl-state:/var/lib/browser-visit-sync
+    command:
+      - "--listen=:50443"
+      - "--log-root=/var/lib/browser-visit-sync/logs"
+      - "--db=/var/lib/browser-visit-sync/browser-visits.db"
+      - "--enrolled=/var/lib/browser-visit-sync/enrolled_machines.db"
+      - "--tls-cert=/certs/server.crt"
+      - "--tls-key=/certs/server.key"
+      - "--tls-client-ca=/certs/ca.crt"
+    depends_on:
+      - seed
+    healthcheck:
+      # gRPC has no HTTP, so we just check the listening socket exists.
+      test: ["CMD", "/usr/local/bin/sync-server", "--help"]
+      interval: 2s
+      timeout: 2s
+      retries: 20
+
+  # One-shot init container that copies the pre-seeded
+  # enrolled_machines.db onto the shared volume before the server
+  # starts.  The host writes test/enrolled_machines.db via
+  # test/seed-enrolled.py.
+  seed:
+    image: alpine:3.20
+    volumes:
+      - ./test/state:/seed:ro
+      - bvl-state:/var/lib/browser-visit-sync
+    command:
+      - sh
+      - -c
+      - |
+        set -e
+        mkdir -p /var/lib/browser-visit-sync
+        cp /seed/enrolled_machines.db /var/lib/browser-visit-sync/enrolled_machines.db
+        # Wipe any leftover state from a previous run so each test
+        # session starts from an empty canonical DB.
+        rm -f /var/lib/browser-visit-sync/browser-visits.db \
+              /var/lib/browser-visit-sync/browser-visits.db-wal \
+              /var/lib/browser-visit-sync/browser-visits.db-shm
+        rm -rf /var/lib/browser-visit-sync/logs
+        chown -R 65532:65532 /var/lib/browser-visit-sync || true
+
+volumes:
+  bvl-state:

--- a/browser-visit-sync-server/go.mod
+++ b/browser-visit-sync-server/go.mod
@@ -1,0 +1,28 @@
+module github.com/theimer/browser-visit-logger/browser-visit-sync-server
+
+go 1.22
+
+require (
+	google.golang.org/grpc v1.64.0
+	google.golang.org/protobuf v1.34.1
+	modernc.org/sqlite v1.30.0
+)
+
+require (
+	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/ncruces/go-strftime v0.1.9 // indirect
+	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	golang.org/x/net v0.22.0 // indirect
+	golang.org/x/sys v0.19.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	modernc.org/gc/v3 v3.0.0-20240107210532-573471604cb6 // indirect
+	modernc.org/libc v1.50.9 // indirect
+	modernc.org/mathutil v1.6.0 // indirect
+	modernc.org/memory v1.8.0 // indirect
+	modernc.org/strutil v1.2.0 // indirect
+	modernc.org/token v1.1.0 // indirect
+)

--- a/browser-visit-sync-server/internal/auth/auth.go
+++ b/browser-visit-sync-server/internal/auth/auth.go
@@ -1,0 +1,165 @@
+// Package auth pins each gRPC call's claimed machine_id to the
+// client cert that's actually presented during mTLS.
+//
+// An enrolled_machines SQLite DB on the VM stores
+//
+//	(machine_id TEXT PRIMARY KEY, cert_sha256 TEXT NOT NULL)
+//
+// Operators add rows via browser-visit-tools/enroll_machine.py. The
+// interceptor below extracts the peer cert from the gRPC context,
+// SHA-256s it, and looks the row up.  The request's claimed
+// machine_id (a field on every Push/Pull message) must match.
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+
+	"github.com/theimer/browser-visit-logger/browser-visit-sync-server/internal/logmw"
+
+	_ "modernc.org/sqlite"
+)
+
+type Enrolled struct{ db *sql.DB }
+
+func OpenEnrolled(path string) (*Enrolled, error) {
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS enrolled_machines (
+		machine_id  TEXT PRIMARY KEY,
+		cert_sha256 TEXT NOT NULL,
+		enrolled_at TEXT NOT NULL
+	)`); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return &Enrolled{db: db}, nil
+}
+
+func (e *Enrolled) Close() error { return e.db.Close() }
+
+// Lookup returns the enrolled machine_id for the supplied cert
+// fingerprint.  Empty string + nil error means "not enrolled".
+func (e *Enrolled) Lookup(fp string) (string, error) {
+	row := e.db.QueryRow(`SELECT machine_id FROM enrolled_machines WHERE cert_sha256 = ?`, fp)
+	var id string
+	if err := row.Scan(&id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	return id, nil
+}
+
+type ctxKey struct{}
+
+// ContextWithMachineID returns a child context carrying the
+// cert-derived machine_id.  The interceptors use it to publish the
+// authenticated identity; handlers read it back via CrossCheck /
+// AuthenticatedMachineID.  Exported so tests can construct a context
+// that looks like one a successful auth pass produced.
+func ContextWithMachineID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, ctxKey{}, id)
+}
+
+func machineIDFromCtx(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(ctxKey{}).(string)
+	return v, ok
+}
+
+// AuthenticatedMachineID is the public accessor for handlers that need
+// to compare the cert-derived identity against the request payload.
+func AuthenticatedMachineID(ctx context.Context) (string, bool) {
+	return machineIDFromCtx(ctx)
+}
+
+func resolveID(ctx context.Context, e *Enrolled) (string, error) {
+	p, ok := peer.FromContext(ctx)
+	if !ok || p.AuthInfo == nil {
+		return "", status.Error(codes.Unauthenticated, "no peer info")
+	}
+	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		return "", status.Error(codes.Unauthenticated, "non-TLS connection")
+	}
+	chains := tlsInfo.State.VerifiedChains
+	if len(chains) == 0 || len(chains[0]) == 0 {
+		return "", status.Error(codes.Unauthenticated, "no verified client cert")
+	}
+	leaf := chains[0][0]
+	sum := sha256.Sum256(leaf.Raw)
+	fp := hex.EncodeToString(sum[:])
+	id, err := e.Lookup(fp)
+	if err != nil {
+		return "", status.Errorf(codes.Internal, "enrolled lookup: %v", err)
+	}
+	if id == "" {
+		return "", status.Errorf(codes.PermissionDenied, "client cert %s not enrolled", fp[:16])
+	}
+	return id, nil
+}
+
+// UnaryInterceptor verifies the mTLS cert against the enrolled DB and
+// attaches the authoritative machine_id to the context.  Also writes
+// the id into logmw's caller slot so the outer logging interceptor
+// can include it in its log line.
+func UnaryInterceptor(e *Enrolled) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		id, err := resolveID(ctx, e)
+		if err != nil {
+			return nil, err
+		}
+		logmw.SetCaller(ctx, id)
+		return handler(ContextWithMachineID(ctx, id), req)
+	}
+}
+
+// StreamInterceptor is the streaming-RPC twin of UnaryInterceptor.
+func StreamInterceptor(e *Enrolled) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		id, err := resolveID(ss.Context(), e)
+		if err != nil {
+			return err
+		}
+		logmw.SetCaller(ss.Context(), id)
+		return handler(srv, &wrappedStream{ServerStream: ss, ctx: ContextWithMachineID(ss.Context(), id)})
+	}
+}
+
+type wrappedStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (w *wrappedStream) Context() context.Context { return w.ctx }
+
+// CrossCheck returns nil iff the cert-derived id matches the
+// request-claimed id.  Handlers call this on every RPC.
+func CrossCheck(ctx context.Context, claimed string) error {
+	id, ok := machineIDFromCtx(ctx)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "no authenticated machine id")
+	}
+	if id != claimed {
+		return status.Errorf(codes.PermissionDenied,
+			"cert identity %q does not match claimed machine_id %q", id, claimed)
+	}
+	return nil
+}
+
+// _ is a placeholder so the file builds even when callers don't use
+// fmt directly.
+var _ = fmt.Sprintf

--- a/browser-visit-sync-server/internal/auth/auth_test.go
+++ b/browser-visit-sync-server/internal/auth/auth_test.go
@@ -1,0 +1,272 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"math/big"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+func openTestEnrolled(t *testing.T) *Enrolled {
+	t.Helper()
+	e, err := OpenEnrolled(filepath.Join(t.TempDir(), "enrolled.db"))
+	if err != nil {
+		t.Fatalf("OpenEnrolled: %v", err)
+	}
+	t.Cleanup(func() { e.Close() })
+	return e
+}
+
+func mintCert(t *testing.T, cn string) *x509.Certificate {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Unix(0, 0),
+		NotAfter:     time.Unix(1<<31-1, 0),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert
+}
+
+func fingerprint(c *x509.Certificate) string {
+	sum := sha256.Sum256(c.Raw)
+	return hex.EncodeToString(sum[:])
+}
+
+func ctxWithCert(cert *x509.Certificate) context.Context {
+	p := &peer.Peer{
+		AuthInfo: credentials.TLSInfo{
+			State: tls.ConnectionState{
+				VerifiedChains: [][]*x509.Certificate{{cert}},
+			},
+		},
+	}
+	return peer.NewContext(context.Background(), p)
+}
+
+func TestOpenEnrolledBadPath(t *testing.T) {
+	// A path under a non-existent, uncreatable directory makes the
+	// CREATE TABLE Exec fail.
+	_, err := OpenEnrolled("/nonexistent-root-xyz/sub/enrolled.db")
+	if err == nil {
+		t.Fatal("expected open error")
+	}
+}
+
+func TestLookup(t *testing.T) {
+	e := openTestEnrolled(t)
+	cert := mintCert(t, "laptop-a")
+	fp := fingerprint(cert)
+	if _, err := e.db.Exec(
+		"INSERT INTO enrolled_machines (machine_id, cert_sha256, enrolled_at) VALUES (?,?,?)",
+		"laptop-a", fp, "now"); err != nil {
+		t.Fatal(err)
+	}
+	id, err := e.Lookup(fp)
+	if err != nil || id != "laptop-a" {
+		t.Fatalf("Lookup hit: id=%q err=%v", id, err)
+	}
+	// Miss → empty, nil.
+	id, err = e.Lookup("deadbeef")
+	if err != nil || id != "" {
+		t.Fatalf("Lookup miss: id=%q err=%v", id, err)
+	}
+}
+
+func TestLookupQueryError(t *testing.T) {
+	e := openTestEnrolled(t)
+	e.db.Close() // subsequent query errors (not ErrNoRows)
+	if _, err := e.Lookup("x"); err == nil {
+		t.Fatal("expected query error")
+	}
+}
+
+func TestResolveIDNoPeer(t *testing.T) {
+	e := openTestEnrolled(t)
+	_, err := resolveID(context.Background(), e)
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("want Unauthenticated, got %v", err)
+	}
+}
+
+func TestResolveIDNonTLS(t *testing.T) {
+	e := openTestEnrolled(t)
+	ctx := peer.NewContext(context.Background(), &peer.Peer{AuthInfo: nonTLSAuth{}})
+	_, err := resolveID(ctx, e)
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("want Unauthenticated, got %v", err)
+	}
+}
+
+type nonTLSAuth struct{}
+
+func (nonTLSAuth) AuthType() string { return "fake" }
+
+func TestResolveIDNoVerifiedChain(t *testing.T) {
+	e := openTestEnrolled(t)
+	p := &peer.Peer{AuthInfo: credentials.TLSInfo{State: tls.ConnectionState{}}}
+	ctx := peer.NewContext(context.Background(), p)
+	_, err := resolveID(ctx, e)
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("want Unauthenticated, got %v", err)
+	}
+}
+
+func TestResolveIDNotEnrolled(t *testing.T) {
+	e := openTestEnrolled(t)
+	cert := mintCert(t, "ghost")
+	_, err := resolveID(ctxWithCert(cert), e)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("want PermissionDenied, got %v", err)
+	}
+}
+
+func TestResolveIDLookupError(t *testing.T) {
+	e := openTestEnrolled(t)
+	e.db.Close() // forces an internal error inside Lookup
+	cert := mintCert(t, "x")
+	_, err := resolveID(ctxWithCert(cert), e)
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("want Internal, got %v", err)
+	}
+}
+
+func TestResolveIDSuccess(t *testing.T) {
+	e := openTestEnrolled(t)
+	cert := mintCert(t, "laptop-a")
+	if _, err := e.db.Exec(
+		"INSERT INTO enrolled_machines (machine_id, cert_sha256, enrolled_at) VALUES (?,?,?)",
+		"laptop-a", fingerprint(cert), "now"); err != nil {
+		t.Fatal(err)
+	}
+	id, err := resolveID(ctxWithCert(cert), e)
+	if err != nil || id != "laptop-a" {
+		t.Fatalf("resolveID success: id=%q err=%v", id, err)
+	}
+}
+
+func TestCrossCheck(t *testing.T) {
+	// No id in ctx → Unauthenticated.
+	if status.Code(CrossCheck(context.Background(), "x")) != codes.Unauthenticated {
+		t.Error("missing id should be Unauthenticated")
+	}
+	ctx := ContextWithMachineID(context.Background(), "laptop-a")
+	// Match → nil.
+	if err := CrossCheck(ctx, "laptop-a"); err != nil {
+		t.Errorf("match should pass: %v", err)
+	}
+	// Mismatch → PermissionDenied.
+	if status.Code(CrossCheck(ctx, "laptop-b")) != codes.PermissionDenied {
+		t.Error("mismatch should be PermissionDenied")
+	}
+}
+
+func TestAuthenticatedMachineID(t *testing.T) {
+	if _, ok := AuthenticatedMachineID(context.Background()); ok {
+		t.Error("empty ctx should report not-ok")
+	}
+	ctx := ContextWithMachineID(context.Background(), "laptop-a")
+	id, ok := AuthenticatedMachineID(ctx)
+	if !ok || id != "laptop-a" {
+		t.Errorf("got (%q,%v)", id, ok)
+	}
+}
+
+func enrolledWith(t *testing.T, cert *x509.Certificate, id string) *Enrolled {
+	e := openTestEnrolled(t)
+	if _, err := e.db.Exec(
+		"INSERT INTO enrolled_machines (machine_id, cert_sha256, enrolled_at) VALUES (?,?,?)",
+		id, fingerprint(cert), "now"); err != nil {
+		t.Fatal(err)
+	}
+	return e
+}
+
+func TestUnaryInterceptor(t *testing.T) {
+	cert := mintCert(t, "laptop-a")
+	e := enrolledWith(t, cert, "laptop-a")
+	intc := UnaryInterceptor(e)
+
+	// Success: handler sees the id in context.
+	var seen string
+	_, err := intc(ctxWithCert(cert), nil, &grpc.UnaryServerInfo{},
+		func(ctx context.Context, req interface{}) (interface{}, error) {
+			id, _ := AuthenticatedMachineID(ctx)
+			seen = id
+			return "ok", nil
+		})
+	if err != nil || seen != "laptop-a" {
+		t.Fatalf("unary success: err=%v seen=%q", err, seen)
+	}
+
+	// Failure: unenrolled cert short-circuits before the handler.
+	ran := false
+	_, err = intc(ctxWithCert(mintCert(t, "ghost")), nil, &grpc.UnaryServerInfo{},
+		func(ctx context.Context, req interface{}) (interface{}, error) {
+			ran = true
+			return nil, nil
+		})
+	if err == nil || ran {
+		t.Fatalf("unary should reject: err=%v ran=%v", err, ran)
+	}
+}
+
+type fakeStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (f *fakeStream) Context() context.Context { return f.ctx }
+
+func TestStreamInterceptor(t *testing.T) {
+	cert := mintCert(t, "laptop-a")
+	e := enrolledWith(t, cert, "laptop-a")
+	intc := StreamInterceptor(e)
+
+	var seen string
+	err := intc(nil, &fakeStream{ctx: ctxWithCert(cert)}, &grpc.StreamServerInfo{},
+		func(srv interface{}, ss grpc.ServerStream) error {
+			id, _ := AuthenticatedMachineID(ss.Context())
+			seen = id
+			return nil
+		})
+	if err != nil || seen != "laptop-a" {
+		t.Fatalf("stream success: err=%v seen=%q", err, seen)
+	}
+
+	ran := false
+	err = intc(nil, &fakeStream{ctx: ctxWithCert(mintCert(t, "ghost"))}, &grpc.StreamServerInfo{},
+		func(srv interface{}, ss grpc.ServerStream) error {
+			ran = true
+			return nil
+		})
+	if err == nil || ran {
+		t.Fatalf("stream should reject: err=%v ran=%v", err, ran)
+	}
+}

--- a/browser-visit-sync-server/internal/logmw/logmw.go
+++ b/browser-visit-sync-server/internal/logmw/logmw.go
@@ -1,0 +1,169 @@
+// Package logmw provides a tiny gRPC logging middleware: one line per
+// RPC, written to the standard logger.  Format:
+//
+//	[caller=<authed_machine_id>] <method> status=<code> dur=<duration> <details>
+//
+// `<details>` is request-specific (e.g. `lines=N` for PushLogs) when
+// we can extract something useful without serialising the whole
+// proto.  Falls back to empty when nothing notable.
+package logmw
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+
+	syncpb "github.com/theimer/browser-visit-logger/browser-visit-sync-server/gen/syncpb"
+)
+
+// callerSlot is a mutable container the auth interceptor writes into
+// once it has derived the machine_id from the client cert.  We need
+// this indirection because grpc.ChainUnaryInterceptor invokes inner
+// interceptors with a *child* context that the outer interceptor
+// can't observe — i.e. plain context.WithValue done by auth wouldn't
+// surface back to logmw.  A pointer-to-struct in the (immutable)
+// context survives that boundary.
+type callerSlot struct{ id string }
+
+type slotKey struct{}
+
+// SetCaller records the cert-derived machine_id so logmw can include
+// it in the log line.  Called by the auth interceptor.
+func SetCaller(ctx context.Context, id string) {
+	if s, ok := ctx.Value(slotKey{}).(*callerSlot); ok {
+		s.id = id
+	}
+}
+
+// UnaryInterceptor logs one line per unary RPC.
+func UnaryInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		slot := &callerSlot{}
+		ctx = context.WithValue(ctx, slotKey{}, slot)
+		start := time.Now()
+		resp, err := handler(ctx, req)
+		log.Printf("%s%s %s dur=%s%s",
+			callerPrefix(slot),
+			info.FullMethod,
+			statusCode(err),
+			time.Since(start).Round(time.Microsecond),
+			unaryDetails(req, resp))
+		return resp, err
+	}
+}
+
+// StreamInterceptor logs one line per streaming RPC (server- or
+// client-streamed).  Request payload isn't available here without
+// wrapping ServerStream.RecvMsg, so for streams we just report
+// method + auth + status + duration.
+func StreamInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		slot := &callerSlot{}
+		wrapped := &slotInjectingStream{ServerStream: ss,
+			ctx: context.WithValue(ss.Context(), slotKey{}, slot)}
+		start := time.Now()
+		err := handler(srv, wrapped)
+		log.Printf("%s%s %s dur=%s (stream)",
+			callerPrefix(slot),
+			info.FullMethod,
+			statusCode(err),
+			time.Since(start).Round(time.Microsecond))
+		return err
+	}
+}
+
+// slotInjectingStream lets the chained inner interceptor see our
+// slot-augmented context via ServerStream.Context().
+type slotInjectingStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *slotInjectingStream) Context() context.Context { return s.ctx }
+
+func callerPrefix(slot *callerSlot) string {
+	if slot.id == "" {
+		return "[caller=?] "
+	}
+	return "[caller=" + slot.id + "] "
+}
+
+func statusCode(err error) string {
+	if err == nil {
+		return "status=OK"
+	}
+	return "status=" + status.Code(err).String()
+}
+
+// unaryDetails extracts a short, structured tail for unary RPCs we
+// know about.  Keep this small: noisy logs are worse than thin ones.
+func unaryDetails(req, resp interface{}) string {
+	switch r := req.(type) {
+	case *syncpb.PushLogsRequest:
+		dates := uniqueDates(r.GetLines())
+		out := " lines=" + itoa(len(r.GetLines()))
+		if len(dates) > 0 {
+			out += " dates=" + commaJoin(dates)
+		}
+		if pr, ok := resp.(*syncpb.PushLogsResponse); ok && pr != nil {
+			out += " accepted_to=" + pr.GetAcceptedDate() + ":" + itoa64(pr.GetAcceptedLineOffset())
+		}
+		return out
+	}
+	return ""
+}
+
+// --- tiny formatting helpers; pulled in to avoid bringing fmt.Sprintf
+// into a hot path for what's essentially a few integers.
+
+func itoa(n int) string   { return itoa64(int64(n)) }
+
+func itoa64(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+func uniqueDates(lines []*syncpb.LogLine) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, l := range lines {
+		d := l.GetDate()
+		if _, ok := seen[d]; ok {
+			continue
+		}
+		seen[d] = struct{}{}
+		out = append(out, d)
+	}
+	return out
+}
+
+func commaJoin(xs []string) string {
+	if len(xs) == 0 {
+		return ""
+	}
+	out := xs[0]
+	for _, x := range xs[1:] {
+		out += "," + x
+	}
+	return out
+}

--- a/browser-visit-sync-server/internal/logmw/logmw_test.go
+++ b/browser-visit-sync-server/internal/logmw/logmw_test.go
@@ -1,0 +1,162 @@
+package logmw
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	syncpb "github.com/theimer/browser-visit-logger/browser-visit-sync-server/gen/syncpb"
+)
+
+func TestItoa64(t *testing.T) {
+	cases := map[int64]string{0: "0", 7: "7", 42: "42", -5: "-5", 1000000: "1000000"}
+	for in, want := range cases {
+		if got := itoa64(in); got != want {
+			t.Errorf("itoa64(%d)=%q want %q", in, got, want)
+		}
+	}
+	if itoa(3) != "3" {
+		t.Error("itoa wrapper")
+	}
+}
+
+func TestCommaJoin(t *testing.T) {
+	if commaJoin(nil) != "" {
+		t.Error("empty")
+	}
+	if commaJoin([]string{"a"}) != "a" {
+		t.Error("single")
+	}
+	if commaJoin([]string{"a", "b", "c"}) != "a,b,c" {
+		t.Error("multi")
+	}
+}
+
+func TestUniqueDates(t *testing.T) {
+	got := uniqueDates([]*syncpb.LogLine{
+		{Date: "d1"}, {Date: "d1"}, {Date: "d2"},
+	})
+	if len(got) != 2 || got[0] != "d1" || got[1] != "d2" {
+		t.Fatalf("uniqueDates: %v", got)
+	}
+}
+
+func TestStatusCode(t *testing.T) {
+	if statusCode(nil) != "status=OK" {
+		t.Error("nil → OK")
+	}
+	if statusCode(status.Error(codes.PermissionDenied, "x")) != "status=PermissionDenied" {
+		t.Error("PD")
+	}
+}
+
+func TestCallerPrefix(t *testing.T) {
+	if callerPrefix(&callerSlot{}) != "[caller=?] " {
+		t.Error("empty slot")
+	}
+	if callerPrefix(&callerSlot{id: "laptop-a"}) != "[caller=laptop-a] " {
+		t.Error("populated slot")
+	}
+}
+
+func TestSetCallerNoSlotIsNoop(t *testing.T) {
+	// Calling SetCaller on a context without a slot must not panic.
+	SetCaller(context.Background(), "x")
+}
+
+func TestUnaryDetailsPushLogs(t *testing.T) {
+	req := &syncpb.PushLogsRequest{Lines: []*syncpb.LogLine{
+		{Date: "2026-05-21"}, {Date: "2026-05-21"}, {Date: "2026-05-22"},
+	}}
+	resp := &syncpb.PushLogsResponse{AcceptedDate: "2026-05-22", AcceptedLineOffset: 4}
+	got := unaryDetails(req, resp)
+	want := " lines=3 dates=2026-05-21,2026-05-22 accepted_to=2026-05-22:4"
+	if got != want {
+		t.Fatalf("unaryDetails=%q want %q", got, want)
+	}
+}
+
+func TestUnaryDetailsPushLogsNoLinesNoResp(t *testing.T) {
+	// Empty lines → no dates clause; non-PushLogsResponse → no accepted clause.
+	got := unaryDetails(&syncpb.PushLogsRequest{}, "not-a-response")
+	if got != " lines=0" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestUnaryDetailsOtherRequestEmpty(t *testing.T) {
+	if unaryDetails(&syncpb.PullLogsRequest{}, nil) != "" {
+		t.Error("non-PushLogs req should yield empty details")
+	}
+}
+
+func TestUnaryInterceptorPopulatesCallerAndLogs(t *testing.T) {
+	intc := UnaryInterceptor()
+	called := false
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		called = true
+		// A downstream interceptor (auth) would call SetCaller here.
+		SetCaller(ctx, "laptop-a")
+		return &syncpb.PushLogsResponse{AcceptedDate: "d", AcceptedLineOffset: 0}, nil
+	}
+	_, err := intc(context.Background(),
+		&syncpb.PushLogsRequest{Lines: []*syncpb.LogLine{{Date: "d"}}},
+		&grpc.UnaryServerInfo{FullMethod: "/svc/PushLogs"}, handler)
+	if err != nil || !called {
+		t.Fatalf("unary interceptor: err=%v called=%v", err, called)
+	}
+}
+
+func TestUnaryInterceptorErrorPath(t *testing.T) {
+	intc := UnaryInterceptor()
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, errors.New("boom")
+	}
+	_, err := intc(context.Background(), &syncpb.PullLogsRequest{},
+		&grpc.UnaryServerInfo{FullMethod: "/svc/PullLogs"}, handler)
+	if err == nil {
+		t.Fatal("error should propagate")
+	}
+}
+
+// fakeStream is a minimal grpc.ServerStream for interceptor tests.
+type fakeStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (f *fakeStream) Context() context.Context { return f.ctx }
+
+func TestStreamInterceptorLogsAndPropagatesContext(t *testing.T) {
+	intc := StreamInterceptor()
+	var sawCtxID string
+	handler := func(srv interface{}, ss grpc.ServerStream) error {
+		SetCaller(ss.Context(), "laptop-b")
+		// The slot lives in the context logmw injected; confirm a later
+		// SetCaller is visible through callerPrefix indirectly by not
+		// panicking and returning nil.
+		sawCtxID = "ok"
+		return nil
+	}
+	err := intc(nil, &fakeStream{ctx: context.Background()},
+		&grpc.StreamServerInfo{FullMethod: "/svc/PullLogs"}, handler)
+	if err != nil || sawCtxID != "ok" {
+		t.Fatalf("stream interceptor: err=%v saw=%q", err, sawCtxID)
+	}
+}
+
+func TestStreamInterceptorErrorPath(t *testing.T) {
+	intc := StreamInterceptor()
+	handler := func(srv interface{}, ss grpc.ServerStream) error {
+		return errors.New("boom")
+	}
+	err := intc(nil, &fakeStream{ctx: context.Background()},
+		&grpc.StreamServerInfo{FullMethod: "/svc/X"}, handler)
+	if err == nil {
+		t.Fatal("error should propagate")
+	}
+}

--- a/browser-visit-sync-server/internal/server/helpers_test.go
+++ b/browser-visit-sync-server/internal/server/helpers_test.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	syncpb "github.com/theimer/browser-visit-logger/browser-visit-sync-server/gen/syncpb"
+)
+
+// mustPush appends a single raw line for machine/date at offset 0.
+func mustPush(t *testing.T, s *Server, machine, date, raw string) {
+	t.Helper()
+	mustPushOffsets(t, s, machine, date, []string{raw})
+}
+
+// mustPushOffsets appends raws at offsets 0..n-1 for machine/date.
+func mustPushOffsets(t *testing.T, s *Server, machine, date string, raws []string) {
+	t.Helper()
+	lines := make([]*syncpb.LogLine, len(raws))
+	for i, r := range raws {
+		lines[i] = &syncpb.LogLine{Date: date, LineOffset: int64(i), RawLine: r}
+	}
+	if _, err := s.PushLogs(authed(machine), &syncpb.PushLogsRequest{
+		MachineId: machine, Lines: lines,
+	}); err != nil {
+		t.Fatalf("seed push for %s: %v", machine, err)
+	}
+}
+
+func makeUnreadable(t *testing.T, s *Server, machine string) {
+	t.Helper()
+	dir := filepath.Join(s.store.LogRoot(), machine)
+	if err := os.Chmod(dir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(dir, 0o755) })
+}
+
+func makeLogRootUnreadable(t *testing.T, s *Server) {
+	t.Helper()
+	// Restore child perms first on cleanup so TempDir removal works.
+	root := s.store.LogRoot()
+	if err := os.Chmod(root, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(root, 0o755) })
+}

--- a/browser-visit-sync-server/internal/server/server.go
+++ b/browser-visit-sync-server/internal/server/server.go
@@ -1,0 +1,146 @@
+// Package server wires the gRPC service to the underlying store.
+package server
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	syncpb "github.com/theimer/browser-visit-logger/browser-visit-sync-server/gen/syncpb"
+	"github.com/theimer/browser-visit-logger/browser-visit-sync-server/internal/auth"
+	"github.com/theimer/browser-visit-logger/browser-visit-sync-server/internal/store"
+)
+
+const snapshotChunkSize = 256 * 1024
+
+type Server struct {
+	syncpb.UnimplementedBrowserVisitSyncServer
+	store *store.Store
+}
+
+func New(s *store.Store) *Server { return &Server{store: s} }
+
+func (s *Server) PushLogs(ctx context.Context, req *syncpb.PushLogsRequest) (*syncpb.PushLogsResponse, error) {
+	if err := auth.CrossCheck(ctx, req.GetMachineId()); err != nil {
+		return nil, err
+	}
+	if req.GetMachineId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "machine_id required")
+	}
+	lines := make([]store.LogLine, 0, len(req.GetLines()))
+	for _, l := range req.GetLines() {
+		if l.GetDate() == "" {
+			return nil, status.Error(codes.InvalidArgument, "log line missing date")
+		}
+		lines = append(lines, store.LogLine{
+			Date: l.GetDate(), LineOffset: l.GetLineOffset(), RawLine: l.GetRawLine(),
+		})
+	}
+	latestDate, latestOff, err := s.store.AppendLogLines(req.GetMachineId(), lines)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "append: %v", err)
+	}
+	for _, l := range lines {
+		if err := s.store.ReplayLine(l.RawLine); err != nil {
+			return nil, status.Errorf(codes.Internal, "replay: %v", err)
+		}
+	}
+	return &syncpb.PushLogsResponse{
+		AcceptedDate:       latestDate,
+		AcceptedLineOffset: latestOff,
+	}, nil
+}
+
+func (s *Server) PullLogs(req *syncpb.PullLogsRequest, stream syncpb.BrowserVisitSync_PullLogsServer) error {
+	if err := auth.CrossCheck(stream.Context(), req.GetMachineId()); err != nil {
+		return err
+	}
+	cursors := map[string]*syncpb.PeerCursor{}
+	for _, c := range req.GetCursors() {
+		cursors[c.GetPeerMachineId()] = c
+	}
+	enrolled, err := s.store.EnrolledMachines()
+	if err != nil {
+		return status.Errorf(codes.Internal, "list machines: %v", err)
+	}
+	for _, peer := range enrolled {
+		if peer == req.GetMachineId() {
+			continue // don't echo caller's own records
+		}
+		cursor := cursors[peer]
+		sinceDate := ""
+		var sinceOff int64 = -1
+		if cursor != nil {
+			sinceDate = cursor.GetDate()
+			sinceOff = cursor.GetLineOffset()
+		}
+		batch := make([]*syncpb.LogLine, 0, 128)
+		err := s.store.LinesAfter(peer, sinceDate, sinceOff, func(l store.LogLine) bool {
+			batch = append(batch, &syncpb.LogLine{
+				Date: l.Date, LineOffset: l.LineOffset, RawLine: l.RawLine,
+			})
+			if len(batch) >= 128 {
+				if err := stream.Send(&syncpb.LogChunk{PeerMachineId: peer, Lines: batch}); err != nil {
+					return false
+				}
+				batch = batch[:0]
+			}
+			return true
+		})
+		if err != nil {
+			return status.Errorf(codes.Internal, "scan %s: %v", peer, err)
+		}
+		if len(batch) > 0 {
+			if err := stream.Send(&syncpb.LogChunk{PeerMachineId: peer, Lines: batch}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Server) ExportDbSnapshot(req *syncpb.ExportDbSnapshotRequest, stream syncpb.BrowserVisitSync_ExportDbSnapshotServer) error {
+	if err := auth.CrossCheck(stream.Context(), req.GetMachineId()); err != nil {
+		return err
+	}
+	dir, err := os.MkdirTemp("", "bvl-snap-")
+	if err != nil {
+		return status.Errorf(codes.Internal, "mkdir temp: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	tmpPath := filepath.Join(dir, "snapshot.db")
+	// VACUUM INTO produces a transactionally-consistent copy without
+	// blocking writers, and emits a deterministic, defragmented file
+	// suitable for byte-stream transfer.
+	if _, err := s.store.DB().Exec(fmt.Sprintf(`VACUUM INTO '%s'`, escapeSinglequotes(tmpPath))); err != nil {
+		return status.Errorf(codes.Internal, "vacuum into: %v", err)
+	}
+	f, err := os.Open(tmpPath)
+	if err != nil {
+		return status.Errorf(codes.Internal, "open snapshot: %v", err)
+	}
+	defer f.Close()
+	buf := make([]byte, snapshotChunkSize)
+	for {
+		n, err := f.Read(buf)
+		if n > 0 {
+			if sendErr := stream.Send(&syncpb.DbSnapshotChunk{Data: buf[:n]}); sendErr != nil {
+				return sendErr
+			}
+		}
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return status.Errorf(codes.Internal, "read snapshot: %v", err)
+		}
+	}
+}
+
+func escapeSinglequotes(s string) string { return strings.ReplaceAll(s, "'", "''") }

--- a/browser-visit-sync-server/internal/server/server_test.go
+++ b/browser-visit-sync-server/internal/server/server_test.go
@@ -1,0 +1,335 @@
+package server
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	syncpb "github.com/theimer/browser-visit-logger/browser-visit-sync-server/gen/syncpb"
+	"github.com/theimer/browser-visit-logger/browser-visit-sync-server/internal/auth"
+	"github.com/theimer/browser-visit-logger/browser-visit-sync-server/internal/store"
+)
+
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "logs"), filepath.Join(dir, "db", "v.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+	return New(st)
+}
+
+// authed returns a context that looks like a successful mTLS pass for id.
+func authed(id string) context.Context {
+	return auth.ContextWithMachineID(context.Background(), id)
+}
+
+// ---- PushLogs ----
+
+func TestPushLogsCrossCheckFails(t *testing.T) {
+	s := newTestServer(t)
+	// No machine id in context → Unauthenticated.
+	_, err := s.PushLogs(context.Background(), &syncpb.PushLogsRequest{MachineId: "laptop-a"})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("want Unauthenticated, got %v", err)
+	}
+}
+
+func TestPushLogsEmptyMachineID(t *testing.T) {
+	s := newTestServer(t)
+	// CrossCheck passes (ctx id "" == claimed ""), then the explicit
+	// empty-machine_id guard fires.
+	_, err := s.PushLogs(authed(""), &syncpb.PushLogsRequest{MachineId: ""})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("want InvalidArgument, got %v", err)
+	}
+}
+
+func TestPushLogsMissingDate(t *testing.T) {
+	s := newTestServer(t)
+	_, err := s.PushLogs(authed("laptop-a"), &syncpb.PushLogsRequest{
+		MachineId: "laptop-a",
+		Lines:     []*syncpb.LogLine{{LineOffset: 0, RawLine: "x"}}, // no Date
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("want InvalidArgument, got %v", err)
+	}
+}
+
+func TestPushLogsSuccessAndReplay(t *testing.T) {
+	s := newTestServer(t)
+	resp, err := s.PushLogs(authed("laptop-a"), &syncpb.PushLogsRequest{
+		MachineId: "laptop-a",
+		Lines: []*syncpb.LogLine{
+			{Date: "2026-05-21", LineOffset: 0,
+				RawLine: "rid\t2026-05-21T10:00:00Z\thttps://x\tTitle"},
+			{Date: "2026-05-21", LineOffset: 1, RawLine: "rid\tsuccess"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("PushLogs: %v", err)
+	}
+	if resp.GetAcceptedDate() != "2026-05-21" || resp.GetAcceptedLineOffset() != 1 {
+		t.Fatalf("resp: %+v", resp)
+	}
+	// Replay happened: the visit row exists.
+	var n int
+	if err := s.store.DB().QueryRow(
+		"SELECT COUNT(*) FROM visits WHERE url='https://x'").Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("replay didn't insert visit: %d", n)
+	}
+}
+
+func TestPushLogsAppendError(t *testing.T) {
+	s := newTestServer(t)
+	// A gap (offset > 0 on an empty file) makes AppendLogLines fail.
+	_, err := s.PushLogs(authed("laptop-a"), &syncpb.PushLogsRequest{
+		MachineId: "laptop-a",
+		Lines:     []*syncpb.LogLine{{Date: "2026-05-21", LineOffset: 9, RawLine: "x"}},
+	})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("want Internal (append gap), got %v", err)
+	}
+}
+
+func TestPushLogsReplayError(t *testing.T) {
+	s := newTestServer(t)
+	s.store.DB().Close() // replay Exec will fail, but append (file I/O) still works
+	_, err := s.PushLogs(authed("laptop-a"), &syncpb.PushLogsRequest{
+		MachineId: "laptop-a",
+		Lines: []*syncpb.LogLine{
+			{Date: "2026-05-21", LineOffset: 0,
+				RawLine: "rid\tts\thttps://x\tTitle"},
+		},
+	})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("want Internal (replay), got %v", err)
+	}
+}
+
+// ---- PullLogs ----
+
+type fakePullStream struct {
+	grpc.ServerStream
+	ctx     context.Context
+	sent    []*syncpb.LogChunk
+	sendN   int
+	failN   int  // fail Send on the (failN)th call (1-based); 0 = never
+	failAll bool // fail every Send
+}
+
+func (f *fakePullStream) Context() context.Context { return f.ctx }
+func (f *fakePullStream) Send(c *syncpb.LogChunk) error {
+	f.sendN++
+	if f.failAll || (f.failN != 0 && f.sendN == f.failN) {
+		return status.Error(codes.Unavailable, "send boom")
+	}
+	// Copy the lines slice — the caller reuses its backing array
+	// across batches (batch = batch[:0]).
+	cp := make([]*syncpb.LogLine, len(c.Lines))
+	copy(cp, c.Lines)
+	f.sent = append(f.sent, &syncpb.LogChunk{PeerMachineId: c.PeerMachineId, Lines: cp})
+	return nil
+}
+
+func TestPullLogsCrossCheckFails(t *testing.T) {
+	s := newTestServer(t)
+	err := s.PullLogs(&syncpb.PullLogsRequest{MachineId: "laptop-a"},
+		&fakePullStream{ctx: context.Background()})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("want Unauthenticated, got %v", err)
+	}
+}
+
+func TestPullLogsStreamsPeersExcludingSelf(t *testing.T) {
+	s := newTestServer(t)
+	// Seed two machines.
+	mustPush(t, s, "laptop-a", "2026-05-21", "a-line")
+	mustPush(t, s, "laptop-b", "2026-05-21", "b-line")
+
+	stream := &fakePullStream{ctx: authed("laptop-a")}
+	err := s.PullLogs(&syncpb.PullLogsRequest{MachineId: "laptop-a"}, stream)
+	if err != nil {
+		t.Fatalf("PullLogs: %v", err)
+	}
+	// Only laptop-b's lines come back (self excluded).
+	if len(stream.sent) != 1 || stream.sent[0].GetPeerMachineId() != "laptop-b" {
+		t.Fatalf("unexpected chunks: %+v", stream.sent)
+	}
+}
+
+func TestPullLogsHonoursCursor(t *testing.T) {
+	s := newTestServer(t)
+	mustPushOffsets(t, s, "laptop-b", "2026-05-21", []string{"l0", "l1"})
+
+	stream := &fakePullStream{ctx: authed("laptop-a")}
+	err := s.PullLogs(&syncpb.PullLogsRequest{
+		MachineId: "laptop-a",
+		Cursors: []*syncpb.PeerCursor{
+			{PeerMachineId: "laptop-b", Date: "2026-05-21", LineOffset: 0},
+		},
+	}, stream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Cursor at offset 0 → only l1 streamed.
+	if len(stream.sent) != 1 || len(stream.sent[0].Lines) != 1 ||
+		stream.sent[0].Lines[0].GetRawLine() != "l1" {
+		t.Fatalf("cursor not honoured: %+v", stream.sent)
+	}
+}
+
+func TestPullLogsBatchedMidScanSend(t *testing.T) {
+	s := newTestServer(t)
+	// 130 lines for one peer forces a mid-scan flush at the 128 mark
+	// (the batched stream.Send inside LinesAfter's yield).
+	raws := make([]string, 130)
+	for i := range raws {
+		raws[i] = "line"
+	}
+	mustPushOffsets(t, s, "laptop-b", "2026-05-21", raws)
+
+	stream := &fakePullStream{ctx: authed("laptop-a")}
+	if err := s.PullLogs(&syncpb.PullLogsRequest{MachineId: "laptop-a"}, stream); err != nil {
+		t.Fatalf("PullLogs: %v", err)
+	}
+	// One full batch of 128 + a final flush of 2.
+	total := 0
+	for _, c := range stream.sent {
+		total += len(c.Lines)
+	}
+	if total != 130 {
+		t.Fatalf("expected 130 lines streamed, got %d", total)
+	}
+}
+
+func TestPullLogsBatchedMidScanSendError(t *testing.T) {
+	s := newTestServer(t)
+	raws := make([]string, 130)
+	for i := range raws {
+		raws[i] = "line"
+	}
+	mustPushOffsets(t, s, "laptop-b", "2026-05-21", raws)
+
+	// Fail every Send so the mid-scan batched Send error (return false)
+	// is exercised and the subsequent final-flush Send also fails.
+	stream := &fakePullStream{ctx: authed("laptop-a"), failAll: true}
+	err := s.PullLogs(&syncpb.PullLogsRequest{MachineId: "laptop-a"}, stream)
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("want Unavailable, got %v", err)
+	}
+}
+
+func TestPullLogsSendErrorFinalFlush(t *testing.T) {
+	s := newTestServer(t)
+	mustPush(t, s, "laptop-b", "2026-05-21", "b-line")
+	stream := &fakePullStream{ctx: authed("laptop-a"), failN: 1}
+	err := s.PullLogs(&syncpb.PullLogsRequest{MachineId: "laptop-a"}, stream)
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("want Unavailable from final-flush Send, got %v", err)
+	}
+}
+
+func TestPullLogsScanError(t *testing.T) {
+	s := newTestServer(t)
+	mustPush(t, s, "laptop-b", "2026-05-21", "b-line")
+	// Make laptop-b's log dir unreadable so LinesAfter errors.
+	makeUnreadable(t, s, "laptop-b")
+	stream := &fakePullStream{ctx: authed("laptop-a")}
+	err := s.PullLogs(&syncpb.PullLogsRequest{MachineId: "laptop-a"}, stream)
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("want Internal (scan), got %v", err)
+	}
+}
+
+func TestPullLogsEnrolledError(t *testing.T) {
+	s := newTestServer(t)
+	mustPush(t, s, "laptop-b", "2026-05-21", "b-line")
+	makeLogRootUnreadable(t, s)
+	stream := &fakePullStream{ctx: authed("laptop-a")}
+	err := s.PullLogs(&syncpb.PullLogsRequest{MachineId: "laptop-a"}, stream)
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("want Internal (enrolled), got %v", err)
+	}
+}
+
+// ---- ExportDbSnapshot ----
+
+type fakeSnapStream struct {
+	grpc.ServerStream
+	ctx     context.Context
+	total   int
+	failN   int
+	sendN   int
+}
+
+func (f *fakeSnapStream) Context() context.Context { return f.ctx }
+func (f *fakeSnapStream) Send(c *syncpb.DbSnapshotChunk) error {
+	f.sendN++
+	if f.failN != 0 && f.sendN == f.failN {
+		return status.Error(codes.Unavailable, "snap send boom")
+	}
+	f.total += len(c.GetData())
+	return nil
+}
+
+func TestExportCrossCheckFails(t *testing.T) {
+	s := newTestServer(t)
+	err := s.ExportDbSnapshot(&syncpb.ExportDbSnapshotRequest{MachineId: "laptop-a"},
+		&fakeSnapStream{ctx: context.Background()})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("want Unauthenticated, got %v", err)
+	}
+}
+
+func TestExportSuccess(t *testing.T) {
+	s := newTestServer(t)
+	mustPush(t, s, "laptop-a", "2026-05-21",
+		"rid\t2026-05-21T10:00:00Z\thttps://x\tTitle")
+	stream := &fakeSnapStream{ctx: authed("laptop-a")}
+	if err := s.ExportDbSnapshot(
+		&syncpb.ExportDbSnapshotRequest{MachineId: "laptop-a"}, stream); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if stream.total == 0 {
+		t.Fatal("expected snapshot bytes")
+	}
+}
+
+func TestExportVacuumError(t *testing.T) {
+	s := newTestServer(t)
+	s.store.DB().Close() // VACUUM INTO fails on a closed DB
+	err := s.ExportDbSnapshot(
+		&syncpb.ExportDbSnapshotRequest{MachineId: "laptop-a"},
+		&fakeSnapStream{ctx: authed("laptop-a")})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("want Internal (vacuum), got %v", err)
+	}
+}
+
+func TestExportSendError(t *testing.T) {
+	s := newTestServer(t)
+	mustPush(t, s, "laptop-a", "2026-05-21",
+		"rid\t2026-05-21T10:00:00Z\thttps://x\tTitle")
+	stream := &fakeSnapStream{ctx: authed("laptop-a"), failN: 1}
+	err := s.ExportDbSnapshot(
+		&syncpb.ExportDbSnapshotRequest{MachineId: "laptop-a"}, stream)
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("want Unavailable (send), got %v", err)
+	}
+}
+
+func TestEscapeSinglequotes(t *testing.T) {
+	if escapeSinglequotes("a'b") != "a''b" {
+		t.Fatal("escape")
+	}
+}

--- a/browser-visit-sync-server/internal/store/errors_test.go
+++ b/browser-visit-sync-server/internal/store/errors_test.go
@@ -1,0 +1,251 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// highWater's non-trivial path: an empty AppendLogLines call after data
+// exists makes it walk the dir and count the latest day's lines.
+func TestHighWaterPopulated(t *testing.T) {
+	st := openTestStore(t)
+	if _, _, err := st.AppendLogLines("laptop-a", []LogLine{
+		{Date: "2026-05-20", LineOffset: 0, RawLine: "a"},
+		{Date: "2026-05-21", LineOffset: 0, RawLine: "b"},
+		{Date: "2026-05-21", LineOffset: 1, RawLine: "c"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Empty batch → AppendLogLines delegates to highWater.
+	d, off, err := st.AppendLogLines("laptop-a", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d != "2026-05-21" || off != 1 {
+		t.Fatalf("highWater populated got (%q,%d) want (2026-05-21,1)", d, off)
+	}
+}
+
+// Open should fail when the log-root path can't be created because a
+// parent component is a regular file.
+func TestOpenMkdirLogRootError(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// logRoot under a file → MkdirAll fails.
+	_, err := Open(filepath.Join(blocker, "logs"), filepath.Join(dir, "db", "x.db"))
+	if err == nil {
+		t.Fatal("expected mkdir log root error")
+	}
+}
+
+// Open should fail when the DB directory can't be created.
+func TestOpenMkdirDBDirError(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Open(filepath.Join(dir, "logs"), filepath.Join(blocker, "db", "x.db"))
+	if err == nil {
+		t.Fatal("expected mkdir db dir error")
+	}
+}
+
+// When a machine "directory" is actually a regular file, pathFor's
+// MkdirAll fails — surfaced through AppendLogLines.
+func TestAppendLogLinesPathForError(t *testing.T) {
+	st := openTestStore(t)
+	// Create a file where the machine dir should be.
+	machineAsFile := filepath.Join(st.logRoot, "laptop-x")
+	if err := os.WriteFile(machineAsFile, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := st.AppendLogLines("laptop-x", []LogLine{
+		{Date: "2026-05-21", LineOffset: 0, RawLine: "a"},
+	})
+	if err == nil {
+		t.Fatal("expected pathFor mkdir error")
+	}
+}
+
+// countLines should surface a read error when the log "file" is a
+// directory (Open succeeds, Read fails with EISDIR).
+func TestCountLinesReadError(t *testing.T) {
+	st := openTestStore(t)
+	// Make the day-log path a directory.
+	machineDir := filepath.Join(st.logRoot, "laptop-a")
+	if err := os.MkdirAll(machineDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logAsDir := filepath.Join(machineDir, "browser-visits-2026-05-21.log")
+	if err := os.MkdirAll(logAsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := st.AppendLogLines("laptop-a", []LogLine{
+		{Date: "2026-05-21", LineOffset: 0, RawLine: "a"},
+	})
+	if err == nil {
+		t.Fatal("expected countLines read error")
+	}
+}
+
+// Closing the DB makes every subsequent Exec fail, exercising the
+// error-return branches in the replay paths.
+func TestReplayDBErrors(t *testing.T) {
+	st := openTestStore(t)
+	st.db.Close() // force "database is closed" on the next Exec
+
+	if err := st.ReplayLine(tsv("rid", "ts", "u", "t")); err == nil {
+		t.Error("replayBasic should surface DB error")
+	}
+	if err := st.ReplayLine(tsv("rid", "ts", "u", "t", "of_interest")); err == nil {
+		t.Error("5-field replay should surface DB error")
+	}
+	if err := st.ReplayLine(tsv("rid", "ts", "u", "t", "read", "f")); err == nil {
+		t.Error("6-field replay should surface DB error")
+	}
+}
+
+// setOfInterest / tagWithFilename's own error returns: replayBasic must
+// succeed first, then the follow-up statement must fail.  We force that
+// by dropping the visits table's columns out from under the UPDATE —
+// simplest is to drop the table after the INSERT-able schema check by
+// using a DB whose visits table is missing the of_interest column.
+func TestTagErrorsAfterVisitInsert(t *testing.T) {
+	st := openTestStore(t)
+	// Rename the column the follow-up UPDATEs depend on so INSERT into
+	// visits still works but the UPDATE statements fail.
+	if _, err := st.db.Exec(`ALTER TABLE visits DROP COLUMN of_interest`); err != nil {
+		t.Fatalf("prep: %v", err)
+	}
+	if err := st.ReplayLine(tsv("rid", "ts", "u1", "t", "of_interest")); err == nil {
+		t.Error("setOfInterest should fail after column drop")
+	}
+
+	// For read/skimmed, drop the counter column.
+	if _, err := st.db.Exec(`ALTER TABLE visits DROP COLUMN read`); err != nil {
+		t.Fatalf("prep read: %v", err)
+	}
+	if err := st.ReplayLine(tsv("rid", "ts", "u2", "t", "read", "f")); err == nil {
+		t.Error("tagWithFilename UPDATE should fail after counter column drop")
+	}
+}
+
+// LinesAfter should surface an os.Open error when a day-log file is
+// unreadable.
+func TestLinesAfterOpenError(t *testing.T) {
+	st := openTestStore(t)
+	if _, _, err := st.AppendLogLines("laptop-a", []LogLine{
+		{Date: "2026-05-21", LineOffset: 0, RawLine: "a"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(st.logRoot, "laptop-a", "browser-visits-2026-05-21.log")
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(path, 0o644) })
+	err := st.LinesAfter("laptop-a", "", -1, func(LogLine) bool { return true })
+	if err == nil {
+		t.Fatal("expected open error from unreadable log")
+	}
+}
+
+// EnrolledMachines / highWater should surface a ReadDir / stat error
+// when the log root is unreadable.
+func TestReadDirErrors(t *testing.T) {
+	st := openTestStore(t)
+	if _, _, err := st.AppendLogLines("laptop-a", []LogLine{
+		{Date: "2026-05-21", LineOffset: 0, RawLine: "a"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	machineDir := filepath.Join(st.logRoot, "laptop-a")
+	if err := os.Chmod(machineDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(machineDir, 0o755) })
+	// highWater walks the machine dir → ReadDir fails.
+	if _, _, err := st.AppendLogLines("laptop-a", nil); err == nil {
+		t.Error("highWater should surface ReadDir error")
+	}
+}
+
+// EnrolledMachines surfaces a ReadDir error when the log root is
+// unreadable.
+func TestEnrolledMachinesReadDirError(t *testing.T) {
+	st := openTestStore(t)
+	if err := os.Chmod(st.logRoot, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(st.logRoot, 0o755) })
+	if _, err := st.EnrolledMachines(); err == nil {
+		t.Fatal("expected ReadDir error")
+	}
+}
+
+// highWater surfaces a countLines error when the latest day-log path is
+// a directory rather than a file.
+func TestHighWaterCountLinesError(t *testing.T) {
+	st := openTestStore(t)
+	machineDir := filepath.Join(st.logRoot, "laptop-a")
+	if err := os.MkdirAll(machineDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A valid-looking day-log name that's actually a directory.
+	if err := os.MkdirAll(
+		filepath.Join(machineDir, "browser-visits-2026-05-21.log"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := st.highWater("laptop-a"); err == nil {
+		t.Fatal("expected countLines error from highWater")
+	}
+}
+
+// LinesAfter: yield returning false on a trailing partial (no final
+// newline) line stops iteration via the partial-line branch.
+func TestLinesAfterTrailingPartialEarlyStop(t *testing.T) {
+	st := openTestStore(t)
+	path, err := st.pathFor("laptop-a", "2026-05-21")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeRaw(path, "partial-no-newline"); err != nil {
+		t.Fatal(err)
+	}
+	got := 0
+	if err := st.LinesAfter("laptop-a", "", -1, func(LogLine) bool {
+		got++
+		return false // stop on the trailing partial line
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got != 1 {
+		t.Fatalf("expected 1 yielded partial line, got %d", got)
+	}
+}
+
+// EnrolledMachines skips non-directory entries in the log root.
+func TestEnrolledMachinesSkipsFiles(t *testing.T) {
+	st := openTestStore(t)
+	if _, _, err := st.AppendLogLines("laptop-a", []LogLine{
+		{Date: "2026-05-21", LineOffset: 0, RawLine: "a"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Stray file in the log root.
+	if err := os.WriteFile(filepath.Join(st.logRoot, "stray.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := st.EnrolledMachines()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != "laptop-a" {
+		t.Fatalf("EnrolledMachines should skip files: %v", got)
+	}
+}

--- a/browser-visit-sync-server/internal/store/replay.go
+++ b/browser-visit-sync-server/internal/store/replay.go
@@ -1,0 +1,106 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// ReplayLine parses one TSV log line and applies it to the canonical
+// DB.  Matches visits_rebuilder.py's logic:
+//   - 4 fields:  record_id, timestamp, url, title           → INSERT OR IGNORE visits
+//   - 5 fields:  ..., tag (of_interest)                     → set of_interest = 1
+//   - 6 fields:  ..., tag (read|skimmed), filename          → increment counter + insert event
+//   - 2 fields:  record_id, result                          → ignored (result line)
+//
+// Lines that don't match any known shape are skipped (caller can log).
+func (s *Store) ReplayLine(raw string) error {
+	fields := strings.Split(raw, "\t")
+	switch len(fields) {
+	case 2:
+		return nil // result line — no DB effect
+	case 4:
+		return s.replayBasic(fields[1], fields[2], fields[3])
+	case 5:
+		if err := s.replayBasic(fields[1], fields[2], fields[3]); err != nil {
+			return err
+		}
+		if fields[4] == "of_interest" {
+			return s.setOfInterest(fields[2])
+		}
+		return nil
+	case 6:
+		if err := s.replayBasic(fields[1], fields[2], fields[3]); err != nil {
+			return err
+		}
+		return s.tagWithFilename(fields[2], fields[1], fields[4], fields[5])
+	default:
+		return nil
+	}
+}
+
+func (s *Store) replayBasic(timestamp, url, title string) error {
+	_, err := s.db.Exec(
+		`INSERT OR IGNORE INTO visits (url, timestamp, title) VALUES (?, ?, ?)`,
+		url, timestamp, title)
+	return err
+}
+
+func (s *Store) setOfInterest(url string) error {
+	_, err := s.db.Exec(`UPDATE visits SET of_interest = '1' WHERE url = ?`, url)
+	return err
+}
+
+func (s *Store) tagWithFilename(url, timestamp, tag, filename string) error {
+	var (
+		eventsTable string
+		counterCol  string
+	)
+	switch tag {
+	case "read":
+		eventsTable = "read_events"
+		counterCol = "read"
+	case "skimmed":
+		eventsTable = "skimmed_events"
+		counterCol = "skimmed"
+	default:
+		return nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+	// The event row's primary key is (url, timestamp), so INSERT OR
+	// IGNORE deduplicates replays of the same log line.  We only
+	// bump the per-URL counter when the event row is actually new,
+	// which keeps `read`/`skimmed` consistent with the single-host
+	// EventsTable.swift semantics (one counter tick per unique
+	// (url, timestamp) event).
+	res, err := tx.Exec(
+		fmt.Sprintf(`INSERT OR IGNORE INTO %s (url, timestamp, filename) VALUES (?, ?, ?)`, eventsTable),
+		url, timestamp, filename)
+	if err != nil {
+		return err
+	}
+	inserted, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if inserted == 0 {
+		return tx.Commit() // duplicate replay; counter already reflects this event
+	}
+	if _, err = tx.Exec(
+		fmt.Sprintf(`UPDATE visits SET %s = %s + 1 WHERE url = ?`, counterCol, counterCol),
+		url); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// _ silences an unused-import warning during refactors.
+var _ = sql.ErrNoRows

--- a/browser-visit-sync-server/internal/store/replay_test.go
+++ b/browser-visit-sync-server/internal/store/replay_test.go
@@ -1,0 +1,144 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+func tsv(fields ...string) string { return strings.Join(fields, "\t") }
+
+func TestReplayResultLineIsNoOp(t *testing.T) {
+	st := openTestStore(t)
+	if err := st.ReplayLine("rid\tsuccess"); err != nil {
+		t.Fatal(err)
+	}
+	if n := countRows(t, st, "visits"); n != 0 {
+		t.Fatalf("result line touched visits: %d", n)
+	}
+}
+
+func TestReplayTooFewFieldsIgnored(t *testing.T) {
+	st := openTestStore(t)
+	if err := st.ReplayLine("only-one-field-but-not-two-tabs"); err != nil {
+		t.Fatal(err)
+	}
+	if n := countRows(t, st, "visits"); n != 0 {
+		t.Fatalf("malformed line touched visits: %d", n)
+	}
+}
+
+func TestReplayBasicVisit(t *testing.T) {
+	st := openTestStore(t)
+	if err := st.ReplayLine(tsv("rid", "2026-05-21T10:00:00Z", "https://x", "Title")); err != nil {
+		t.Fatal(err)
+	}
+	var ts, title string
+	row := st.DB().QueryRow("SELECT timestamp, title FROM visits WHERE url=?", "https://x")
+	if err := row.Scan(&ts, &title); err != nil {
+		t.Fatal(err)
+	}
+	if ts != "2026-05-21T10:00:00Z" || title != "Title" {
+		t.Fatalf("visit row wrong: %q %q", ts, title)
+	}
+}
+
+func TestReplayOfInterest(t *testing.T) {
+	st := openTestStore(t)
+	line := tsv("rid", "2026-05-21T10:00:00Z", "https://x", "Title", "of_interest")
+	if err := st.ReplayLine(line); err != nil {
+		t.Fatal(err)
+	}
+	var oi string
+	if err := st.DB().QueryRow("SELECT of_interest FROM visits WHERE url=?", "https://x").Scan(&oi); err != nil {
+		t.Fatal(err)
+	}
+	if oi != "1" {
+		t.Fatalf("of_interest=%q want 1", oi)
+	}
+}
+
+func TestReplayFiveFieldsUnknownTagJustInsertsVisit(t *testing.T) {
+	st := openTestStore(t)
+	// 5 fields but tag != of_interest → visit inserted, no flag set.
+	line := tsv("rid", "2026-05-21T10:00:00Z", "https://x", "Title", "weird")
+	if err := st.ReplayLine(line); err != nil {
+		t.Fatal(err)
+	}
+	var oi *string
+	if err := st.DB().QueryRow("SELECT of_interest FROM visits WHERE url=?", "https://x").Scan(&oi); err != nil {
+		t.Fatal(err)
+	}
+	if oi != nil {
+		t.Fatalf("of_interest should be NULL, got %v", *oi)
+	}
+}
+
+func TestReplayReadIncrementsCounterOncePerEvent(t *testing.T) {
+	st := openTestStore(t)
+	line := tsv("rid", "2026-05-21T10:00:00Z", "https://x", "Title", "read", "a.mhtml")
+	if err := st.ReplayLine(line); err != nil {
+		t.Fatal(err)
+	}
+	// Replay identical line → event dedups, counter stays at 1.
+	if err := st.ReplayLine(line); err != nil {
+		t.Fatal(err)
+	}
+	var readCount int
+	if err := st.DB().QueryRow("SELECT read FROM visits WHERE url=?", "https://x").Scan(&readCount); err != nil {
+		t.Fatal(err)
+	}
+	if readCount != 1 {
+		t.Fatalf("read counter=%d want 1 (dedup)", readCount)
+	}
+	// A second event with a distinct timestamp bumps to 2.
+	line2 := tsv("rid", "2026-05-21T10:05:00Z", "https://x", "Title", "read", "b.mhtml")
+	if err := st.ReplayLine(line2); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DB().QueryRow("SELECT read FROM visits WHERE url=?", "https://x").Scan(&readCount); err != nil {
+		t.Fatal(err)
+	}
+	if readCount != 2 {
+		t.Fatalf("read counter=%d want 2", readCount)
+	}
+}
+
+func TestReplaySkimmed(t *testing.T) {
+	st := openTestStore(t)
+	line := tsv("rid", "2026-05-21T10:00:00Z", "https://x", "Title", "skimmed", "a.mhtml")
+	if err := st.ReplayLine(line); err != nil {
+		t.Fatal(err)
+	}
+	var skimmed int
+	if err := st.DB().QueryRow("SELECT skimmed FROM visits WHERE url=?", "https://x").Scan(&skimmed); err != nil {
+		t.Fatal(err)
+	}
+	if skimmed != 1 {
+		t.Fatalf("skimmed=%d want 1", skimmed)
+	}
+}
+
+func TestReplaySixFieldsUnknownTagNoop(t *testing.T) {
+	st := openTestStore(t)
+	// 6 fields but tag is neither read nor skimmed → tagWithFilename
+	// returns early after the visit insert.
+	line := tsv("rid", "2026-05-21T10:00:00Z", "https://x", "Title", "bogus", "f.mhtml")
+	if err := st.ReplayLine(line); err != nil {
+		t.Fatal(err)
+	}
+	if n := countRows(t, st, "read_events"); n != 0 {
+		t.Fatalf("unknown 6-field tag created read_events: %d", n)
+	}
+	if n := countRows(t, st, "visits"); n != 1 {
+		t.Fatalf("visit row missing: %d", n)
+	}
+}
+
+func countRows(t *testing.T, st *Store, table string) int {
+	t.Helper()
+	var n int
+	if err := st.DB().QueryRow("SELECT COUNT(*) FROM " + table).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}

--- a/browser-visit-sync-server/internal/store/store.go
+++ b/browser-visit-sync-server/internal/store/store.go
@@ -1,0 +1,370 @@
+// Package store mirrors each laptop's per-day log file on the VM and
+// replays incoming lines into the canonical SQLite DB.
+//
+// On-disk layout:
+//
+//	<logRoot>/<machine_id>/browser-visits-YYYY-MM-DD.log
+//
+// PushLogs is idempotent on (machine_id, date, line_offset): the
+// store accepts any prefix or contiguous suffix of what's already on
+// disk for that file and drops duplicates.  Out-of-order pushes (a
+// later offset arriving before an earlier one) are rejected as an
+// invariant violation by the caller; BVLSync never produces that
+// pattern.
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+
+	_ "modernc.org/sqlite"
+)
+
+// Store handles all VM-side persistence: per-machine log files plus
+// the canonical SQLite DB.
+type Store struct {
+	logRoot string
+	db      *sql.DB
+
+	mu sync.Mutex // serialises per-file appends
+}
+
+func Open(logRoot, dbPath string) (*Store, error) {
+	if err := os.MkdirAll(logRoot, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir log root: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir db dir: %w", err)
+	}
+	db, err := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)")
+	if err != nil {
+		return nil, err
+	}
+	if err := ensureSchema(db); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return &Store{logRoot: logRoot, db: db}, nil
+}
+
+func (s *Store) Close() error { return s.db.Close() }
+
+// AppendLogLines writes the supplied lines to the per-machine, per-day
+// file iff they extend the file (line_offset == current line count).
+// Lines that fall strictly before the current count are silently
+// dropped as already-recorded.  A gap (offset > count) is an error.
+//
+// Returns the new high-water (date, line_offset) for that machine.
+func (s *Store) AppendLogLines(machineID string, lines []LogLine) (string, int64, error) {
+	if len(lines) == 0 {
+		date, off, err := s.highWater(machineID)
+		return date, off, err
+	}
+	// Group by date so we can write whole files in one open.
+	sort.Slice(lines, func(i, j int) bool {
+		if lines[i].Date != lines[j].Date {
+			return lines[i].Date < lines[j].Date
+		}
+		return lines[i].LineOffset < lines[j].LineOffset
+	})
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var (
+		latestDate   string
+		latestOffset int64
+	)
+	for _, group := range groupByDate(lines) {
+		path, err := s.pathFor(machineID, group[0].Date)
+		if err != nil {
+			return "", 0, err
+		}
+		curCount, err := countLines(path)
+		if err != nil {
+			return "", 0, err
+		}
+		toWrite := []LogLine{}
+		for _, l := range group {
+			switch {
+			case l.LineOffset < curCount:
+				continue // already on disk
+			case l.LineOffset == curCount:
+				toWrite = append(toWrite, l)
+				curCount++
+			default:
+				return "", 0, fmt.Errorf("gap: %s/%s expected offset %d, got %d", machineID, l.Date, curCount, l.LineOffset)
+			}
+		}
+		if len(toWrite) > 0 {
+			if err := appendFile(path, toWrite); err != nil {
+				return "", 0, err
+			}
+		}
+		latestDate = group[0].Date
+		latestOffset = curCount - 1
+	}
+	return latestDate, latestOffset, nil
+}
+
+// LinesAfter streams lines for one machine that come strictly after
+// the supplied cursor, ordered by (date asc, line_offset asc).
+//
+// The yield func returns false to stop iteration early.
+func (s *Store) LinesAfter(machineID, sinceDate string, sinceOffset int64, yield func(LogLine) bool) error {
+	dir := filepath.Join(s.logRoot, machineID)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	var dates []string
+	for _, e := range entries {
+		if d, ok := parseLogFilename(e.Name()); ok {
+			if d >= sinceDate {
+				dates = append(dates, d)
+			}
+		}
+	}
+	sort.Strings(dates)
+	for _, d := range dates {
+		path := filepath.Join(dir, fmt.Sprintf("browser-visits-%s.log", d))
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		err = func() error {
+			defer f.Close()
+			var offset int64
+			buf := make([]byte, 0, 4096)
+			scratch := make([]byte, 4096)
+			for {
+				n, err := f.Read(scratch)
+				if n > 0 {
+					buf = append(buf, scratch[:n]...)
+					for {
+						i := indexByte(buf, '\n')
+						if i < 0 {
+							break
+						}
+						line := string(buf[:i])
+						buf = buf[i+1:]
+						if d > sinceDate || offset > sinceOffset {
+							if !yield(LogLine{Date: d, LineOffset: offset, RawLine: line}) {
+								return io.EOF
+							}
+						}
+						offset++
+					}
+				}
+				if err == io.EOF {
+					if len(buf) > 0 {
+						// Trailing partial line (no final newline) — emit if past cursor.
+						if d > sinceDate || offset > sinceOffset {
+							if !yield(LogLine{Date: d, LineOffset: offset, RawLine: string(buf)}) {
+								return io.EOF
+							}
+						}
+					}
+					return nil
+				}
+				if err != nil {
+					return err
+				}
+			}
+		}()
+		if err != nil && !errors.Is(err, io.EOF) {
+			return err
+		}
+	}
+	return nil
+}
+
+// EnrolledMachines returns every machine_id the VM has ever seen a
+// PushLogs from (derived from the directory listing under logRoot).
+// Used by PullLogs to decide whose logs to scan when the caller's
+// cursor list is missing a peer.
+func (s *Store) EnrolledMachines() ([]string, error) {
+	entries, err := os.ReadDir(s.logRoot)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() {
+			out = append(out, e.Name())
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// DB returns the underlying sqlite handle so server-level code can run
+// VACUUM INTO etc.  Callers must not close it.
+func (s *Store) DB() *sql.DB { return s.db }
+
+// LogRoot returns the directory under which per-machine log mirrors
+// live.  Exposed so callers (and tests) can locate the on-disk files.
+func (s *Store) LogRoot() string { return s.logRoot }
+
+// ---------------------------------------------------------------- helpers
+
+type LogLine struct {
+	Date       string
+	LineOffset int64
+	RawLine    string
+}
+
+func groupByDate(lines []LogLine) [][]LogLine {
+	var groups [][]LogLine
+	start := 0
+	for i := 1; i <= len(lines); i++ {
+		if i == len(lines) || lines[i].Date != lines[start].Date {
+			groups = append(groups, lines[start:i])
+			start = i
+		}
+	}
+	return groups
+}
+
+func (s *Store) pathFor(machineID, date string) (string, error) {
+	dir := filepath.Join(s.logRoot, machineID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, fmt.Sprintf("browser-visits-%s.log", date)), nil
+}
+
+func countLines(path string) (int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	defer f.Close()
+	var n int64
+	buf := make([]byte, 64*1024)
+	for {
+		c, err := f.Read(buf)
+		for i := 0; i < c; i++ {
+			if buf[i] == '\n' {
+				n++
+			}
+		}
+		if err == io.EOF {
+			return n, nil
+		}
+		if err != nil {
+			return 0, err
+		}
+	}
+}
+
+func appendFile(path string, lines []LogLine) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	var b strings.Builder
+	for _, l := range lines {
+		b.WriteString(l.RawLine)
+		b.WriteByte('\n')
+	}
+	_, err = f.WriteString(b.String())
+	return err
+}
+
+func (s *Store) highWater(machineID string) (string, int64, error) {
+	dir := filepath.Join(s.logRoot, machineID)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", -1, nil
+		}
+		return "", 0, err
+	}
+	var dates []string
+	for _, e := range entries {
+		if d, ok := parseLogFilename(e.Name()); ok {
+			dates = append(dates, d)
+		}
+	}
+	if len(dates) == 0 {
+		return "", -1, nil
+	}
+	sort.Strings(dates)
+	latest := dates[len(dates)-1]
+	count, err := countLines(filepath.Join(dir, fmt.Sprintf("browser-visits-%s.log", latest)))
+	if err != nil {
+		return "", 0, err
+	}
+	return latest, count - 1, nil
+}
+
+var logFilenameRE = regexp.MustCompile(`^browser-visits-(\d{4}-\d{2}-\d{2})\.log$`)
+
+func parseLogFilename(name string) (string, bool) {
+	m := logFilenameRE.FindStringSubmatch(name)
+	if m == nil {
+		return "", false
+	}
+	return m[1], true
+}
+
+func indexByte(b []byte, c byte) int {
+	for i := 0; i < len(b); i++ {
+		if b[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+func ensureSchema(db *sql.DB) error {
+	// Mirrors browser-visit-logger/schema.sql verbatim. Kept in lockstep
+	// by hand for now; a follow-up will load the .sql file at runtime.
+	const ddl = `
+CREATE TABLE IF NOT EXISTS visits (
+    url         TEXT PRIMARY KEY,
+    timestamp   TEXT NOT NULL,
+    title       TEXT NOT NULL DEFAULT '',
+    of_interest TEXT,
+    read        INTEGER NOT NULL DEFAULT 0,
+    skimmed     INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_visits_timestamp ON visits(timestamp);
+CREATE TABLE IF NOT EXISTS read_events (
+    url       TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    filename  TEXT NOT NULL DEFAULT '',
+    directory TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (url, timestamp)
+);
+CREATE TABLE IF NOT EXISTS skimmed_events (
+    url       TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    filename  TEXT NOT NULL DEFAULT '',
+    directory TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (url, timestamp)
+);
+CREATE TABLE IF NOT EXISTS snapshots (
+    date   TEXT PRIMARY KEY,
+    sealed INTEGER NOT NULL DEFAULT 0
+);
+`
+	_, err := db.Exec(ddl)
+	return err
+}

--- a/browser-visit-sync-server/internal/store/store_test.go
+++ b/browser-visit-sync-server/internal/store/store_test.go
@@ -1,0 +1,259 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeRaw(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+func openTestStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := Open(filepath.Join(dir, "logs"), filepath.Join(dir, "db", "visits.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+	return st
+}
+
+func TestLogRootAccessor(t *testing.T) {
+	st := openTestStore(t)
+	if st.LogRoot() == "" {
+		t.Fatal("LogRoot should be non-empty")
+	}
+}
+
+func TestOpenCreatesDirsAndSchema(t *testing.T) {
+	st := openTestStore(t)
+	// Schema present: a bare query against each table should succeed.
+	for _, tbl := range []string{"visits", "read_events", "skimmed_events", "snapshots"} {
+		if _, err := st.DB().Exec("SELECT * FROM " + tbl + " LIMIT 0"); err != nil {
+			t.Errorf("table %s missing: %v", tbl, err)
+		}
+	}
+}
+
+func TestAppendLogLinesEmptyReturnsHighWater(t *testing.T) {
+	st := openTestStore(t)
+	// No lines, nothing on disk yet → date "", offset -1.
+	date, off, err := st.AppendLogLines("laptop-a", nil)
+	if err != nil {
+		t.Fatalf("AppendLogLines empty: %v", err)
+	}
+	if date != "" || off != -1 {
+		t.Fatalf("got (%q,%d), want (\"\",-1)", date, off)
+	}
+}
+
+func TestAppendLogLinesAppendsAndIsIdempotent(t *testing.T) {
+	st := openTestStore(t)
+	batch := []LogLine{
+		{Date: "2026-05-21", LineOffset: 0, RawLine: "a"},
+		{Date: "2026-05-21", LineOffset: 1, RawLine: "b"},
+	}
+	d, off, err := st.AppendLogLines("laptop-a", batch)
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if d != "2026-05-21" || off != 1 {
+		t.Fatalf("got (%q,%d), want (2026-05-21,1)", d, off)
+	}
+
+	// Replaying the same batch is a no-op (dedup against existing length).
+	d2, off2, err := st.AppendLogLines("laptop-a", batch)
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	if d2 != "2026-05-21" || off2 != 1 {
+		t.Fatalf("replay got (%q,%d), want (2026-05-21,1)", d2, off2)
+	}
+
+	// Only two lines on disk.
+	var lines []LogLine
+	if err := st.LinesAfter("laptop-a", "", -1, func(l LogLine) bool {
+		lines = append(lines, l)
+		return true
+	}); err != nil {
+		t.Fatalf("LinesAfter: %v", err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines on disk, got %d", len(lines))
+	}
+}
+
+func TestAppendLogLinesGapIsError(t *testing.T) {
+	st := openTestStore(t)
+	_, _, err := st.AppendLogLines("laptop-a", []LogLine{
+		{Date: "2026-05-21", LineOffset: 5, RawLine: "x"},
+	})
+	if err == nil {
+		t.Fatal("expected gap error, got nil")
+	}
+}
+
+func TestAppendLogLinesMultiDate(t *testing.T) {
+	st := openTestStore(t)
+	d, off, err := st.AppendLogLines("laptop-a", []LogLine{
+		{Date: "2026-05-21", LineOffset: 0, RawLine: "a"},
+		{Date: "2026-05-22", LineOffset: 0, RawLine: "b"},
+	})
+	if err != nil {
+		t.Fatalf("append multi-date: %v", err)
+	}
+	// Latest group wins for the returned high-water mark.
+	if d != "2026-05-22" || off != 0 {
+		t.Fatalf("got (%q,%d), want (2026-05-22,0)", d, off)
+	}
+}
+
+func TestLinesAfterCursorAndMultiDay(t *testing.T) {
+	st := openTestStore(t)
+	if _, _, err := st.AppendLogLines("laptop-a", []LogLine{
+		{Date: "2026-05-21", LineOffset: 0, RawLine: "a0"},
+		{Date: "2026-05-21", LineOffset: 1, RawLine: "a1"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := st.AppendLogLines("laptop-a", []LogLine{
+		{Date: "2026-05-22", LineOffset: 0, RawLine: "b0"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cursor at (2026-05-21, 0): should see a1, b0 — not a0.
+	var got []string
+	if err := st.LinesAfter("laptop-a", "2026-05-21", 0, func(l LogLine) bool {
+		got = append(got, l.RawLine)
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0] != "a1" || got[1] != "b0" {
+		t.Fatalf("cursor walk wrong: %v", got)
+	}
+}
+
+func TestLinesAfterEarlyStop(t *testing.T) {
+	st := openTestStore(t)
+	if _, _, err := st.AppendLogLines("laptop-a", []LogLine{
+		{Date: "2026-05-21", LineOffset: 0, RawLine: "a0"},
+		{Date: "2026-05-21", LineOffset: 1, RawLine: "a1"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	if err := st.LinesAfter("laptop-a", "", -1, func(l LogLine) bool {
+		count++
+		return false // stop after the first
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("early stop: callback ran %d times, want 1", count)
+	}
+}
+
+func TestLinesAfterMissingMachine(t *testing.T) {
+	st := openTestStore(t)
+	// Unknown machine dir → no error, no lines.
+	called := false
+	if err := st.LinesAfter("ghost", "", -1, func(l LogLine) bool {
+		called = true
+		return true
+	}); err != nil {
+		t.Fatalf("LinesAfter missing: %v", err)
+	}
+	if called {
+		t.Fatal("callback should not run for missing machine")
+	}
+}
+
+func TestLinesAfterTrailingPartialLine(t *testing.T) {
+	st := openTestStore(t)
+	// Write a file with no trailing newline by going around AppendLogLines.
+	path, err := st.pathFor("laptop-a", "2026-05-21")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeRaw(path, "line0\nline1-no-newline"); err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	if err := st.LinesAfter("laptop-a", "", -1, func(l LogLine) bool {
+		got = append(got, l.RawLine)
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[1] != "line1-no-newline" {
+		t.Fatalf("partial-line handling wrong: %v", got)
+	}
+}
+
+func TestEnrolledMachines(t *testing.T) {
+	st := openTestStore(t)
+	for _, m := range []string{"laptop-b", "laptop-a"} {
+		if _, _, err := st.AppendLogLines(m, []LogLine{
+			{Date: "2026-05-21", LineOffset: 0, RawLine: "x"},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := st.EnrolledMachines()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sorted.
+	if len(got) != 2 || got[0] != "laptop-a" || got[1] != "laptop-b" {
+		t.Fatalf("EnrolledMachines: %v", got)
+	}
+}
+
+func TestHighWaterEmptyMachine(t *testing.T) {
+	st := openTestStore(t)
+	d, off, err := st.highWater("nobody")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d != "" || off != -1 {
+		t.Fatalf("highWater empty: (%q,%d)", d, off)
+	}
+}
+
+func TestParseLogFilename(t *testing.T) {
+	cases := map[string]bool{
+		"browser-visits-2026-05-21.log": true,
+		"browser-visits-2026-5-21.log":  false,
+		"MANIFEST.tsv":                  false,
+		"browser-visits-.log":           false,
+	}
+	for name, want := range cases {
+		_, ok := parseLogFilename(name)
+		if ok != want {
+			t.Errorf("parseLogFilename(%q)=%v want %v", name, ok, want)
+		}
+	}
+}
+
+func TestGroupByDate(t *testing.T) {
+	groups := groupByDate([]LogLine{
+		{Date: "d1"}, {Date: "d1"}, {Date: "d2"},
+	})
+	if len(groups) != 2 || len(groups[0]) != 2 || len(groups[1]) != 1 {
+		t.Fatalf("groupByDate wrong: %v", groups)
+	}
+}
+
+func TestIndexByte(t *testing.T) {
+	if indexByte([]byte("abc"), 'b') != 1 {
+		t.Fatal("indexByte hit wrong")
+	}
+	if indexByte([]byte("abc"), 'z') != -1 {
+		t.Fatal("indexByte miss should be -1")
+	}
+}

--- a/browser-visit-sync-server/proto/sync.proto
+++ b/browser-visit-sync-server/proto/sync.proto
@@ -1,0 +1,66 @@
+syntax = "proto3";
+
+package bvl.sync.v1;
+
+option go_package = "github.com/theimer/browser-visit-logger/browser-visit-sync-server/gen/syncpb;syncpb";
+
+// BrowserVisitSync is the gRPC service exposed by the EC2 VM to laptops
+// running BVLSync. Authentication is mTLS: the client cert CN must
+// equal the machine_id present in each request.
+service BrowserVisitSync {
+  // Append log lines to the VM's mirror of the caller's log files and
+  // replay them into the canonical DB.
+  rpc PushLogs (PushLogsRequest) returns (PushLogsResponse);
+
+  // Stream log lines from every peer machine the caller hasn't fully
+  // synced yet, based on the per-peer cursors the caller supplies.
+  rpc PullLogs (PullLogsRequest) returns (stream LogChunk);
+
+  // Stream a transactionally-consistent SQLite snapshot of the VM's
+  // canonical DB (`VACUUM INTO` server-side). Used by the db_diff tool.
+  rpc ExportDbSnapshot (ExportDbSnapshotRequest) returns (stream DbSnapshotChunk);
+}
+
+// One TSV line as written on the originating laptop, plus enough
+// metadata to address it uniquely.
+message LogLine {
+  string date = 1;          // 'YYYY-MM-DD' UTC bucket the line belongs to.
+  int64 line_offset = 2;    // 0-based monotonic offset within (machine_id, date).
+  string raw_line = 3;      // Exact TSV line, without trailing newline.
+}
+
+message PushLogsRequest {
+  string machine_id = 1;             // Sender machine_id. Cross-checked against mTLS CN.
+  repeated LogLine lines = 2;
+}
+
+message PushLogsResponse {
+  // High-water mark the server now has for the caller, after applying
+  // this batch. Client uses it to advance its self-cursor.
+  string accepted_date = 1;
+  int64 accepted_line_offset = 2;
+}
+
+message PeerCursor {
+  string peer_machine_id = 1;
+  string date = 2;          // Highest fully-pulled date.
+  int64 line_offset = 3;    // Highest fully-pulled offset within that date.
+}
+
+message PullLogsRequest {
+  string machine_id = 1;             // Caller. Self-records won't be echoed back.
+  repeated PeerCursor cursors = 2;   // One per peer the caller knows about. Missing peers default to (date='', offset=0).
+}
+
+message LogChunk {
+  string peer_machine_id = 1;
+  repeated LogLine lines = 2;
+}
+
+message ExportDbSnapshotRequest {
+  string machine_id = 1;
+}
+
+message DbSnapshotChunk {
+  bytes data = 1;
+}

--- a/browser-visit-sync-server/test/README.md
+++ b/browser-visit-sync-server/test/README.md
@@ -1,0 +1,89 @@
+# Integration tests
+
+End-to-end tests that exercise the dockerized sync-server with real
+mTLS over a real TCP socket.  Designed to run on the developer's Mac
+without an EC2 instance.
+
+## What's tested
+
+| Scenario | Verifies |
+|---|---|
+| Push + Pull round-trip | A laptop's pushed lines reach other laptops; the sender doesn't get its own lines echoed. |
+| Push idempotency | Replaying the same `PushLogs` doesn't double-count. |
+| Read counter convergence | `visits.read` counter sums to 2 when two laptops mark the same URL as read. |
+| Rogue cert rejection | A signed-but-not-enrolled cert gets `PERMISSION_DENIED`. |
+| Identity spoof rejection | Laptop A's cert claiming to be laptop B is refused. |
+| `ExportDbSnapshot` validity | Streamed bytes form a valid SQLite file with the expected tables. |
+| End-to-end with `db_diff.py` | `db_diff.py` reports zero differences when fed the same snapshot twice. |
+
+## Prereqs
+
+- Docker + `docker compose` (Docker Desktop on Mac, or rootless Docker).
+- Python 3 (the venv + deps are created automatically — see Running).
+- `openssl` and `bash` on `$PATH` (default on macOS).
+
+`protoc` and `go` are **not** required on the host — the Docker build
+installs them and runs `make proto` + `go mod tidy` + `go build`
+internally.  The Python test driver generates its own gRPC stubs via
+`grpcio-tools` (installed into the test venv).
+
+## Running
+
+```
+cd browser-visit-sync-server
+make test-integration
+```
+
+`make test-integration` is the only command you should ever need.  On
+first run it creates `test/.venv/` (a Python virtualenv) and installs
+`test/requirements.txt` into it; subsequent runs reuse the venv.  The
+host's system Python is never touched.
+
+To rebuild the venv after editing `requirements.txt`:
+
+```
+make clean-venv test-integration
+```
+
+## Watching the server live
+
+Two terminals.  In the first, bring up a sticky stack and tail logs:
+
+```
+BVL_TEST_KEEP_RUNNING=1 make test-integration   # leaves the stack up
+docker compose -f docker-compose.test.yml logs -f sync-server
+```
+
+In a second terminal, fire individual tests at the *already-running*
+stack (do NOT use the normal `make test-integration` here — it would
+tear down the server out from under your `logs -f`):
+
+```
+BVL_TEST_USE_EXISTING=1 test/.venv/bin/python -m pytest \
+    test/test_sync.py::test_push_pull_round_trip -v
+```
+
+When done, in either terminal:
+
+```
+docker compose -f docker-compose.test.yml down -v
+```
+
+To keep the stack running between runs (for debugging):
+
+```
+BVL_TEST_KEEP_RUNNING=1 make test-integration
+docker compose -f docker-compose.test.yml logs -f sync-server
+docker compose -f docker-compose.test.yml down -v   # cleanup
+```
+
+## State that lives on disk
+
+```
+test/certs/                     minted on every run by gen-certs.sh
+test/state/enrolled_machines.db pre-seeded by seed-enrolled.py
+docker volume bvl-state         server's /var/lib (cleaned by `down -v`)
+```
+
+The certs and state directories are wiped at the start of every test
+session, so each run starts deterministic.

--- a/browser-visit-sync-server/test/conftest.py
+++ b/browser-visit-sync-server/test/conftest.py
@@ -1,0 +1,194 @@
+"""Pytest fixtures for integration tests against a live sync-server.
+
+Session-scoped fixtures bring the stack up once per `pytest` invocation:
+
+  1. Compile the proto into Python stubs on the fly (so we don't have to
+     check generated code in or require a separate codegen step on the
+     host).
+  2. Mint the cert hierarchy via test/gen-certs.sh.
+  3. Seed the enrolled_machines.db (excluding 'rogue-client' so the
+     "unenrolled rejection" test can use that cert).
+  4. Start the docker-compose stack (assumed: caller has set up Docker).
+  5. Wait until the server's listening socket accepts a TLS handshake.
+
+After all tests, tear the stack down.
+"""
+import os
+import shutil
+import socket
+import ssl
+import subprocess
+import sys
+import sqlite3
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+SERVER_DIR = HERE.parent          # browser-visit-sync-server/
+CERTS = HERE / 'certs'
+STATE = HERE / 'state'
+PROTO = SERVER_DIR / 'proto' / 'sync.proto'
+
+MACHINES = ['laptop-a', 'laptop-b', 'laptop-c']
+ROGUE = 'rogue-client'            # minted but NOT enrolled
+
+
+# ----------------------------------------------------------------- proto
+
+@pytest.fixture(scope='session')
+def grpc_stubs(tmp_path_factory):
+    """Compile sync.proto into a session-scoped temp dir and import it.
+
+    Returns (sync_pb2, sync_pb2_grpc).
+    """
+    out = tmp_path_factory.mktemp('syncpb')
+    from grpc_tools import protoc
+    rc = protoc.main([
+        'protoc',
+        f'-I{PROTO.parent}',
+        f'--python_out={out}',
+        f'--grpc_python_out={out}',
+        str(PROTO),
+    ])
+    if rc != 0:
+        pytest.fail(f"protoc failed (rc={rc})")
+    sys.path.insert(0, str(out))
+    import importlib
+    sync_pb2 = importlib.import_module('sync_pb2')
+    sync_pb2_grpc = importlib.import_module('sync_pb2_grpc')
+    return sync_pb2, sync_pb2_grpc
+
+
+# ----------------------------------------------------------------- certs
+
+@pytest.fixture(scope='session')
+def certs_dir():
+    # When reusing an existing server, the on-disk certs were minted
+    # by the original session and the running server has the matching
+    # CA loaded.  Regenerating now would break TLS — leave them be.
+    if os.environ.get('BVL_TEST_USE_EXISTING') == '1':
+        if not CERTS.exists():
+            pytest.fail(f"BVL_TEST_USE_EXISTING=1 but {CERTS} doesn't exist")
+        return CERTS
+    subprocess.check_call(
+        ['bash', str(HERE / 'gen-certs.sh'), *MACHINES, ROGUE])
+    return CERTS
+
+
+# ----------------------------------------------------------------- enrolled DB
+
+@pytest.fixture(scope='session')
+def enrolled_db(certs_dir):
+    STATE.mkdir(exist_ok=True)
+    db = STATE / 'enrolled_machines.db'
+    # Same reasoning as certs_dir: the running server has already
+    # opened this DB, and the fingerprints inside have to match its
+    # CA.  Don't touch.
+    if os.environ.get('BVL_TEST_USE_EXISTING') == '1':
+        if not db.exists():
+            pytest.fail(f"BVL_TEST_USE_EXISTING=1 but {db} doesn't exist")
+        return db
+    if db.exists():
+        db.unlink()
+    subprocess.check_call([
+        sys.executable, str(HERE / 'seed-enrolled.py'),
+        '--certs-dir', str(certs_dir),
+        '--db', str(db),
+        '--exclude', ROGUE,
+    ])
+    return db
+
+
+# ----------------------------------------------------------------- server
+
+@pytest.fixture(scope='session')
+def server(certs_dir, enrolled_db):
+    """Bring up the dockerised sync-server for the test session.
+
+    Two env-var knobs control lifecycle:
+
+    BVL_TEST_USE_EXISTING=1
+        Don't touch docker at all.  Assume a server is already
+        running on localhost:50443 and just verify it's reachable.
+        Use this when you've left a stack running (with
+        BVL_TEST_KEEP_RUNNING=1 previously) and want to fire
+        additional tests against it from a second terminal without
+        tearing down the one a `logs -f` is following.
+
+    BVL_TEST_KEEP_RUNNING=1
+        Bring the stack up normally, but skip the teardown at
+        session end so you can tail logs / poke at the server
+        afterwards.
+
+    With neither set, the fixture is fully self-contained: down,
+    build, up, run tests, down.
+    """
+    compose = ['docker', 'compose', '-f', str(SERVER_DIR / 'docker-compose.test.yml')]
+    use_existing = os.environ.get('BVL_TEST_USE_EXISTING') == '1'
+
+    if not use_existing:
+        # Always start clean.
+        subprocess.run(compose + ['down', '-v'], cwd=SERVER_DIR,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.check_call(compose + ['build'], cwd=SERVER_DIR)
+        subprocess.check_call(compose + ['up', '-d'], cwd=SERVER_DIR)
+
+    try:
+        _wait_for_tls('127.0.0.1', 50443, certs_dir, timeout=60)
+        yield {'addr': '127.0.0.1:50443', 'certs': certs_dir}
+    finally:
+        # Never tear down a stack we didn't bring up; never tear
+        # down when the user explicitly asked us to keep it.
+        if not use_existing and os.environ.get('BVL_TEST_KEEP_RUNNING') != '1':
+            subprocess.run(compose + ['down', '-v'], cwd=SERVER_DIR,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _wait_for_tls(host, port, certs, timeout):
+    deadline = time.time() + timeout
+    ctx = ssl.create_default_context(cafile=str(certs / 'ca.crt'))
+    ctx.load_cert_chain(certfile=str(certs / 'laptop-a.crt'),
+                        keyfile=str(certs / 'laptop-a.key'))
+    last_err = None
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=2) as sock:
+                with ctx.wrap_socket(sock, server_hostname='localhost'):
+                    return
+        except Exception as e:
+            last_err = e
+            time.sleep(0.5)
+    raise RuntimeError(f"server didn't come up on {host}:{port}: {last_err}")
+
+
+# ----------------------------------------------------------------- per-test channel
+
+@pytest.fixture
+def channel_for(server, grpc_stubs):
+    """Returns a factory: channel_for('laptop-a') → secure gRPC channel."""
+    import grpc
+    certs = server['certs']
+    addr = server['addr']
+
+    created = []
+    def factory(machine_id):
+        with open(certs / 'ca.crt', 'rb') as f: ca = f.read()
+        with open(certs / f'{machine_id}.crt', 'rb') as f: cert = f.read()
+        with open(certs / f'{machine_id}.key', 'rb') as f: key = f.read()
+        creds = grpc.ssl_channel_credentials(
+            root_certificates=ca, private_key=key, certificate_chain=cert)
+        # Override authority to match SAN on server cert.
+        ch = grpc.secure_channel(
+            addr, creds,
+            options=[('grpc.ssl_target_name_override', 'localhost')])
+        created.append(ch)
+        return ch
+
+    yield factory
+
+    for ch in created:
+        ch.close()

--- a/browser-visit-sync-server/test/gen-certs.sh
+++ b/browser-visit-sync-server/test/gen-certs.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# gen-certs.sh — Mint a CA, a server cert, and one client cert per
+# machine ID supplied on the command line, into ./certs/.
+#
+# Used by the integration-test harness to set up mTLS without any
+# external infrastructure.  Re-runs are destructive (the certs/ dir is
+# wiped) so the test starts from a known state every time.
+#
+# Usage:
+#   ./gen-certs.sh laptop-a laptop-b laptop-c rogue-client
+#
+# Output:
+#   certs/ca.crt              CA cert (use as both server-CA and client-CA)
+#   certs/ca.key              CA private key
+#   certs/server.crt          Server cert (CN=localhost, SAN=localhost,127.0.0.1)
+#   certs/server.key
+#   certs/<id>.crt            Client cert (CN=<id>)
+#   certs/<id>.key            Client private key
+#   certs/<id>.sha256         SHA-256 of DER-encoded client cert
+#   certs/fingerprints.tsv    machine_id<TAB>cert_sha256
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/certs"
+rm -rf "$DIR"
+mkdir -p "$DIR"
+cd "$DIR"
+
+# Minimal openssl config so SAN works without a config file.
+SAN_CNF=$(cat <<'EOF'
+[ req ]
+default_bits       = 2048
+prompt             = no
+default_md         = sha256
+distinguished_name = dn
+req_extensions     = req_ext
+
+[ dn ]
+CN = localhost
+
+[ req_ext ]
+subjectAltName = @alt_names
+extendedKeyUsage = serverAuth
+
+[ alt_names ]
+DNS.1 = localhost
+DNS.2 = sync-server
+IP.1  = 127.0.0.1
+EOF
+)
+
+# 1) CA
+openssl genrsa -out ca.key 2048 2>/dev/null
+openssl req -new -x509 -days 3650 -key ca.key -subj "/CN=bvl-test-ca" -out ca.crt
+
+# 2) Server cert
+echo "$SAN_CNF" > server.cnf
+openssl genrsa -out server.key 2048 2>/dev/null
+openssl req -new -key server.key -config server.cnf -out server.csr
+openssl x509 -req -days 3650 -in server.csr -CA ca.crt -CAkey ca.key \
+  -CAcreateserial -extfile server.cnf -extensions req_ext -out server.crt 2>/dev/null
+rm server.csr server.cnf
+
+# 3) Client certs
+# OpenSSL 3.x rejects extfiles without a named section, so use a small
+# inline file with a [client_ext] block.
+cat > client_ext.cnf <<'EOF'
+[ client_ext ]
+extendedKeyUsage = clientAuth
+keyUsage = digitalSignature
+EOF
+
+: > fingerprints.tsv
+for id in "$@"; do
+    openssl genrsa -out "${id}.key" 2048 2>/dev/null
+    openssl req -new -key "${id}.key" -subj "/CN=${id}" -out "${id}.csr"
+    openssl x509 -req -days 3650 -in "${id}.csr" -CA ca.crt -CAkey ca.key \
+      -CAcreateserial -extfile client_ext.cnf -extensions client_ext \
+      -out "${id}.crt" 2>/dev/null
+    rm "${id}.csr"
+    fp=$(openssl x509 -in "${id}.crt" -outform DER | openssl dgst -sha256 -hex | awk '{print $NF}')
+    echo "$fp" > "${id}.sha256"
+    printf '%s\t%s\n' "$id" "$fp" >> fingerprints.tsv
+done
+rm client_ext.cnf
+
+chmod 600 *.key
+echo "wrote certs to $DIR"
+cat fingerprints.tsv

--- a/browser-visit-sync-server/test/requirements.txt
+++ b/browser-visit-sync-server/test/requirements.txt
@@ -1,0 +1,3 @@
+grpcio==1.64.0
+grpcio-tools==1.64.0
+pytest==8.2.0

--- a/browser-visit-sync-server/test/seed-enrolled.py
+++ b/browser-visit-sync-server/test/seed-enrolled.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Seed the enrolled_machines.db from a fingerprints.tsv.
+
+Used by the test harness before starting the server.  Reads
+`<certs-dir>/fingerprints.tsv` (one `machine_id<TAB>cert_sha256` per
+line) and inserts a row for each (skipping any IDs passed via
+``--exclude``, which lets us mint a "rogue" cert that isn't enrolled
+so we can prove the auth path rejects it).
+"""
+import argparse
+import datetime
+import os
+import sqlite3
+import sys
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--certs-dir', required=True)
+    p.add_argument('--db', required=True)
+    p.add_argument('--exclude', action='append', default=[],
+                   help='machine_id values to omit from the enrolled table')
+    args = p.parse_args()
+
+    fp_path = os.path.join(args.certs_dir, 'fingerprints.tsv')
+    conn = sqlite3.connect(args.db)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS enrolled_machines (
+            machine_id TEXT PRIMARY KEY,
+            cert_sha256 TEXT NOT NULL,
+            enrolled_at TEXT NOT NULL
+        )
+    """)
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    skipped = set(args.exclude)
+    with open(fp_path) as f:
+        for line in f:
+            mid, fp = line.rstrip('\n').split('\t')
+            if mid in skipped:
+                print(f"skipping {mid}")
+                continue
+            conn.execute(
+                "INSERT OR REPLACE INTO enrolled_machines "
+                "(machine_id, cert_sha256, enrolled_at) VALUES (?, ?, ?)",
+                (mid, fp, now))
+            print(f"enrolled {mid}")
+    conn.commit()
+    conn.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/browser-visit-sync-server/test/test_sync.py
+++ b/browser-visit-sync-server/test/test_sync.py
@@ -1,0 +1,206 @@
+"""End-to-end integration tests against the dockerized sync-server.
+
+Scenarios:
+
+  * Push + Pull round-trip: laptop-a pushes lines; laptop-b pulls
+    and sees them; laptop-a does NOT get its own lines echoed back.
+  * Cursor idempotency: replaying the same PushLogs is a no-op (no
+    duplicate rows in the canonical DB, server reports same high
+    water mark).
+  * Read counter convergence: when both laptops record a 'read' on
+    the same URL, the canonical DB shows read=2 (summed).
+  * mTLS rejection: the rogue cert (minted but not enrolled) gets
+    PERMISSION_DENIED on any RPC.
+  * Identity spoofing rejection: laptop-a's cert sending a request
+    that claims machine_id='laptop-b' is refused.
+  * ExportDbSnapshot: returns a real SQLite file the local DB diff
+    tool can read.
+
+All scenarios share one server instance; tests don't reset state
+between cases, so they're written to be order-independent within
+their own URL namespace.
+"""
+import io
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+import grpc
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+TOOLS_DIR = HERE.parent.parent / 'browser-visit-tools'
+
+
+def _line(record_id, timestamp, url, title, tag=None, filename=None):
+    """Build a TSV log line matching VisitLog.appendAction's format."""
+    fields = [record_id, timestamp, url, title]
+    if tag:
+        fields.append(tag)
+        if tag in ('read', 'skimmed'):
+            fields.append(filename or '')
+    return '\t'.join(fields)
+
+
+def _push(stub, sync_pb2, machine_id, lines_with_offset, date='2026-05-21'):
+    pb = sync_pb2.PushLogsRequest(
+        machine_id=machine_id,
+        lines=[
+            sync_pb2.LogLine(date=date, line_offset=i, raw_line=raw)
+            for i, raw in lines_with_offset
+        ])
+    return stub.PushLogs(pb, timeout=10)
+
+
+def _pull_all(stub, sync_pb2, machine_id, cursors=None):
+    req = sync_pb2.PullLogsRequest(
+        machine_id=machine_id,
+        cursors=[
+            sync_pb2.PeerCursor(
+                peer_machine_id=peer, date=date, line_offset=off)
+            for peer, (date, off) in (cursors or {}).items()
+        ])
+    out = {}
+    for chunk in stub.PullLogs(req, timeout=15):
+        out.setdefault(chunk.peer_machine_id, []).extend(
+            (l.date, l.line_offset, l.raw_line) for l in chunk.lines)
+    return out
+
+
+# ----------------------------------------------------------------- tests
+
+def _result_line(record_id):
+    """Result line is 2 TSV fields: record_id, 'success'."""
+    return f"{record_id}\tsuccess"
+
+
+def test_push_pull_round_trip(channel_for, grpc_stubs):
+    sync_pb2, sync_pb2_grpc = grpc_stubs
+    a_url = f"https://a.example/{uuid.uuid4()}"
+    stub_a = sync_pb2_grpc.BrowserVisitSyncStub(channel_for('laptop-a'))
+    stub_b = sync_pb2_grpc.BrowserVisitSyncStub(channel_for('laptop-b'))
+
+    # Use a per-test date so each test starts fresh at offset 0 even
+    # though the server's state persists across tests in this session.
+    date = '2026-05-21'
+    lines = [
+        (0, _line('rid1', '2026-05-21T10:00:00Z', a_url, 'Title A')),
+        (1, _result_line('rid1')),
+        (2, _line('rid2', '2026-05-21T10:01:00Z', a_url, 'Title A', tag='of_interest')),
+        (3, _result_line('rid2')),
+    ]
+    resp = _push(stub_a, sync_pb2, 'laptop-a', lines, date=date)
+    assert resp.accepted_date == date
+    assert resp.accepted_line_offset == 3
+
+    # laptop-b pulls — should see all four lines for laptop-a.
+    chunks = _pull_all(stub_b, sync_pb2, 'laptop-b')
+    assert 'laptop-a' in chunks
+    assert len(chunks['laptop-a']) >= 4
+    assert 'laptop-b' not in chunks  # we haven't pushed anything yet
+
+    # laptop-a pulling: should NOT see its own records echoed.
+    chunks_a = _pull_all(stub_a, sync_pb2, 'laptop-a')
+    assert 'laptop-a' not in chunks_a
+
+
+def test_push_idempotent_on_replay(channel_for, grpc_stubs):
+    sync_pb2, sync_pb2_grpc = grpc_stubs
+    stub = sync_pb2_grpc.BrowserVisitSyncStub(channel_for('laptop-a'))
+    url = f"https://idem.example/{uuid.uuid4()}"
+    date = '2026-05-22'  # distinct from other tests
+    batch = [
+        (0, _line('rid-idem-1', '2026-05-22T11:00:00Z', url, 'T')),
+        (1, _result_line('rid-idem-1')),
+    ]
+    r1 = _push(stub, sync_pb2, 'laptop-a', batch, date=date)
+    r2 = _push(stub, sync_pb2, 'laptop-a', batch, date=date)
+    assert r1.accepted_date == r2.accepted_date
+    assert r1.accepted_line_offset == r2.accepted_line_offset
+
+
+def test_read_counter_sums_across_laptops(channel_for, grpc_stubs):
+    sync_pb2, sync_pb2_grpc = grpc_stubs
+    url = f"https://sum.example/{uuid.uuid4()}"
+    stub_a = sync_pb2_grpc.BrowserVisitSyncStub(channel_for('laptop-a'))
+    stub_b = sync_pb2_grpc.BrowserVisitSyncStub(channel_for('laptop-b'))
+
+    # Each laptop uses its own dedicated date so its offsets start at 0.
+    _push(stub_a, sync_pb2, 'laptop-a', [
+        (0, _line('rid-sum-a', '2026-05-23T12:00:00Z', url, 'S',
+                  tag='read', filename='a.mhtml')),
+        (1, _result_line('rid-sum-a')),
+    ], date='2026-05-23')
+    _push(stub_b, sync_pb2, 'laptop-b', [
+        (0, _line('rid-sum-b', '2026-05-23T12:00:01Z', url, 'S',
+                  tag='read', filename='b.mhtml')),
+        (1, _result_line('rid-sum-b')),
+    ], date='2026-05-23')
+
+    # Snapshot the canonical DB and inspect the counter directly.
+    db_path = _export_snapshot(channel_for, sync_pb2, sync_pb2_grpc, 'laptop-c')
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT read FROM visits WHERE url = ?", (url,)).fetchone()
+        assert row is not None, "URL not present in canonical DB"
+        assert row[0] == 2, f"expected read=2, got {row[0]}"
+
+
+def test_rogue_client_rejected(channel_for, grpc_stubs):
+    sync_pb2, sync_pb2_grpc = grpc_stubs
+    stub = sync_pb2_grpc.BrowserVisitSyncStub(channel_for('rogue-client'))
+    with pytest.raises(grpc.RpcError) as ei:
+        _push(stub, sync_pb2, 'rogue-client', [
+            (0, _line('rid-rogue', '2026-05-21T13:00:00Z', 'https://x', 'T'))])
+    assert ei.value.code() == grpc.StatusCode.PERMISSION_DENIED
+
+
+def test_identity_spoof_rejected(channel_for, grpc_stubs):
+    sync_pb2, sync_pb2_grpc = grpc_stubs
+    # Connect with laptop-a's cert but claim to be laptop-b.
+    stub = sync_pb2_grpc.BrowserVisitSyncStub(channel_for('laptop-a'))
+    with pytest.raises(grpc.RpcError) as ei:
+        _push(stub, sync_pb2, 'laptop-b', [
+            (0, _line('rid-spoof', '2026-05-21T13:30:00Z', 'https://x', 'T'))])
+    assert ei.value.code() == grpc.StatusCode.PERMISSION_DENIED
+
+
+def test_export_db_snapshot_is_valid_sqlite(channel_for, grpc_stubs):
+    sync_pb2, sync_pb2_grpc = grpc_stubs
+    db_path = _export_snapshot(channel_for, sync_pb2, sync_pb2_grpc, 'laptop-a')
+    assert os.path.getsize(db_path) > 0
+    with sqlite3.connect(db_path) as conn:
+        names = {r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'")}
+    # The canonical DB schema includes these tables, set up by the
+    # store layer.
+    assert {'visits', 'read_events', 'skimmed_events', 'snapshots'} <= names
+
+
+def test_db_diff_against_snapshot(channel_for, grpc_stubs):
+    """End-to-end: snapshot → feed to db_diff.py → expect 0 diffs vs itself."""
+    sync_pb2, sync_pb2_grpc = grpc_stubs
+    db = _export_snapshot(channel_for, sync_pb2, sync_pb2_grpc, 'laptop-a')
+    rc = subprocess.call([
+        sys.executable, str(TOOLS_DIR / 'db_diff.py'),
+        '--db-a', db, '--db-b', db,
+    ], stdout=subprocess.DEVNULL)
+    assert rc == 0
+
+
+# ----------------------------------------------------------------- helpers
+
+def _export_snapshot(channel_for, sync_pb2, sync_pb2_grpc, machine_id):
+    stub = sync_pb2_grpc.BrowserVisitSyncStub(channel_for(machine_id))
+    req = sync_pb2.ExportDbSnapshotRequest(machine_id=machine_id)
+    fd, path = tempfile.mkstemp(suffix='.db')
+    os.close(fd)
+    with open(path, 'wb') as f:
+        for chunk in stub.ExportDbSnapshot(req, timeout=30):
+            f.write(chunk.data)
+    return path

--- a/browser-visit-tools/.gitignore
+++ b/browser-visit-tools/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+.venv-test/
+.coverage
+coverage/

--- a/browser-visit-tools/Makefile
+++ b/browser-visit-tools/Makefile
@@ -1,0 +1,32 @@
+.PHONY: test venv clean clean-venv
+
+# Python venv for the test suite, colocated and gitignored.  Created
+# on first `make test`; reused afterward.  The host's system Python is
+# never touched.  Mirrors browser-visit-sync-server/Makefile.
+VENV       := .venv-test
+VENV_BIN   := $(VENV)/bin
+VENV_PY    := $(VENV_BIN)/python
+VENV_PIP   := $(VENV_BIN)/pip
+VENV_STAMP := $(VENV)/.installed
+
+venv: $(VENV_STAMP)
+
+$(VENV_STAMP): requirements-test.txt
+	python3 -m venv $(VENV)
+	$(VENV_PIP) install --upgrade pip
+	$(VENV_PIP) install -r requirements-test.txt
+	touch $(VENV_STAMP)
+
+# Run the suite with coverage over every shipped module.  --cov-fail-under
+# makes a coverage regression a hard failure.
+test: venv
+	$(VENV_PY) -m pytest tests/ \
+		--cov=reading_list --cov=db_diff --cov=fetch_vm_snapshot \
+		--cov=enroll_machine --cov=migrate_icloud_to_gdrive \
+		--cov-report=term-missing --cov-fail-under=100
+
+clean:
+	rm -rf .pytest_cache .coverage
+
+clean-venv:
+	rm -rf $(VENV)

--- a/browser-visit-tools/README.md
+++ b/browser-visit-tools/README.md
@@ -1,18 +1,24 @@
 # Browser Visit Tools
 
-Standalone command-line tools that consume the SQLite database produced
-by the sibling [`browser-visit-logger/`](../browser-visit-logger/)
-project.  Read-only consumers — they never write back to the database.
+Command-line tools that complement the
+[`browser-visit-logger/`](../browser-visit-logger/) project.  Split
+into two groups:
 
-These tools depend only on the DB schema (`visits`, `read_events`,
-`skimmed_events`).  No Python imports cross the directory boundary,
-so this project can be vendored or copied without dragging the logger
-along.
+- **Read-only DB consumers** — `reading_list.py`, `db_diff.py`.
+  Depend only on the DB schema (`visits`, `read_events`,
+  `skimmed_events`).  No Python imports cross the directory
+  boundary, so they can be vendored or copied without the logger.
+- **Multi-laptop sync operations** — `fetch_vm_snapshot.py`,
+  `enroll_machine.py`, `migrate_icloud_to_gdrive.py`,
+  `install_laptop.sh`, `uninstall_laptop_legacy.sh`.  Specific to
+  the multi-laptop architecture (see the top-level
+  [README](../README.md) and
+  [`browser-visit-sync-server/`](../browser-visit-sync-server/)).
 
 ## CLI scripts
 
 All scripts live at the project root.  They share the same `BVL_*`
-env-var conventions as `browser-visit-logger` (currently just
+env-var conventions as `browser-visit-logger` (notably
 `BVL_DB_FILE`) and accept overriding flags so they're safe to point
 at test data.
 
@@ -20,9 +26,15 @@ Each shell wrapper delegates to a Python script.  The wrapper forwards
 all arguments verbatim and intercepts `--help` / `-h` to print a
 one-line wrapper note before delegating.
 
-| Wrapper | Underlying tool |
-|---------|------------------|
-| `./generate_reading_list` | `reading_list.py` (Python) |
+| Wrapper / script | Underlying tool | Purpose |
+|---|---|---|
+| `./generate_reading_list` | `reading_list.py` | of_interest-but-unread → HTML or Markdown |
+| `db_diff.py` | (Python, no wrapper) | Diff two `browser-visits.db` files |
+| `fetch_vm_snapshot.py` | (Python, no wrapper) | Download a consistent VM DB snapshot via gRPC |
+| `enroll_machine.py` | (Python, no wrapper) | VM-side admin: enroll a laptop's mTLS cert |
+| `migrate_icloud_to_gdrive.py` | (Python, no wrapper) | One-time iCloud → Google Drive snapshot migration |
+| `install_laptop.sh` | (Bash) | Laptop install for multi-laptop mode |
+| `uninstall_laptop_legacy.sh` | (Bash) | Remove legacy verifier LaunchAgent |
 
 ### `generate_reading_list`
 
@@ -77,28 +89,207 @@ Flags:
 | `--output FILE` | Override the default output path; takes precedence over the format-derived default |
 | `-v`, `--verbose` | DEBUG log level |
 
+The default output directory is `~/Documents/browser-visit-logger/`,
+overridable via the `BVL_OUTPUT_DIR` env var (an explicit `--output`
+still wins over both).
+
 The output file is overwritten on every run.  Parent directory is
 created if missing.  Exit codes: `0` on success, `1` if the database
 file is missing.
 
-## Development
+### `db_diff.py`
+
+Compares two `browser-visits.db` SQLite files.  Reports presence
+differences (rows in A not in B, and vice versa) per table, plus
+value differences for rows present in both.  Counter columns
+(`visits.read`, `visits.skimmed`) legitimately diverge between sync
+windows; suppress them with `--ignore-counters`.
+
+Exit codes: `0` no differences, `1` differences found, `2` tool
+error.  Output is text by default; pass `--format json` to pipe into
+other tooling.
 
 ```bash
-pip install -r requirements-test.txt
-python3 -m pytest tests/ --cov=reading_list --cov-report=term-missing
+# Diff a laptop's local DB against a freshly-pulled VM snapshot
+python3 fetch_vm_snapshot.py --server vm:50443 --machine-id $(hostname) \
+    --client-cert ~/.browser-visit-logger/tls/client.crt \
+    --client-key  ~/.browser-visit-logger/tls/client.key \
+    --ca          ~/.browser-visit-logger/tls/server-ca.crt \
+    --out /tmp/vm.db
+python3 db_diff.py --db-a ~/browser-visits.db --db-b /tmp/vm.db --ignore-counters
+
+# Diff two arbitrary snapshots
+python3 db_diff.py --db-a a.db --db-b b.db --sample 10 --format json
 ```
 
-45 tests, 100% line coverage.
+Default tables: `visits, read_events, skimmed_events, snapshots`
+(intrinsically per-machine tables — `sync_state`, `mover_errors` —
+are excluded).  Override with `--tables a,b,c`.
+
+### `fetch_vm_snapshot.py`
+
+gRPC client for the sync-server's `ExportDbSnapshot` RPC.  Streams a
+`VACUUM INTO`-produced copy of the canonical DB to a local file.
+Pairs with `db_diff.py`.
+
+Requires the generated Python gRPC stubs from
+`browser-visit-sync-server/gen/syncpb_py/`; the script tells you
+exactly which `make` target to run if they're missing.
+
+```bash
+python3 fetch_vm_snapshot.py \
+    --server bvl-vm.example.com:50443 \
+    --machine-id $(scutil --get LocalHostName) \
+    --client-cert ~/.browser-visit-logger/tls/client.crt \
+    --client-key  ~/.browser-visit-logger/tls/client.key \
+    --ca          ~/.browser-visit-logger/tls/server-ca.crt \
+    --out /tmp/vm-snapshot.db
+
+# Local dev (no TLS)
+python3 fetch_vm_snapshot.py --server localhost:50051 \
+    --machine-id laptop-a --insecure --out /tmp/vm.db \
+    --client-cert /dev/null --client-key /dev/null --ca /dev/null
+```
+
+### `enroll_machine.py`
+
+Admin tool that runs on the **EC2 VM** (or wherever you have the
+`enrolled_machines.db` SQLite file the sync-server reads).  Inserts
+a `(machine_id, cert_sha256, enrolled_at)` row so the server's
+mTLS interceptor accepts the laptop's client cert.
+
+```bash
+# Enroll
+python3 enroll_machine.py \
+    --db /var/lib/browser-visit-sync/enrolled_machines.db \
+    --machine-id marvins-mbp \
+    --cert /etc/browser-visit-sync/clients/marvins-mbp.crt
+
+# List
+python3 enroll_machine.py --db enrolled_machines.db --list
+
+# Revoke
+python3 enroll_machine.py --db enrolled_machines.db \
+    --machine-id marvins-mbp --revoke
+```
+
+Reads PEM (preferred — needs `cryptography`) or DER directly.
+
+### `migrate_icloud_to_gdrive.py`
+
+One-time migration for users moving from single-laptop to
+multi-laptop mode.  Copies every file under the iCloud snapshots
+root to the Google Drive root (preserving the `YYYY-MM-DD/` layout),
+verifies each file via SHA-256, and rewrites the `directory` column
+on every affected `read_events` / `skimmed_events` row.  Idempotent
+— re-runs skip files already present with matching hashes.  Always
+leaves the iCloud copy in place so you can verify before deleting
+it.
+
+```bash
+# Dry run first to see what would happen
+python3 migrate_icloud_to_gdrive.py --dry-run \
+    --src ~/Documents/browser-visit-logger/snapshots \
+    --dst "~/Library/CloudStorage/GoogleDrive/My Drive/browser-visit-logger/snapshots" \
+    --db  ~/browser-visits.db
+
+# Run for real
+python3 migrate_icloud_to_gdrive.py \
+    --src ~/Documents/browser-visit-logger/snapshots \
+    --dst "~/Library/CloudStorage/GoogleDrive/My Drive/browser-visit-logger/snapshots" \
+    --db  ~/browser-visits.db
+```
+
+### `install_laptop.sh`
+
+Orchestrates a multi-laptop-mode install on a Mac.  Three steps:
+
+1. Runs `uninstall_laptop_legacy.sh` (idempotent).
+2. Delegates to `browser-visit-logger/install.sh` to build /
+   re-sign the BVLHost app bundle and install the Chrome
+   native-messaging manifest.
+3. Writes `~/.browser-visit-logger/config.json` with this laptop's
+   `machine_id` (sanitised `scutil --get LocalHostName`) and an
+   optional `sync_server` endpoint.  Ensures `~/.browser-visit-logger/tls/`
+   exists with mode 0700 ready for the user to drop in
+   `client.crt` / `client.key` / `server-ca.crt`.
+
+```bash
+bash install_laptop.sh                              # uses existing config if any
+bash install_laptop.sh --server bvl-vm.example.com:50443
+```
+
+Prints the resolved `machine_id` at the end — pass it to
+`enroll_machine.py` on the VM.
+
+### `uninstall_laptop_legacy.sh`
+
+Removes the legacy `com.browser.visit.logger.snapshot_verifier`
+LaunchAgent and its `.app` bundle.  In multi-laptop mode, sealing /
+manifest verification / cross-day reconciliation all live on the VM
+now.  Idempotent and conservative: never touches user data
+(`~/browser-visits-*.log`, `~/browser-visits.db`, the iCloud
+archive, `~/.browser-visit-logger/`).  Also sweeps up the
+even-older `snapshot_mover` LaunchAgent if any install older than
+the verifier consolidation is still lingering.
+
+```bash
+bash uninstall_laptop_legacy.sh
+```
+
+`install_laptop.sh` runs this script as its first step, so most
+users never invoke it directly.
+
+## Development
+
+A `Makefile` builds a throwaway virtualenv under `.venv-test/`
+(gitignored, auto-created on first run) and runs the suite gated at
+100% line coverage — the host's system Python is never touched:
+
+```bash
+make test          # venv + pytest, --cov-fail-under=100 across all modules
+make clean-venv    # rebuild the venv after editing requirements-test.txt
+```
+
+**85 tests, 100% line coverage** across every shipped module:
+`reading_list.py`, `db_diff.py`, `fetch_vm_snapshot.py`,
+`enroll_machine.py`, `migrate_icloud_to_gdrive.py`.  These standalone
+unit tests are in addition to the end-to-end exercise the sync tools
+get from the integration suite under
+[`browser-visit-sync-server/test/`](../browser-visit-sync-server/test/).
+
+Test deps: `pytest`, `pytest-cov`, and `cryptography` (the last only
+because `enroll_machine.py`'s PEM-cert path uses it and the tests
+exercise that path).  `fetch_vm_snapshot.py`'s gRPC dependency is
+*faked* in tests, so `grpcio` is not required to run them.
+
+**Production-data safety.** `reading_list.py` is the only tool with
+`~`-rooted defaults (`BVL_DB_FILE` to read, `BVL_OUTPUT_DIR` to write);
+`tests/conftest.py` forces both to a throwaway sandbox before import so
+a mis-isolated test can never touch real data.  The other tools take
+all paths as required CLI args, so they have no default to guard.
 
 ## Project layout
 
 ```
 browser-visit-tools/
-├── reading_list.py          # generate the markdown reading list
-├── generate_reading_list    # bash wrapper → reading_list.py
+├── reading_list.py                 # generate the reading list (HTML / Markdown)
+├── generate_reading_list           # bash wrapper → reading_list.py
+├── db_diff.py                      # diff two SQLite browser-visits DBs
+├── fetch_vm_snapshot.py            # gRPC client → ExportDbSnapshot
+├── enroll_machine.py               # VM-side admin tool
+├── migrate_icloud_to_gdrive.py     # one-time archive migration
+├── install_laptop.sh               # multi-laptop laptop install
+├── uninstall_laptop_legacy.sh      # remove legacy verifier LaunchAgent
+├── Makefile                        # venv + test (gated at 100% coverage)
 ├── tests/
-│   ├── conftest.py
-│   └── test_reading_list.py
+│   ├── conftest.py                 # sandboxes BVL_DB_FILE / BVL_OUTPUT_DIR
+│   ├── test_reading_list.py
+│   ├── test_db_diff.py
+│   ├── test_enroll_machine.py
+│   ├── test_fetch_vm_snapshot.py
+│   └── test_migrate.py
 ├── requirements-test.txt
+├── .venv-test/                     # test virtualenv (gitignored, auto-created)
 └── README.md
 ```

--- a/browser-visit-tools/db_diff.py
+++ b/browser-visit-tools/db_diff.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+db_diff.py — Compare two browser-visits SQLite DB files.
+
+Useful for verifying that a laptop has converged with the EC2 VM, for
+debugging sync regressions, and for offline forensics.
+
+The tool opens both files read-only via ATTACH DATABASE and reports,
+per table:
+
+  1. *Presence* — primary keys in A missing from B, and vice versa.
+  2. *Value differences* — rows with matching PKs but differing
+     non-PK columns.
+
+`visits.read` and `visits.skimmed` are counters that legitimately
+diverge between sync windows.  Pass ``--ignore-counters`` to suppress
+those columns in the value-diff stage.
+
+Tables compared by default: visits, read_events, skimmed_events,
+snapshots.  `sync_state` and `mover_errors` are excluded because both
+are intrinsically per-machine.
+
+Usage
+-----
+    db_diff.py --db-a ~/browser-visits.db --db-b /tmp/vm.db
+    db_diff.py --db-a a.db --db-b b.db --ignore-counters --sample 10
+    db_diff.py --db-a a.db --db-b b.db --format json
+
+Exit codes
+----------
+    0   no differences
+    1   differences found
+    2   tool error (file not found, schema mismatch, ...)
+"""
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from typing import Any, Dict, List, Tuple
+
+
+DEFAULT_TABLES = ['visits', 'read_events', 'skimmed_events', 'snapshots']
+COUNTER_COLUMNS = {'visits': ('read', 'skimmed')}
+
+
+def _pk_columns(conn: sqlite3.Connection, db_alias: str, table: str) -> List[str]:
+    rows = list(conn.execute(f"PRAGMA {db_alias}.table_info({table})"))
+    pk_rows = sorted((r for r in rows if r[5] > 0), key=lambda r: r[5])
+    return [r[1] for r in pk_rows]
+
+
+def _all_columns(conn: sqlite3.Connection, db_alias: str, table: str) -> List[str]:
+    rows = list(conn.execute(f"PRAGMA {db_alias}.table_info({table})"))
+    return [r[1] for r in rows]
+
+
+def _table_exists(conn: sqlite3.Connection, db_alias: str, table: str) -> bool:
+    row = conn.execute(
+        f"SELECT 1 FROM {db_alias}.sqlite_master "
+        f"WHERE type='table' AND name=?", (table,)).fetchone()
+    return row is not None
+
+
+def _presence_diff(conn: sqlite3.Connection, table: str, pk: List[str],
+                   sample: int) -> Tuple[int, int, List[Tuple], List[Tuple]]:
+    """Return (a_only_count, b_only_count, a_only_sample, b_only_sample)."""
+    cols = ', '.join(pk)
+    a_only_sql = (
+        f"SELECT {cols} FROM a.{table} "
+        f"EXCEPT SELECT {cols} FROM b.{table}")
+    b_only_sql = (
+        f"SELECT {cols} FROM b.{table} "
+        f"EXCEPT SELECT {cols} FROM a.{table}")
+    a_only = list(conn.execute(a_only_sql))
+    b_only = list(conn.execute(b_only_sql))
+    return len(a_only), len(b_only), a_only[:sample], b_only[:sample]
+
+
+def _value_diff(conn: sqlite3.Connection, table: str, pk: List[str],
+                cols: List[str], ignore_cols: List[str],
+                sample: int) -> Tuple[int, List[Dict[str, Any]]]:
+    non_pk = [c for c in cols if c not in pk and c not in ignore_cols]
+    if not non_pk:
+        return 0, []
+    pk_join = ' AND '.join(f"a.{table}.{c} = b.{table}.{c}" for c in pk)
+    diff_predicates = ' OR '.join(
+        f"COALESCE(a.{table}.{c}, '') != COALESCE(b.{table}.{c}, '')"
+        for c in non_pk)
+    select_cols = (
+        [f"a.{table}.{c} AS pk_{c}" for c in pk]
+        + [f"a.{table}.{c} AS a_{c}" for c in non_pk]
+        + [f"b.{table}.{c} AS b_{c}" for c in non_pk]
+    )
+    sql = (
+        f"SELECT {', '.join(select_cols)} "
+        f"FROM a.{table} INNER JOIN b.{table} ON {pk_join} "
+        f"WHERE {diff_predicates}")
+    count = 0
+    samples: List[Dict[str, Any]] = []
+    for row in conn.execute(sql):
+        count += 1
+        if len(samples) < sample:
+            samples.append(dict(zip([d[0] for d in conn.execute(sql).description], row)))
+    return count, samples
+
+
+def diff(db_a: str, db_b: str, tables: List[str], ignore_counters: bool,
+         sample: int) -> Dict[str, Any]:
+    if not os.path.isfile(db_a):
+        raise FileNotFoundError(db_a)
+    if not os.path.isfile(db_b):
+        raise FileNotFoundError(db_b)
+    conn = sqlite3.connect(':memory:')
+    conn.execute("ATTACH DATABASE ? AS a", (f"file:{db_a}?mode=ro",))
+    conn.execute("ATTACH DATABASE ? AS b", (f"file:{db_b}?mode=ro",))
+    # PySQLite ignores mode=ro on attached files in some versions; we
+    # never write so the distinction is academic.
+
+    report: Dict[str, Any] = {'db_a': db_a, 'db_b': db_b, 'tables': {}}
+    any_diff = False
+
+    for t in tables:
+        if not (_table_exists(conn, 'a', t) and _table_exists(conn, 'b', t)):
+            report['tables'][t] = {'error': 'missing in one or both DBs'}
+            any_diff = True
+            continue
+        cols_a = _all_columns(conn, 'a', t)
+        cols_b = _all_columns(conn, 'b', t)
+        if cols_a != cols_b:
+            report['tables'][t] = {
+                'error': 'column lists differ',
+                'a_columns': cols_a, 'b_columns': cols_b,
+            }
+            any_diff = True
+            continue
+        pk = _pk_columns(conn, 'a', t)
+        if not pk:
+            pk = cols_a  # treat the whole row as the key
+        ignore = list(COUNTER_COLUMNS.get(t, ())) if ignore_counters else []
+        a_only_n, b_only_n, a_only_s, b_only_s = _presence_diff(
+            conn, t, pk, sample)
+        val_n, val_s = _value_diff(conn, t, pk, cols_a, ignore, sample)
+        report['tables'][t] = {
+            'a_only_count': a_only_n,
+            'b_only_count': b_only_n,
+            'value_diff_count': val_n,
+            'a_only_sample': [list(r) for r in a_only_s],
+            'b_only_sample': [list(r) for r in b_only_s],
+            'value_diff_sample': val_s,
+            'pk': pk,
+            'ignored_columns': ignore,
+        }
+        if a_only_n or b_only_n or val_n:
+            any_diff = True
+
+    report['any_difference'] = any_diff
+    return report
+
+
+def _format_text(report: Dict[str, Any]) -> str:
+    lines = [f"diff: {report['db_a']}  vs  {report['db_b']}"]
+    for tname, t in report['tables'].items():
+        if 'error' in t:
+            lines.append(f"  {tname}: ERROR — {t['error']}")
+            continue
+        lines.append(
+            f"  {tname}: "
+            f"{t['a_only_count']} in A only, "
+            f"{t['b_only_count']} in B only, "
+            f"{t['value_diff_count']} value differences"
+            + (f" (ignoring {','.join(t['ignored_columns'])})" if t['ignored_columns'] else ''))
+        for r in t['a_only_sample']:
+            lines.append(f"      A-only: {r}")
+        for r in t['b_only_sample']:
+            lines.append(f"      B-only: {r}")
+        for r in t['value_diff_sample']:
+            lines.append(f"      diff:   {r}")
+    lines.append(f"any_difference: {report['any_difference']}")
+    return '\n'.join(lines)
+
+
+def main(argv: List[str]) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument('--db-a', required=True)
+    p.add_argument('--db-b', required=True)
+    p.add_argument('--tables', default=','.join(DEFAULT_TABLES))
+    p.add_argument('--ignore-counters', action='store_true')
+    p.add_argument('--sample', type=int, default=5)
+    p.add_argument('--format', choices=['text', 'json'], default='text')
+    args = p.parse_args(argv)
+
+    try:
+        report = diff(args.db_a, args.db_b,
+                      [t.strip() for t in args.tables.split(',') if t.strip()],
+                      args.ignore_counters, args.sample)
+    except FileNotFoundError as e:
+        print(f"error: db file not found: {e}", file=sys.stderr)
+        return 2
+
+    if args.format == 'json':
+        print(json.dumps(report, indent=2, default=str))
+    else:
+        print(_format_text(report))
+    return 1 if report['any_difference'] else 0
+
+
+if __name__ == '__main__':  # pragma: no cover
+    sys.exit(main(sys.argv[1:]))

--- a/browser-visit-tools/enroll_machine.py
+++ b/browser-visit-tools/enroll_machine.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+enroll_machine.py — Admin helper that grants a laptop access to the
+sync-server by recording its (machine_id, client cert SHA-256) pair
+in the VM's ``enrolled_machines.db``.
+
+Run this on the EC2 VM, or wherever you have access to the
+``enrolled_machines.db`` SQLite file the sync-server is configured to
+read.
+
+Usage
+-----
+    # Enroll
+    enroll_machine.py \\
+        --db /var/lib/browser-visit-sync/enrolled_machines.db \\
+        --machine-id marvins-mbp \\
+        --cert /etc/browser-visit-sync/clients/marvins-mbp.crt
+
+    # List
+    enroll_machine.py --db ... --list
+
+    # Revoke
+    enroll_machine.py --db ... --machine-id marvins-mbp --revoke
+"""
+
+import argparse
+import datetime
+import hashlib
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def cert_fingerprint(cert_path: Path) -> str:
+    """SHA-256 hex of the DER-encoded leaf cert."""
+    data = cert_path.read_bytes()
+    if b'-----BEGIN CERTIFICATE-----' in data:
+        # PEM → DER
+        try:
+            from cryptography import x509
+            from cryptography.hazmat.primitives import serialization
+        except ImportError:
+            print("error: needs `cryptography` (pip install cryptography) "
+                  "to decode PEM. Or supply a DER file directly.",
+                  file=sys.stderr)
+            sys.exit(2)
+        cert = x509.load_pem_x509_certificate(data)
+        der = cert.public_bytes(serialization.Encoding.DER)
+    else:
+        der = data
+    return hashlib.sha256(der).hexdigest()
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS enrolled_machines (
+            machine_id  TEXT PRIMARY KEY,
+            cert_sha256 TEXT NOT NULL,
+            enrolled_at TEXT NOT NULL
+        )
+    """)
+
+
+def enroll(db_path: Path, machine_id: str, cert_path: Path) -> None:
+    fp = cert_fingerprint(cert_path)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        ensure_schema(conn)
+        conn.execute(
+            "INSERT OR REPLACE INTO enrolled_machines "
+            "(machine_id, cert_sha256, enrolled_at) VALUES (?, ?, ?)",
+            (machine_id, fp,
+             datetime.datetime.now(datetime.timezone.utc).isoformat()))
+        conn.commit()
+        print(f"enrolled {machine_id} with fingerprint {fp}")
+    finally:
+        conn.close()
+
+
+def revoke(db_path: Path, machine_id: str) -> None:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        ensure_schema(conn)
+        cur = conn.execute(
+            "DELETE FROM enrolled_machines WHERE machine_id = ?",
+            (machine_id,))
+        conn.commit()
+        print(f"revoked {machine_id} (deleted {cur.rowcount} row(s))")
+    finally:
+        conn.close()
+
+
+def list_all(db_path: Path) -> None:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        ensure_schema(conn)
+        for row in conn.execute(
+                "SELECT machine_id, cert_sha256, enrolled_at "
+                "FROM enrolled_machines ORDER BY machine_id"):
+            print(f"{row[0]:30s}  {row[1][:16]}...  {row[2]}")
+    finally:
+        conn.close()
+
+
+def main(argv):
+    p = argparse.ArgumentParser()
+    p.add_argument('--db', required=True)
+    p.add_argument('--machine-id')
+    p.add_argument('--cert', help='PEM or DER encoded client cert')
+    p.add_argument('--revoke', action='store_true')
+    p.add_argument('--list', action='store_true')
+    args = p.parse_args(argv)
+
+    db = Path(os.path.expanduser(args.db))
+    db.parent.mkdir(parents=True, exist_ok=True)
+
+    if args.list:
+        list_all(db)
+        return 0
+    if not args.machine_id:
+        print("error: --machine-id required (or use --list)", file=sys.stderr)
+        return 2
+    if args.revoke:
+        revoke(db, args.machine_id)
+        return 0
+    if not args.cert:
+        print("error: --cert required to enroll", file=sys.stderr)
+        return 2
+    enroll(db, args.machine_id, Path(os.path.expanduser(args.cert)))
+    return 0
+
+
+if __name__ == '__main__':  # pragma: no cover
+    sys.exit(main(sys.argv[1:]))

--- a/browser-visit-tools/fetch_vm_snapshot.py
+++ b/browser-visit-tools/fetch_vm_snapshot.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+fetch_vm_snapshot.py — Download a transactionally-consistent copy of
+the VM's canonical browser-visits SQLite DB via the
+`ExportDbSnapshot` gRPC RPC.
+
+The result is a plain .db file ready to feed into ``db_diff.py``.
+
+Usage
+-----
+    fetch_vm_snapshot.py \\
+        --server bvl-vm.example.com:50443 \\
+        --machine-id $(scutil --get LocalHostName) \\
+        --client-cert ~/.browser-visit-logger/tls/client.crt \\
+        --client-key  ~/.browser-visit-logger/tls/client.key \\
+        --ca          ~/.browser-visit-logger/tls/server-ca.crt \\
+        --out /tmp/vm-snapshot.db
+
+Composed with db_diff.py for the common case:
+
+    fetch_vm_snapshot.py --out /tmp/vm.db
+    db_diff.py --db-a ~/browser-visits.db --db-b /tmp/vm.db --ignore-counters
+
+Requires the generated Python grpc stubs to exist under
+``browser-visit-sync-server/gen/syncpb_py/``.  Run
+``protoc --python_out --grpc_python_out`` against ``sync.proto`` to
+produce them; see the sync-server README.
+"""
+
+import argparse
+import os
+import sys
+
+try:
+    import grpc
+except ImportError:  # pragma: no cover - import-time environment guard
+    print("error: this tool requires `grpcio` (pip install grpcio)", file=sys.stderr)
+    sys.exit(2)
+
+
+def _load_stubs():
+    here = os.path.dirname(os.path.abspath(__file__))
+    gen = os.path.normpath(os.path.join(
+        here, '..', 'browser-visit-sync-server', 'gen', 'syncpb_py'))
+    if gen not in sys.path:
+        sys.path.insert(0, gen)
+    try:
+        import sync_pb2          # noqa: F401
+        import sync_pb2_grpc     # noqa: F401
+    except ImportError as e:
+        print(f"error: generated grpc stubs not found at {gen}: {e}",
+              file=sys.stderr)
+        print("Run `make proto-py` in browser-visit-sync-server/ first.",
+              file=sys.stderr)
+        sys.exit(2)
+    return sys.modules['sync_pb2'], sys.modules['sync_pb2_grpc']
+
+
+def main(argv):
+    p = argparse.ArgumentParser()
+    p.add_argument('--server', required=True,
+                   help='host:port of the sync-server')
+    p.add_argument('--machine-id', required=True,
+                   help='this laptop\'s machine_id (must match client cert CN)')
+    p.add_argument('--client-cert', required=True)
+    p.add_argument('--client-key', required=True)
+    p.add_argument('--ca', required=True,
+                   help='PEM bundle that signed the server cert')
+    p.add_argument('--out', required=True,
+                   help='destination path for the downloaded snapshot')
+    p.add_argument('--insecure', action='store_true',
+                   help='skip TLS; for local development only')
+    args = p.parse_args(argv)
+
+    sync_pb2, sync_pb2_grpc = _load_stubs()
+
+    if args.insecure:
+        channel = grpc.insecure_channel(args.server)
+    else:
+        with open(args.client_cert, 'rb') as f: cert = f.read()
+        with open(args.client_key, 'rb') as f: key = f.read()
+        with open(args.ca, 'rb') as f: ca = f.read()
+        creds = grpc.ssl_channel_credentials(
+            root_certificates=ca, private_key=key, certificate_chain=cert)
+        channel = grpc.secure_channel(args.server, creds)
+
+    stub = sync_pb2_grpc.BrowserVisitSyncStub(channel)
+    req = sync_pb2.ExportDbSnapshotRequest(machine_id=args.machine_id)
+    written = 0
+    with open(args.out, 'wb') as f:
+        for chunk in stub.ExportDbSnapshot(req):
+            f.write(chunk.data)
+            written += len(chunk.data)
+    print(f"wrote {written} bytes to {args.out}")
+    return 0
+
+
+if __name__ == '__main__':  # pragma: no cover
+    sys.exit(main(sys.argv[1:]))

--- a/browser-visit-tools/install_laptop.sh
+++ b/browser-visit-tools/install_laptop.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# install_laptop.sh — Set up (or upgrade) a laptop for the
+# multi-laptop browser-visit-logger architecture:
+#
+#   1. Run uninstall_laptop_legacy.sh first to remove the
+#      snapshot-verifier LaunchAgent (which now lives on the EC2 VM).
+#   2. Delegate to the existing browser-visit-logger/install.sh for
+#      the BVLHost + extension manifest.  install.sh has been updated
+#      to skip the verifier LaunchAgent on its own; we keep this
+#      wrapper to enforce the order and write the new sync config.
+#   3. Materialize ~/.browser-visit-logger/config.json with the
+#      machine_id (sanitized LocalHostName), and ensure mTLS material
+#      is in place under ~/.browser-visit-logger/tls/.
+#
+# Usage:
+#   bash browser-visit-tools/install_laptop.sh
+#   bash browser-visit-tools/install_laptop.sh --server bvl-vm.example.com:50443
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONFIG_DIR="$HOME/.browser-visit-logger"
+CONFIG_FILE="$CONFIG_DIR/config.json"
+TLS_DIR="$CONFIG_DIR/tls"
+
+SERVER=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --server) SERVER="$2"; shift 2 ;;
+    -h|--help) sed -n '1,/^set -euo/p' "$0" | sed '$d'; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+info() { echo "[install-laptop] $*"; }
+
+info "Step 1/3: removing legacy verifier LaunchAgent (if present)"
+bash "$SCRIPT_DIR/uninstall_laptop_legacy.sh"
+
+info "Step 2/3: running the upstream install.sh (BVLHost + extension)"
+bash "$REPO_ROOT/browser-visit-logger/install.sh"
+
+info "Step 3/3: writing machine config"
+mkdir -p "$CONFIG_DIR" "$TLS_DIR"
+chmod 700 "$TLS_DIR"
+
+# Sanitize hostname into a machine_id.  Mirrors Paths.swift's
+# sanitiseMachineId: keep [A-Za-z0-9_-], collapse runs of '-'.
+RAW_HOST="$(scutil --get LocalHostName 2>/dev/null || hostname -s)"
+MACHINE_ID="$(echo "$RAW_HOST" | sed 's/[^A-Za-z0-9_-]/-/g' | sed 's/--*/-/g' | sed 's/^-//; s/-$//')"
+if [[ -z "$MACHINE_ID" ]]; then
+  MACHINE_ID="unknown-host"
+fi
+
+if [[ -f "$CONFIG_FILE" ]]; then
+  info "config already exists at $CONFIG_FILE — leaving machine_id unchanged"
+else
+  python3 - <<PY
+import json, datetime, pathlib
+cfg = {
+    "machine_id": "$MACHINE_ID",
+    "assigned_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+}
+if "$SERVER":
+    cfg["sync_server"] = "$SERVER"
+pathlib.Path("$CONFIG_FILE").write_text(json.dumps(cfg, indent=2, sort_keys=True) + "\n")
+PY
+  info "wrote $CONFIG_FILE with machine_id=$MACHINE_ID"
+fi
+
+cat <<EOF
+
+[install-laptop] Done.
+
+Machine ID:  $MACHINE_ID
+Config file: $CONFIG_FILE
+TLS dir:     $TLS_DIR
+
+Next steps:
+  1. Generate a client cert for this laptop (out of band) and drop
+     client.crt / client.key into $TLS_DIR.  Also put the server CA
+     into $TLS_DIR/server-ca.crt.
+  2. On the VM, enroll this laptop:
+       enroll_machine.py --db enrolled_machines.db \\
+         --machine-id $MACHINE_ID --cert client.crt
+  3. (Optional) Migrate the iCloud archive to Google Drive:
+       python3 browser-visit-tools/migrate_icloud_to_gdrive.py --src ... --dst ... --db ~/browser-visits.db
+  4. Trigger a Chrome → extension interaction; BVLSync should fire
+     within ~60s.
+EOF

--- a/browser-visit-tools/migrate_icloud_to_gdrive.py
+++ b/browser-visit-tools/migrate_icloud_to_gdrive.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+migrate_icloud_to_gdrive.py — One-time migration of historical snapshots
+from the iCloud archive directory to the new Google Drive archive.
+
+What it does:
+  1. Copies every file under the iCloud snapshots root to the Drive
+     snapshots root, preserving the YYYY-MM-DD/ subdir layout.
+  2. Verifies each file via SHA-256 before considering it migrated.
+  3. Rewrites the `directory` column in `read_events` and
+     `skimmed_events` for rows whose `directory` points into the
+     iCloud root, swapping in the Drive root.
+  4. Leaves the iCloud copy untouched.  The user can delete it after
+     confirming everything still works.
+
+Idempotent: re-running skips files already present at the destination
+with a matching hash, and the SQL UPDATE only touches rows whose
+`directory` still starts with the iCloud root.
+
+Usage
+-----
+    migrate_icloud_to_gdrive.py \\
+        --src ~/Documents/browser-visit-logger/snapshots \\
+        --dst "~/Library/CloudStorage/GoogleDrive/My Drive/browser-visit-logger/snapshots" \\
+        --db  ~/browser-visits.db
+
+    # Dry run — print what would be copied / what SQL would be emitted
+    migrate_icloud_to_gdrive.py --src ... --dst ... --db ... --dry-run
+"""
+
+import argparse
+import hashlib
+import os
+import shutil
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def sha256_of(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open('rb') as f:
+        for chunk in iter(lambda: f.read(1 << 16), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def migrate_files(src: Path, dst: Path, dry_run: bool) -> int:
+    copied = 0
+    for root, _, files in os.walk(src):
+        rel = Path(root).relative_to(src)
+        out_dir = dst / rel
+        for fn in files:
+            src_path = Path(root) / fn
+            dst_path = out_dir / fn
+            if dst_path.exists():
+                # Verify hashes match; if they do, skip.
+                if sha256_of(src_path) == sha256_of(dst_path):
+                    continue
+                print(f"warn: {dst_path} exists with different hash, leaving alone", file=sys.stderr)
+                continue
+            if dry_run:
+                print(f"would copy: {src_path}  ->  {dst_path}")
+            else:
+                out_dir.mkdir(parents=True, exist_ok=True)
+                # Copy via a temp name then rename to avoid partials
+                # being picked up by the verifier on the VM.
+                tmp = dst_path.with_suffix(dst_path.suffix + '.partial')
+                shutil.copy2(src_path, tmp)
+                if sha256_of(tmp) != sha256_of(src_path):
+                    tmp.unlink(missing_ok=True)
+                    raise RuntimeError(f"hash mismatch after copy: {src_path}")
+                tmp.rename(dst_path)
+            copied += 1
+    return copied
+
+
+def rewrite_db_directories(db_path: Path, old_root: Path, new_root: Path,
+                           dry_run: bool) -> int:
+    conn = sqlite3.connect(str(db_path))
+    total = 0
+    try:
+        old = str(old_root).rstrip('/') + '/'
+        new = str(new_root).rstrip('/') + '/'
+        for table in ('read_events', 'skimmed_events'):
+            sql = (f"UPDATE {table} SET directory = "
+                   f"REPLACE(directory, ?, ?) WHERE directory LIKE ?")
+            params = (old, new, old + '%')
+            if dry_run:
+                # Count affected rows without modifying.
+                count_sql = f"SELECT COUNT(*) FROM {table} WHERE directory LIKE ?"
+                n = conn.execute(count_sql, (old + '%',)).fetchone()[0]
+                print(f"would update {n} rows in {table}: {old} -> {new}")
+                total += n
+            else:
+                cur = conn.execute(sql, params)
+                total += cur.rowcount or 0
+        if not dry_run:
+            conn.commit()
+    finally:
+        conn.close()
+    return total
+
+
+def main(argv):
+    p = argparse.ArgumentParser()
+    p.add_argument('--src', required=True, help='iCloud snapshots root')
+    p.add_argument('--dst', required=True, help='Google Drive snapshots root')
+    p.add_argument('--db', required=True, help='browser-visits.db path')
+    p.add_argument('--dry-run', action='store_true')
+    args = p.parse_args(argv)
+
+    src = Path(os.path.expanduser(args.src))
+    dst = Path(os.path.expanduser(args.dst))
+    db = Path(os.path.expanduser(args.db))
+
+    if not src.exists():
+        print(f"error: --src not found: {src}", file=sys.stderr)
+        return 2
+    if not db.exists():
+        print(f"error: --db not found: {db}", file=sys.stderr)
+        return 2
+    if not args.dry_run:
+        dst.mkdir(parents=True, exist_ok=True)
+
+    copied = migrate_files(src, dst, args.dry_run)
+    print(f"{'would copy' if args.dry_run else 'copied'} {copied} files")
+
+    updated = rewrite_db_directories(db, src, dst, args.dry_run)
+    print(f"{'would update' if args.dry_run else 'updated'} {updated} DB rows")
+
+    if not args.dry_run:
+        print("done. The iCloud copy was left in place; remove it manually "
+              "after verifying things still work.")
+    return 0
+
+
+if __name__ == '__main__':  # pragma: no cover
+    sys.exit(main(sys.argv[1:]))

--- a/browser-visit-tools/reading_list.py
+++ b/browser-visit-tools/reading_list.py
@@ -47,7 +47,11 @@ import sys
 
 HOME    = os.path.expanduser('~')
 DB_FILE = os.environ.get('BVL_DB_FILE', os.path.join(HOME, 'browser-visits.db'))
-_OUTPUT_DIR = os.path.join(HOME, 'Documents', 'browser-visit-logger')
+# Output dir is env-overridable (BVL_OUTPUT_DIR) so the default write
+# target can be redirected away from ~/Documents — used by the test
+# suite's sandbox net, and handy for ad-hoc runs.  --output still wins.
+_OUTPUT_DIR = os.environ.get(
+    'BVL_OUTPUT_DIR', os.path.join(HOME, 'Documents', 'browser-visit-logger'))
 _FORMATS = ('html', 'markdown')
 _DEFAULT_FORMAT = 'html'
 _EXTENSIONS = {'html': 'html', 'markdown': 'md'}

--- a/browser-visit-tools/requirements-test.txt
+++ b/browser-visit-tools/requirements-test.txt
@@ -1,2 +1,4 @@
 pytest>=7
 pytest-cov>=4
+# enroll_machine.py's PEM-cert path uses cryptography; tests exercise it.
+cryptography>=42

--- a/browser-visit-tools/tests/conftest.py
+++ b/browser-visit-tools/tests/conftest.py
@@ -8,13 +8,26 @@ Also pins the local timezone to UTC for the test session so
 ``_format_timestamp`` (which converts stored UTC into local time)
 produces deterministic output.  Tests that need to verify the local
 conversion actually happens override TZ for their own scope.
+
+Production-data safety net: the only tool with a ~-rooted default is
+reading_list (BVL_DB_FILE read default, BVL_OUTPUT_DIR write default);
+both are forced to a throwaway sandbox before import so a mis-isolated
+test can never read or overwrite real user data.  `setdefault` lets an
+intentionally exported value still win.  The other tools (db_diff,
+enroll_machine, migrate, fetch_vm_snapshot) take all paths as required
+args, so they have no ~ default to guard.
 """
 import os
 import sys
+import tempfile
 import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+_SANDBOX = tempfile.mkdtemp(prefix='bvl-tools-test-sandbox-')
+os.environ.setdefault('BVL_DB_FILE', os.path.join(_SANDBOX, 'browser-visits.db'))
+os.environ.setdefault('BVL_OUTPUT_DIR', _SANDBOX)
 
 os.environ['TZ'] = 'UTC'
 time.tzset()

--- a/browser-visit-tools/tests/test_db_diff.py
+++ b/browser-visit-tools/tests/test_db_diff.py
@@ -1,0 +1,186 @@
+"""Unit tests for db_diff.py."""
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import db_diff  # noqa: E402
+
+
+SCHEMA = """
+CREATE TABLE visits (url TEXT PRIMARY KEY, timestamp TEXT NOT NULL,
+    title TEXT NOT NULL DEFAULT '', of_interest TEXT,
+    read INTEGER NOT NULL DEFAULT 0, skimmed INTEGER NOT NULL DEFAULT 0);
+CREATE TABLE read_events (url TEXT NOT NULL, timestamp TEXT NOT NULL,
+    filename TEXT NOT NULL DEFAULT '', directory TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (url, timestamp));
+CREATE TABLE skimmed_events (url TEXT NOT NULL, timestamp TEXT NOT NULL,
+    filename TEXT NOT NULL DEFAULT '', directory TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (url, timestamp));
+CREATE TABLE snapshots (date TEXT PRIMARY KEY, sealed INTEGER NOT NULL DEFAULT 0);
+"""
+
+
+def _mkdb(path, visits):
+    c = sqlite3.connect(path)
+    c.executescript(SCHEMA)
+    for v in visits:
+        c.execute("INSERT INTO visits (url, timestamp, title, read) VALUES (?,?,?,?)", v)
+    c.commit()
+    c.close()
+
+
+def test_identical_dbs_no_diff(tmp_path):
+    a, b = str(tmp_path / 'a.db'), str(tmp_path / 'b.db')
+    rows = [('u1', 't', 'T', 1)]
+    _mkdb(a, rows)
+    _mkdb(b, rows)
+    rep = db_diff.diff(a, b, db_diff.DEFAULT_TABLES, False, 5)
+    assert rep['any_difference'] is False
+    for t in db_diff.DEFAULT_TABLES:
+        assert rep['tables'][t]['a_only_count'] == 0
+        assert rep['tables'][t]['b_only_count'] == 0
+        assert rep['tables'][t]['value_diff_count'] == 0
+
+
+def test_presence_diff(tmp_path):
+    a, b = str(tmp_path / 'a.db'), str(tmp_path / 'b.db')
+    _mkdb(a, [('u1', 't', 'T', 0), ('only-a', 't', 'T', 0)])
+    _mkdb(b, [('u1', 't', 'T', 0), ('only-b', 't', 'T', 0)])
+    rep = db_diff.diff(a, b, ['visits'], False, 5)
+    v = rep['tables']['visits']
+    assert v['a_only_count'] == 1 and v['b_only_count'] == 1
+    assert rep['any_difference'] is True
+
+
+def test_value_diff_and_ignore_counters(tmp_path):
+    a, b = str(tmp_path / 'a.db'), str(tmp_path / 'b.db')
+    _mkdb(a, [('u1', 't', 'TitleA', 1)])
+    _mkdb(b, [('u1', 't', 'TitleB', 9)])  # title + read differ
+    # With counters counted, both title and read differ → 1 diff row.
+    rep = db_diff.diff(a, b, ['visits'], False, 5)
+    assert rep['tables']['visits']['value_diff_count'] == 1
+    # Ignoring counters, only title differs → still 1 row.
+    rep2 = db_diff.diff(a, b, ['visits'], True, 5)
+    assert rep2['tables']['visits']['value_diff_count'] == 1
+    assert 'read' in rep2['tables']['visits']['ignored_columns']
+
+
+def test_value_diff_only_counter_difference_suppressed(tmp_path):
+    a, b = str(tmp_path / 'a.db'), str(tmp_path / 'b.db')
+    _mkdb(a, [('u1', 't', 'Same', 1)])
+    _mkdb(b, [('u1', 't', 'Same', 5)])  # only read differs
+    rep = db_diff.diff(a, b, ['visits'], True, 5)
+    assert rep['tables']['visits']['value_diff_count'] == 0
+    assert rep['any_difference'] is False
+
+
+def test_missing_table(tmp_path):
+    a, b = str(tmp_path / 'a.db'), str(tmp_path / 'b.db')
+    _mkdb(a, [])
+    _mkdb(b, [])
+    rep = db_diff.diff(a, b, ['nonexistent'], False, 5)
+    assert 'error' in rep['tables']['nonexistent']
+    assert rep['any_difference'] is True
+
+
+def test_column_mismatch(tmp_path):
+    a, b = str(tmp_path / 'a.db'), str(tmp_path / 'b.db')
+    _mkdb(a, [])
+    c = sqlite3.connect(b)
+    c.execute("CREATE TABLE visits (url TEXT PRIMARY KEY, extra TEXT)")
+    c.commit()
+    c.close()
+    rep = db_diff.diff(a, b, ['visits'], False, 5)
+    assert rep['tables']['visits']['error'] == 'column lists differ'
+
+
+def test_no_primary_key_uses_whole_row(tmp_path):
+    a, b = str(tmp_path / 'a.db'), str(tmp_path / 'b.db')
+    for p in (a, b):
+        c = sqlite3.connect(p)
+        c.execute("CREATE TABLE t (x TEXT, y TEXT)")
+        c.execute("INSERT INTO t VALUES ('1','2')")
+        c.commit()
+        c.close()
+    rep = db_diff.diff(a, b, ['t'], False, 5)
+    assert rep['tables']['t']['pk'] == ['x', 'y']
+    assert rep['any_difference'] is False
+
+
+def test_diff_missing_file_raises(tmp_path):
+    a = str(tmp_path / 'a.db')
+    _mkdb(a, [])
+    with pytest.raises(FileNotFoundError):
+        db_diff.diff(a, str(tmp_path / 'nope.db'), ['visits'], False, 5)
+    with pytest.raises(FileNotFoundError):
+        db_diff.diff(str(tmp_path / 'nope.db'), a, ['visits'], False, 5)
+
+
+def test_format_text(tmp_path):
+    a, b = str(tmp_path / 'a.db'), str(tmp_path / 'b.db')
+    _mkdb(a, [('only-a', 't', 'T', 0)])
+    _mkdb(b, [])
+    rep = db_diff.diff(a, b, ['visits', 'nonexistent'], True, 5)
+    text = db_diff._format_text(rep)
+    assert 'visits:' in text
+    assert 'ERROR' in text  # the nonexistent table
+    assert 'any_difference: True' in text
+
+
+def test_format_text_b_only_and_value_samples(tmp_path):
+    a, b = str(tmp_path / 'a.db'), str(tmp_path / 'b.db')
+    # b has an extra row (b-only) and a differing value row.
+    _mkdb(a, [('shared', 't', 'TitleA', 0)])
+    _mkdb(b, [('shared', 't', 'TitleB', 0), ('only-b', 't', 'T', 0)])
+    rep = db_diff.diff(a, b, ['visits'], False, 5)
+    text = db_diff._format_text(rep)
+    assert 'B-only:' in text
+    assert 'diff:' in text
+
+
+# ---- main / CLI ----
+
+def test_main_no_diff_exit_0(tmp_path, capsys):
+    a, b = str(tmp_path / 'a.db'), str(tmp_path / 'b.db')
+    _mkdb(a, [('u', 't', 'T', 0)])
+    _mkdb(b, [('u', 't', 'T', 0)])
+    rc = db_diff.main(['--db-a', a, '--db-b', b])
+    assert rc == 0
+
+
+def test_main_diff_exit_1(tmp_path):
+    a, b = str(tmp_path / 'a.db'), str(tmp_path / 'b.db')
+    _mkdb(a, [('only-a', 't', 'T', 0)])
+    _mkdb(b, [])
+    rc = db_diff.main(['--db-a', a, '--db-b', b])
+    assert rc == 1
+
+
+def test_main_json_format(tmp_path, capsys):
+    a, b = str(tmp_path / 'a.db'), str(tmp_path / 'b.db')
+    _mkdb(a, [('u', 't', 'T', 0)])
+    _mkdb(b, [('u', 't', 'T', 0)])
+    db_diff.main(['--db-a', a, '--db-b', b, '--format', 'json'])
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed['any_difference'] is False
+
+
+def test_main_missing_file_exit_2(tmp_path, capsys):
+    a = str(tmp_path / 'a.db')
+    _mkdb(a, [])
+    rc = db_diff.main(['--db-a', a, '--db-b', str(tmp_path / 'nope.db')])
+    assert rc == 2
+    assert 'not found' in capsys.readouterr().err
+
+
+def test_main_custom_tables_and_sample(tmp_path):
+    a, b = str(tmp_path / 'a.db'), str(tmp_path / 'b.db')
+    _mkdb(a, [('u%d' % i, 't', 'T', 0) for i in range(10)])
+    _mkdb(b, [])
+    rc = db_diff.main(['--db-a', a, '--db-b', b, '--tables', 'visits', '--sample', '3'])
+    assert rc == 1

--- a/browser-visit-tools/tests/test_enroll_machine.py
+++ b/browser-visit-tools/tests/test_enroll_machine.py
@@ -1,0 +1,126 @@
+"""Unit tests for enroll_machine.py."""
+import datetime
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import enroll_machine as em  # noqa: E402
+
+
+def _mint(tmp_path, cn='laptop-a', pem=True):
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+    cert = (x509.CertificateBuilder()
+            .subject_name(subject).issuer_name(issuer).public_key(key.public_key())
+            .serial_number(1)
+            .not_valid_before(datetime.datetime(2020, 1, 1))
+            .not_valid_after(datetime.datetime(2040, 1, 1))
+            .sign(key, hashes.SHA256()))
+    enc = serialization.Encoding.PEM if pem else serialization.Encoding.DER
+    path = tmp_path / (cn + ('.crt' if pem else '.der'))
+    path.write_bytes(cert.public_bytes(enc))
+    return path, cert
+
+
+def test_fingerprint_pem_and_der_match(tmp_path):
+    pem_path, cert = _mint(tmp_path, pem=True)
+    der_path = tmp_path / 'a.der'
+    der_path.write_bytes(cert.public_bytes(serialization.Encoding.DER))
+    assert em.cert_fingerprint(pem_path) == em.cert_fingerprint(der_path)
+
+
+def test_enroll_and_list_and_revoke(tmp_path, capsys):
+    db = tmp_path / 'enrolled.db'
+    cert_path, _ = _mint(tmp_path)
+    em.enroll(db, 'laptop-a', cert_path)
+    # Row present.
+    conn = sqlite3.connect(str(db))
+    n = conn.execute("SELECT COUNT(*) FROM enrolled_machines").fetchone()[0]
+    conn.close()
+    assert n == 1
+    # List prints the machine.
+    em.list_all(db)
+    assert 'laptop-a' in capsys.readouterr().out
+    # Revoke removes it.
+    em.revoke(db, 'laptop-a')
+    conn = sqlite3.connect(str(db))
+    n = conn.execute("SELECT COUNT(*) FROM enrolled_machines").fetchone()[0]
+    conn.close()
+    assert n == 0
+
+
+def test_enroll_replace(tmp_path):
+    db = tmp_path / 'enrolled.db'
+    c1, _ = _mint(tmp_path, 'laptop-a')
+    em.enroll(db, 'laptop-a', c1)
+    c2, _ = _mint(tmp_path, 'laptop-a-again')
+    # Same machine_id, new cert → INSERT OR REPLACE.
+    (tmp_path / 'laptop-a-again.crt').rename(tmp_path / 'replace.crt')
+    em.enroll(db, 'laptop-a', tmp_path / 'replace.crt')
+    conn = sqlite3.connect(str(db))
+    n = conn.execute("SELECT COUNT(*) FROM enrolled_machines").fetchone()[0]
+    conn.close()
+    assert n == 1
+
+
+# ---- main / CLI ----
+
+def test_main_list(tmp_path, capsys):
+    db = tmp_path / 'enrolled.db'
+    cert_path, _ = _mint(tmp_path)
+    em.enroll(db, 'laptop-a', cert_path)
+    rc = em.main(['--db', str(db), '--list'])
+    assert rc == 0
+    assert 'laptop-a' in capsys.readouterr().out
+
+
+def test_main_enroll(tmp_path):
+    db = tmp_path / 'enrolled.db'
+    cert_path, _ = _mint(tmp_path)
+    rc = em.main(['--db', str(db), '--machine-id', 'laptop-a', '--cert', str(cert_path)])
+    assert rc == 0
+
+
+def test_main_revoke(tmp_path):
+    db = tmp_path / 'enrolled.db'
+    cert_path, _ = _mint(tmp_path)
+    em.enroll(db, 'laptop-a', cert_path)
+    rc = em.main(['--db', str(db), '--machine-id', 'laptop-a', '--revoke'])
+    assert rc == 0
+
+
+def test_main_missing_machine_id(tmp_path, capsys):
+    db = tmp_path / 'enrolled.db'
+    rc = em.main(['--db', str(db)])
+    assert rc == 2
+    assert 'machine-id required' in capsys.readouterr().err
+
+
+def test_main_enroll_missing_cert(tmp_path, capsys):
+    db = tmp_path / 'enrolled.db'
+    rc = em.main(['--db', str(db), '--machine-id', 'laptop-a'])
+    assert rc == 2
+    assert 'cert required' in capsys.readouterr().err
+
+
+def test_cert_fingerprint_pem_without_cryptography(tmp_path, monkeypatch, capsys):
+    pem_path, _ = _mint(tmp_path, pem=True)
+    # Simulate cryptography being unavailable for the PEM branch.
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name.startswith('cryptography'):
+            raise ImportError('no cryptography')
+        return real_import(name, *a, **k)
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+    with pytest.raises(SystemExit) as ei:
+        em.cert_fingerprint(pem_path)
+    assert ei.value.code == 2

--- a/browser-visit-tools/tests/test_fetch_vm_snapshot.py
+++ b/browser-visit-tools/tests/test_fetch_vm_snapshot.py
@@ -1,0 +1,96 @@
+"""Unit tests for fetch_vm_snapshot.py.
+
+grpc and the generated stubs aren't installed in the test venv, so we
+inject fakes into sys.modules before importing the module under test.
+"""
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Inject a fake `grpc` BEFORE importing the module (its top-level
+# `import grpc` would otherwise sys.exit(2)).
+_fake_grpc = types.ModuleType('grpc')
+_fake_grpc.insecure_channel = lambda ep: ('insecure', ep)
+_fake_grpc.secure_channel = lambda ep, creds: ('secure', ep, creds)
+_fake_grpc.ssl_channel_credentials = lambda **kw: ('creds', kw)
+sys.modules.setdefault('grpc', _fake_grpc)
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import fetch_vm_snapshot as fv  # noqa: E402
+
+
+class Msg:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+class FakeChunk:
+    def __init__(self, data):
+        self.data = data
+
+
+class FakeStub:
+    def __init__(self, channel):
+        pass
+
+    def ExportDbSnapshot(self, req):
+        return iter([FakeChunk(b'abc'), FakeChunk(b'de')])
+
+
+def _inject_stubs(monkeypatch):
+    pb2 = types.ModuleType('sync_pb2')
+    pb2.ExportDbSnapshotRequest = Msg
+    pb2_grpc = types.ModuleType('sync_pb2_grpc')
+    pb2_grpc.BrowserVisitSyncStub = FakeStub
+    monkeypatch.setitem(sys.modules, 'sync_pb2', pb2)
+    monkeypatch.setitem(sys.modules, 'sync_pb2_grpc', pb2_grpc)
+
+
+def test_load_stubs_success(monkeypatch):
+    _inject_stubs(monkeypatch)
+    pb2, pb2_grpc = fv._load_stubs()
+    # _load_stubs must return the actual imported modules (identity),
+    # not just something attr-shaped — proves it resolved + returned them.
+    assert pb2 is sys.modules['sync_pb2']
+    assert pb2_grpc is sys.modules['sync_pb2_grpc']
+
+
+def test_load_stubs_failure(monkeypatch, capsys):
+    monkeypatch.setitem(sys.modules, 'sync_pb2', None)
+    monkeypatch.setitem(sys.modules, 'sync_pb2_grpc', None)
+    with pytest.raises(SystemExit) as ei:
+        fv._load_stubs()
+    assert ei.value.code == 2
+    assert 'stubs not found' in capsys.readouterr().err
+
+
+def test_main_insecure(tmp_path, monkeypatch, capsys):
+    _inject_stubs(monkeypatch)
+    out = tmp_path / 'snap.db'
+    rc = fv.main([
+        '--server', 'localhost:50051', '--machine-id', 'laptop-a',
+        '--client-cert', '/dev/null', '--client-key', '/dev/null',
+        '--ca', '/dev/null', '--out', str(out), '--insecure',
+    ])
+    assert rc == 0
+    assert out.read_bytes() == b'abcde'
+    assert 'wrote 5 bytes' in capsys.readouterr().out
+
+
+def test_main_secure(tmp_path, monkeypatch):
+    _inject_stubs(monkeypatch)
+    # Real cert/key/ca files (contents irrelevant — fake grpc ignores them).
+    for fn in ('c.crt', 'c.key', 'ca.crt'):
+        (tmp_path / fn).write_bytes(b'x')
+    out = tmp_path / 'snap.db'
+    rc = fv.main([
+        '--server', 'vm:50443', '--machine-id', 'laptop-a',
+        '--client-cert', str(tmp_path / 'c.crt'),
+        '--client-key', str(tmp_path / 'c.key'),
+        '--ca', str(tmp_path / 'ca.crt'),
+        '--out', str(out),
+    ])
+    assert rc == 0
+    assert out.read_bytes() == b'abcde'

--- a/browser-visit-tools/tests/test_migrate.py
+++ b/browser-visit-tools/tests/test_migrate.py
@@ -1,0 +1,169 @@
+"""Unit tests for migrate_icloud_to_gdrive.py."""
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import migrate_icloud_to_gdrive as mig  # noqa: E402
+
+
+def _seed_snapshots(src):
+    d = src / '2026-05-21'
+    d.mkdir(parents=True)
+    (d / 'a.mhtml').write_text('alpha')
+    (d / 'b.pdf').write_text('bravo')
+    return d
+
+
+def _seed_db(path, directory):
+    c = sqlite3.connect(str(path))
+    c.executescript("""
+        CREATE TABLE read_events (url TEXT, timestamp TEXT, filename TEXT,
+            directory TEXT, PRIMARY KEY (url, timestamp));
+        CREATE TABLE skimmed_events (url TEXT, timestamp TEXT, filename TEXT,
+            directory TEXT, PRIMARY KEY (url, timestamp));
+    """)
+    c.execute("INSERT INTO read_events VALUES ('u1','t','a.mhtml',?)",
+              (directory + '/2026-05-21',))
+    c.execute("INSERT INTO skimmed_events VALUES ('u2','t','b.pdf',?)",
+              (directory + '/2026-05-21',))
+    c.commit()
+    c.close()
+
+
+def test_sha256_of(tmp_path):
+    f = tmp_path / 'x'
+    f.write_text('hello')
+    import hashlib
+    assert mig.sha256_of(f) == hashlib.sha256(b'hello').hexdigest()
+
+
+def test_migrate_files_copies(tmp_path):
+    src, dst = tmp_path / 'icloud', tmp_path / 'gdrive'
+    _seed_snapshots(src)
+    n = mig.migrate_files(src, dst, dry_run=False)
+    assert n == 2
+    assert (dst / '2026-05-21' / 'a.mhtml').read_text() == 'alpha'
+    # No leftover .partial files.
+    assert not list(dst.rglob('*.partial'))
+
+
+def test_migrate_files_dry_run(tmp_path, capsys):
+    src, dst = tmp_path / 'icloud', tmp_path / 'gdrive'
+    _seed_snapshots(src)
+    n = mig.migrate_files(src, dst, dry_run=True)
+    assert n == 2
+    assert not dst.exists()  # nothing actually written
+    assert 'would copy' in capsys.readouterr().out
+
+
+def test_migrate_files_skip_matching_hash(tmp_path):
+    src, dst = tmp_path / 'icloud', tmp_path / 'gdrive'
+    _seed_snapshots(src)
+    mig.migrate_files(src, dst, dry_run=False)
+    # Second run: destination already has identical files → 0 copied.
+    n = mig.migrate_files(src, dst, dry_run=False)
+    assert n == 0
+
+
+def test_migrate_files_warn_on_hash_mismatch(tmp_path, capsys):
+    src, dst = tmp_path / 'icloud', tmp_path / 'gdrive'
+    _seed_snapshots(src)
+    # Pre-create a destination file with different content.
+    (dst / '2026-05-21').mkdir(parents=True)
+    (dst / '2026-05-21' / 'a.mhtml').write_text('DIFFERENT')
+    (dst / '2026-05-21' / 'b.pdf').write_text('bravo')  # matches → skipped
+    n = mig.migrate_files(src, dst, dry_run=False)
+    assert n == 0  # neither copied (one mismatch warned, one identical)
+    assert 'different hash' in capsys.readouterr().err
+
+
+def test_rewrite_db_directories(tmp_path):
+    db = tmp_path / 'v.db'
+    old = tmp_path / 'icloud'
+    new = tmp_path / 'gdrive'
+    _seed_db(db, str(old))
+    n = mig.rewrite_db_directories(db, old, new, dry_run=False)
+    assert n == 2
+    c = sqlite3.connect(str(db))
+    rows = [r[0] for r in c.execute(
+        "SELECT directory FROM read_events UNION SELECT directory FROM skimmed_events")]
+    c.close()
+    assert all(str(new) in r for r in rows)
+    assert all(str(old) not in r for r in rows)
+
+
+def test_rewrite_db_directories_dry_run(tmp_path, capsys):
+    db = tmp_path / 'v.db'
+    old, new = tmp_path / 'icloud', tmp_path / 'gdrive'
+    _seed_db(db, str(old))
+    n = mig.rewrite_db_directories(db, old, new, dry_run=True)
+    assert n == 2
+    # Unchanged on disk.
+    c = sqlite3.connect(str(db))
+    rows = [r[0] for r in c.execute("SELECT directory FROM read_events")]
+    c.close()
+    assert str(old) in rows[0]
+    assert 'would update' in capsys.readouterr().out
+
+
+# ---- main ----
+
+def test_main_dry_run(tmp_path, capsys):
+    src, dst = tmp_path / 'icloud', tmp_path / 'gdrive'
+    _seed_snapshots(src)
+    db = tmp_path / 'v.db'
+    _seed_db(db, str(src))
+    rc = mig.main(['--src', str(src), '--dst', str(dst), '--db', str(db), '--dry-run'])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert 'would copy' in out and 'would update' in out
+
+
+def test_main_real_run(tmp_path, capsys):
+    src, dst = tmp_path / 'icloud', tmp_path / 'gdrive'
+    _seed_snapshots(src)
+    db = tmp_path / 'v.db'
+    _seed_db(db, str(src))
+    rc = mig.main(['--src', str(src), '--dst', str(dst), '--db', str(db)])
+    assert rc == 0
+    assert (dst / '2026-05-21' / 'a.mhtml').exists()
+    assert 'done' in capsys.readouterr().out
+
+
+def test_main_src_missing(tmp_path, capsys):
+    db = tmp_path / 'v.db'
+    _seed_db(db, str(tmp_path / 'icloud'))
+    rc = mig.main(['--src', str(tmp_path / 'nope'), '--dst', str(tmp_path / 'g'),
+                   '--db', str(db)])
+    assert rc == 2
+    assert 'src not found' in capsys.readouterr().err
+
+
+def test_main_db_missing(tmp_path, capsys):
+    src = tmp_path / 'icloud'
+    _seed_snapshots(src)
+    rc = mig.main(['--src', str(src), '--dst', str(tmp_path / 'g'),
+                   '--db', str(tmp_path / 'nope.db')])
+    assert rc == 2
+    assert 'db not found' in capsys.readouterr().err
+
+
+def test_migrate_files_hash_mismatch_after_copy(tmp_path, monkeypatch):
+    # Force the post-copy hash check to fail → RuntimeError.
+    src, dst = tmp_path / 'icloud', tmp_path / 'gdrive'
+    _seed_snapshots(src)
+    calls = {'n': 0}
+    real = mig.sha256_of
+
+    def flaky(path):
+        # Return a wrong hash for the temp (.partial) verification only.
+        if str(path).endswith('.partial'):
+            return 'deadbeef'
+        return real(path)
+    monkeypatch.setattr(mig, 'sha256_of', flaky)
+    with pytest.raises(RuntimeError, match='hash mismatch'):
+        mig.migrate_files(src, dst, dry_run=False)

--- a/browser-visit-tools/uninstall_laptop_legacy.sh
+++ b/browser-visit-tools/uninstall_laptop_legacy.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# uninstall_laptop_legacy.sh — Remove the legacy snapshot verifier
+# LaunchAgent + binary from this laptop.  Used when migrating to the
+# multi-laptop architecture (where verification runs on the EC2 VM).
+#
+# Idempotent: if a piece is already gone, it's skipped.  Never touches
+# user data (~/browser-visits-*.log, ~/browser-visits.db, snapshot
+# directories, the new .browser-visit-logger config dir).
+#
+# Usage:
+#   bash browser-visit-tools/uninstall_laptop_legacy.sh
+
+set -euo pipefail
+
+VERIFIER_LABEL="com.browser.visit.logger.snapshot_verifier"
+MOVER_LABEL="com.browser.visit.logger.snapshot_mover"  # older generation
+LAUNCH_DIR="$HOME/Library/LaunchAgents"
+APP_PARENT="$HOME/Library/Application Support/browser-visit-logger"
+VERIFIER_APP="$APP_PARENT/BrowserVisitLoggerVerifier.app"
+
+info() { echo "[uninstall] $*"; }
+warn() { echo "[uninstall] WARN: $*" >&2; }
+
+unload_agent() {
+  local label="$1"
+  local plist="$LAUNCH_DIR/${label}.plist"
+  if [[ ! -f "$plist" ]]; then
+    info "no LaunchAgent plist for $label (already gone)"
+    return 0
+  fi
+  if launchctl bootout "gui/$(id -u)" "$plist" 2>/dev/null; then
+    info "booted out $label"
+  else
+    # Fall back to the older `unload` API; ignore failure (may not be loaded).
+    launchctl unload "$plist" 2>/dev/null || true
+    info "unloaded $label (legacy API)"
+  fi
+}
+
+remove_plist() {
+  local label="$1"
+  local plist="$LAUNCH_DIR/${label}.plist"
+  if [[ -f "$plist" ]]; then
+    rm -f "$plist"
+    info "removed $plist"
+  fi
+}
+
+remove_app() {
+  local path="$1"
+  if [[ -d "$path" ]]; then
+    rm -rf "$path"
+    info "removed $path"
+  else
+    info "no app at $path (already gone)"
+  fi
+}
+
+info "Removing legacy snapshot-verifier LaunchAgent (now runs on the VM)"
+unload_agent "$VERIFIER_LABEL"
+remove_plist "$VERIFIER_LABEL"
+
+# Also clean up the even-older snapshot_mover LaunchAgent if any
+# install from before the verifier consolidation is still lingering.
+unload_agent "$MOVER_LABEL"
+remove_plist "$MOVER_LABEL"
+
+remove_app "$VERIFIER_APP"
+
+info ""
+info "Done. The following was preserved (user data + new sync infra):"
+info "  - ~/browser-visits-*.log"
+info "  - ~/browser-visits.db"
+info "  - ~/Documents/browser-visit-logger/  (legacy iCloud archive)"
+info "  - ~/.browser-visit-logger/           (machine config + mTLS)"
+info "  - BrowserVisitLoggerHost.app         (still serves Chrome native msgs)"
+info ""
+info "Next:"
+info "  1. Run browser-visit-tools/migrate_icloud_to_gdrive.py to copy the"
+info "     iCloud archive into Google Drive and rewrite DB paths."
+info "  2. Verify launchctl no longer lists the verifier:"
+info "       launchctl list | grep $VERIFIER_LABEL  # expected: empty"


### PR DESCRIPTION
## Summary

Adds an **optional multi-laptop sync layer** on top of the existing single-laptop browser-visit-logger, so several Macs can share their browsing state through a central gRPC service on an EC2 VM. Single-laptop installs are unaffected — the sync hook is gated on `~/.browser-visit-logger/config.json` existing.

### New: `browser-visit-sync-server/` (Go)
The canonical store that runs on the EC2 VM. Three RPCs over mTLS:
- **`PushLogs`** — mirror a laptop's new log lines, replay them into the canonical DB (idempotent on `(machine_id, date, line_offset)`).
- **`PullLogs`** — stream every *other* peer's not-yet-seen lines, per supplied cursors.
- **`ExportDbSnapshot`** — stream a `VACUUM INTO` snapshot (feeds `db_diff.py`).

Auth pins each cert's SHA-256 to a `machine_id` via an `enrolled_machines` DB; `CrossCheck` rejects identity spoofing. Includes a per-RPC logging interceptor, Dockerfile, and systemd unit.

### `browser-visit-logger`
- `schema.sql` / `Schema.swift`: new `sync_state` table (per-peer cursors).
- `Paths.swift`: hostname-based machine ID, Google Drive snapshot default (`BVL_GDRIVE_SNAPSHOTS_DIR`), peer-log + config paths.
- `main.swift`: after responding to Chrome, fork a detached `sync_client.py`.
- `native-host/sync_client.py` (new): flock-guarded, debounced push/pull subprocess; surfaces failures via the existing `mover_errors` escalation path.

### `browser-visit-tools` (new scripts)
`db_diff.py`, `fetch_vm_snapshot.py`, `enroll_machine.py`, `migrate_icloud_to_gdrive.py`, `install_laptop.sh`, `uninstall_laptop_legacy.sh`. `reading_list` output dir is now env-overridable (`BVL_OUTPUT_DIR`).

## Testing
- **Logger Python 225 · Tools Python 85 · Logger JS 131 — all 100%** (Python suites gated at `--cov-fail-under=100`).
- Go sync-server: per-package unit tests (logmw 100%, auth 98%, server 96%, store 94%) + a 7-test Docker Compose integration suite. Residual Go gaps are `main()` and unreachable defensive branches; generated protobuf excluded by convention.
- Meaningfulness verified by mutation testing (6 deliberate bugs, each caught by a test).
- Makefiles build gitignored, throwaway test virtualenvs; a `conftest` safety net forces all `BVL_*` paths to a sandbox so tests can never touch real user data.

## Fixed along the way
- A pre-existing sealer test that scanned `$HOME` (now isolates `LOG_DIR`).
- A latent bug where `sync_client.open_db()` didn't create the `visits`/event tables it replays into.

## Docs
Top-level + per-project READMEs updated for the architecture, test commands, dependencies, and assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)