### PR TITLE
Remove dead link to nonexistent architecture plan doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ The setup can run in either of two modes:
   Each laptop's local DB converges to the union of all laptops'
   activity within ~1 minute of any interaction.
 
-The architecture is described in detail in
-[plans/i-want-to-be-witty-nygaard.md](.claude/plans/i-want-to-be-witty-nygaard.md).
-
 ## [`browser-visit-logger/`](browser-visit-logger/)
 
 The Chrome extension and macOS native-messaging host that records


### PR DESCRIPTION
The README linked to `.claude/plans/i-want-to-be-witty-nygaard.md`, which was never committed and does not exist (no such file, no `.claude/plans/` directory, nothing in git history under that name). The only reference to it anywhere was this README link.

The README already contains the single/multi-laptop mode overview and the end-to-end data-flow diagram, so this just drops the dangling reference and its orphaned introductory sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)