### PR TITLE
Add EC2 VM management tools for the sync-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Includes a full Docker Compose integration suite under
 see that directory's README for the venv + `make test-integration`
 workflow.
 
+The EC2 VM that hosts this service is created and managed by the
+`manage_vm.py` / `manage_sync_server.py` tools (below): the binary is
+cross-compiled (`make build-linux`), deployed as a systemd service, and
+the VM is reached entirely over AWS SSM — no SSH, no inbound port 22,
+only the gRPC port `50443` is open to enrolled laptops.
+
 ## [`browser-visit-tools/`](browser-visit-tools/)
 
 Standalone scripts that consume the database or operate on the
@@ -86,9 +92,14 @@ multi-laptop setup itself:
 - **`uninstall_laptop_legacy.sh`** — removes the legacy
   snapshot-verifier LaunchAgent (the verifier moves to the VM in
   multi-laptop mode).  Idempotent; never touches user data.
+- **`manage_vm.py`** — idempotently creates and operates the EC2 VM
+  (instance + security group + IAM instance profile) via `boto3`.
+- **`manage_sync_server.py`** — provisions, deploys, and controls the
+  sync-server on the VM over AWS SSM (no SSH).
 
 The read-only tools depend only on the DB schema; the sync-related
-tools depend on the gRPC stubs the sync-server emits.
+tools depend on the gRPC stubs the sync-server emits; the EC2 tools
+depend on `boto3` + AWS credentials.
 
 ## [`browser-visit-mcp/`](browser-visit-mcp/)
 

--- a/browser-visit-sync-server/Makefile
+++ b/browser-visit-sync-server/Makefile
@@ -1,4 +1,4 @@
-.PHONY: proto build test cover test-integration venv clean clean-venv
+.PHONY: proto build build-linux test cover test-integration venv clean clean-venv
 
 PROTO_DIR := proto
 GEN_DIR   := gen/syncpb
@@ -23,6 +23,16 @@ proto:
 
 build:
 	go build -o bin/sync-server ./cmd/sync-server
+
+# Cross-compile a stripped Linux binary for the EC2 VM.  CGO_ENABLED=0 is
+# safe because the SQLite driver (modernc.org/sqlite) is pure Go.  GOARCH
+# must match the instance arch chosen by manage_vm.py (amd64↔x86_64,
+# arm64↔arm64).  Consumed by ../browser-visit-tools/manage_sync_server.py.
+GOARCH ?= amd64
+build-linux:
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) \
+		go build -trimpath -ldflags="-s -w" \
+		-o bin/sync-server-linux-$(GOARCH) ./cmd/sync-server
 
 test:
 	go test ./...

--- a/browser-visit-sync-server/README.md
+++ b/browser-visit-sync-server/README.md
@@ -81,6 +81,15 @@ go mod tidy      # produces go.sum (also gitignored)
 make build       # → bin/sync-server
 ```
 
+To produce the stripped Linux binary the EC2 deploy tooling installs,
+cross-compile with `build-linux` (the SQLite driver is pure Go, so
+`CGO_ENABLED=0` works).  `GOARCH` must match the instance arch:
+
+```
+make build-linux GOARCH=amd64    # → bin/sync-server-linux-amd64  (t3/x86_64)
+make build-linux GOARCH=arm64    # → bin/sync-server-linux-arm64  (t4g/arm64)
+```
+
 Built and tested with Go 1.22+ (the module's `go` directive) — a
 current toolchain (e.g. Go 1.26) works fine.
 
@@ -137,6 +146,14 @@ pins the user to `bvlsync`, restarts on failure, and confines
 filesystem writes to `/var/lib/browser-visit-sync/`.  The Dockerfile
 at [`deploy/Dockerfile`](deploy/Dockerfile) is a multi-stage build
 that produces a distroless `nonroot` image (~20 MB).
+
+To create and operate the VM itself without doing any of this by hand,
+use [`browser-visit-tools/manage_vm.py`](../browser-visit-tools/README.md#manage_vmpy)
+(idempotent EC2 create) and
+[`manage_sync_server.py`](../browser-visit-tools/README.md#manage_sync_serverpy)
+— the latter provisions the `bvlsync` user + dirs, installs this unit
+and the TLS material, cross-deploys the `build-linux` binary, and
+controls the service, all over AWS SSM (no SSH).
 
 TLS floor is **TLS 1.2** — pragmatic interop with macOS-system
 Python 3.9 (LibreSSL 2.8.3) that doesn't speak TLS 1.3.  mTLS is the

--- a/browser-visit-tools/Makefile
+++ b/browser-visit-tools/Makefile
@@ -23,6 +23,7 @@ test: venv
 	$(VENV_PY) -m pytest tests/ \
 		--cov=reading_list --cov=db_diff --cov=fetch_vm_snapshot \
 		--cov=enroll_machine --cov=migrate_icloud_to_gdrive \
+		--cov=_bvl_aws --cov=manage_vm --cov=manage_sync_server \
 		--cov-report=term-missing --cov-fail-under=100
 
 clean:

--- a/browser-visit-tools/README.md
+++ b/browser-visit-tools/README.md
@@ -14,6 +14,10 @@ into two groups:
   the multi-laptop architecture (see the top-level
   [README](../README.md) and
   [`browser-visit-sync-server/`](../browser-visit-sync-server/)).
+- **EC2 VM management** — `manage_vm.py`, `manage_sync_server.py`
+  (with the internal `_bvl_aws.py` helper).  Create and operate the
+  EC2 VM that hosts the sync-server, and remotely manage the server
+  process over AWS SSM (no SSH).  Need `boto3` and AWS credentials.
 
 ## CLI scripts
 
@@ -35,6 +39,9 @@ one-line wrapper note before delegating.
 | `migrate_icloud_to_gdrive.py` | (Python, no wrapper) | One-time iCloud → Google Drive snapshot migration |
 | `install_laptop.sh` | (Bash) | Laptop install for multi-laptop mode |
 | `uninstall_laptop_legacy.sh` | (Bash) | Remove legacy verifier LaunchAgent |
+| `manage_vm.py` | (Python, no wrapper) | Create / start / stop / status / terminate the EC2 VM |
+| `manage_sync_server.py` | (Python, no wrapper) | Provision / deploy / control / health-check the sync-server over SSM |
+| `_bvl_aws.py` | (internal) | Shared boto3 / SSM / S3 helpers — not a CLI entrypoint |
 
 ### `generate_reading_list`
 
@@ -240,6 +247,111 @@ bash uninstall_laptop_legacy.sh
 `install_laptop.sh` runs this script as its first step, so most
 users never invoke it directly.
 
+### `manage_vm.py`
+
+Creates and manages the EC2 VM that hosts the sync-server.  Talks to
+AWS via `boto3`; credentials come from the ambient chain (env / shared
+config / SSO).  Idempotency keys on the tags
+`bvl:role=sync-server` / `bvl:managed-by=browser-visit-tools` — `create`
+looks for an existing tagged, non-terminated instance before launching
+a new one, so re-running is safe.  It also find-or-creates the
+security group (gRPC port `50443` ingress only — **no SSH**) and an IAM
+instance profile carrying `AmazonSSMManagedInstanceCore` so the VM is
+reachable over SSM.
+
+State (region, instance id, arch, …) is persisted to
+`~/.browser-visit-logger/vm.json`; every subcommand loads it and falls
+back to tag-discovery if it's missing or stale.
+
+| Subcommand | Effect |
+|---|---|
+| `create` | Idempotently create the VM + SG + IAM profile |
+| `start` / `stop` / `reboot` | Lifecycle control |
+| `status` | Print state, type, public address |
+| `terminate` | Terminate the instance (`--purge-infra` also deletes the shared SG + role) |
+
+```bash
+# Create (the only required flag is the CIDR allowed to reach the gRPC port)
+python3 manage_vm.py create --allow-cidr 203.0.113.7/32
+
+# Pick arch / size / region (arch must match the deployed binary)
+python3 manage_vm.py create --allow-cidr 203.0.113.7/32 \
+    --region us-west-2 --arch arm64 --instance-type t4g.small --volume-size 30
+
+python3 manage_vm.py status
+python3 manage_vm.py stop
+python3 manage_vm.py terminate --purge-infra
+```
+
+`create` flags: `--allow-cidr CIDR` (required, repeatable), `--region`,
+`--instance-type`, `--volume-size` (GiB, default 20),
+`--arch {x86_64,arm64}` (default `x86_64`), `--ami` (override the
+resolved Amazon Linux 2023 AMI).  Exit codes: 0 ok, 1 AWS/operation
+failure, 2 usage.
+
+### `manage_sync_server.py`
+
+Provisions, deploys, and operates the sync-server **process** on the
+VM, entirely over AWS SSM `SendCommand` (no SSH, no open port 22).
+Resolves the instance the same way `manage_vm.py` does, waits for the
+SSM agent to report `Online`, then runs the relevant shell over
+`AWS-RunShellScript`.
+
+The cross-compiled binary and the systemd unit / TLS material are
+staged through a private, per-account S3 bucket
+(`bvl-sync-deploy-<account>-<region>`, 7-day expiry lifecycle; TLS
+objects are written with SSE) which the VM pulls from via its instance
+profile — SSM's ~100 KB command-parameter cap can't carry the ~20 MB
+binary inline.
+
+Build the Linux binary first:
+
+```bash
+make -C ../browser-visit-sync-server build-linux GOARCH=amd64   # or arm64
+```
+
+| Subcommand | Effect |
+|---|---|
+| `provision` | Create the `bvlsync` user + data dirs, install the systemd unit and TLS material, `systemctl enable` (idempotent) |
+| `deploy` | Stage the binary → S3 → `/usr/local/bin/sync-server`, restart |
+| `start` / `stop` / `restart` | `systemctl` control |
+| `status` | `systemctl is-active` + `status` |
+| `logs` | `journalctl` **snapshot** (`--lines`, `--since`); for a live tail use `aws ssm start-session` |
+| `health` | service active + gRPC port answers + disk under 90 % |
+
+```bash
+# First-boot setup (TLS material passed as local PEM paths)
+python3 manage_sync_server.py provision \
+    --server-cert server.crt --server-key server.key \
+    --clients-ca clients-ca.crt
+
+# Install the binary and start
+python3 manage_sync_server.py deploy \
+    --binary ../browser-visit-sync-server/bin/sync-server-linux-amd64
+python3 manage_sync_server.py start
+python3 manage_sync_server.py health
+python3 manage_sync_server.py logs --lines 50
+```
+
+`provision --and-deploy --binary <path>` chains a deploy after
+provisioning.  `deploy` refuses a binary whose arch token doesn't match
+the VM's recorded arch unless you pass `--force`.  Exit codes: 0 ok,
+1 remote/AWS failure, 2 usage.
+
+#### Prerequisites
+
+`boto3` (`pip install boto3`) and AWS credentials with, at minimum:
+
+- EC2: `ec2:RunInstances`, `*Instances`, security-group create/authorize/delete,
+  `ec2:DescribeImages`/`DescribeInstances`
+- IAM: `iam:CreateRole`, `AttachRolePolicy`, `PutRolePolicy`,
+  `CreateInstanceProfile`, `AddRoleToInstanceProfile`, and **`iam:PassRole`**
+  (RunInstances fails confusingly without it)
+- SSM: `ssm:SendCommand`, `GetCommandInvocation`,
+  `DescribeInstanceInformation`, `GetParameter`
+- S3: full access to the `bvl-sync-deploy-*` bucket
+- STS: `sts:GetCallerIdentity`
+
 ## Development
 
 A `Makefile` builds a throwaway virtualenv under `.venv-test/`
@@ -251,17 +363,21 @@ make test          # venv + pytest, --cov-fail-under=100 across all modules
 make clean-venv    # rebuild the venv after editing requirements-test.txt
 ```
 
-**85 tests, 100% line coverage** across every shipped module:
-`reading_list.py`, `db_diff.py`, `fetch_vm_snapshot.py`,
-`enroll_machine.py`, `migrate_icloud_to_gdrive.py`.  These standalone
-unit tests are in addition to the end-to-end exercise the sync tools
-get from the integration suite under
+**100% line coverage** across every shipped module: `reading_list.py`,
+`db_diff.py`, `fetch_vm_snapshot.py`, `enroll_machine.py`,
+`migrate_icloud_to_gdrive.py`, `_bvl_aws.py`, `manage_vm.py`,
+`manage_sync_server.py`.  These standalone unit tests are in addition
+to the end-to-end exercise the sync tools get from the integration
+suite under
 [`browser-visit-sync-server/test/`](../browser-visit-sync-server/test/).
 
 Test deps: `pytest`, `pytest-cov`, and `cryptography` (the last only
 because `enroll_machine.py`'s PEM-cert path uses it and the tests
-exercise that path).  `fetch_vm_snapshot.py`'s gRPC dependency is
-*faked* in tests, so `grpcio` is not required to run them.
+exercise that path).  `fetch_vm_snapshot.py`'s gRPC dependency and the
+`boto3` used by the EC2-management tools are both *faked* in tests
+(every AWS call routes through the single `_bvl_aws.client` seam and
+hand-rolled recording fakes), so neither `grpcio` nor `boto3` is
+required to run the suite — and neither is in `requirements-test.txt`.
 
 **Production-data safety.** `reading_list.py` is the only tool with
 `~`-rooted defaults (`BVL_DB_FILE` to read, `BVL_OUTPUT_DIR` to write);
@@ -281,14 +397,20 @@ browser-visit-tools/
 ├── migrate_icloud_to_gdrive.py     # one-time archive migration
 ├── install_laptop.sh               # multi-laptop laptop install
 ├── uninstall_laptop_legacy.sh      # remove legacy verifier LaunchAgent
+├── manage_vm.py                    # EC2 VM lifecycle (boto3)
+├── manage_sync_server.py           # sync-server ops over SSM
+├── _bvl_aws.py                     # shared boto3 / SSM / S3 helpers
 ├── Makefile                        # venv + test (gated at 100% coverage)
 ├── tests/
-│   ├── conftest.py                 # sandboxes BVL_DB_FILE / BVL_OUTPUT_DIR
+│   ├── conftest.py                 # sandboxes BVL_DB_FILE / BVL_OUTPUT_DIR / BVL_VM_STATE_FILE
 │   ├── test_reading_list.py
 │   ├── test_db_diff.py
 │   ├── test_enroll_machine.py
 │   ├── test_fetch_vm_snapshot.py
-│   └── test_migrate.py
+│   ├── test_migrate.py
+│   ├── test_bvl_aws.py
+│   ├── test_manage_vm.py
+│   └── test_manage_sync_server.py
 ├── requirements-test.txt
 ├── .venv-test/                     # test virtualenv (gitignored, auto-created)
 └── README.md

--- a/browser-visit-tools/_bvl_aws.py
+++ b/browser-visit-tools/_bvl_aws.py
@@ -1,0 +1,252 @@
+"""
+_bvl_aws.py — Internal helpers shared by ``manage_vm.py`` and
+``manage_sync_server.py``.  Not a CLI entrypoint (leading underscore).
+
+Everything that talks to AWS routes through :func:`client`, the single
+seam the unit tests monkeypatch so the suite never makes a real API
+call (and ``boto3`` need not be installed in the test venv — it is
+imported lazily, mirroring how ``fetch_vm_snapshot.py`` treats grpc).
+
+Contents:
+  * boto3 client factory + region resolution
+  * resource tags + tag-based instance discovery
+  * ``vm.json`` state-file load/save (under the existing config dir)
+  * SSM: wait-for-online, send-command-and-wait
+  * S3: staging-bucket ensure + upload
+"""
+
+import datetime
+import json
+import os
+import sys
+import time
+from collections import namedtuple
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# boto3 client factory (the test seam) + region
+# ---------------------------------------------------------------------------
+
+# Tag set stamped on every resource this tooling creates, and the basis
+# for idempotent discovery.
+TAG_MANAGED_BY = ('bvl:managed-by', 'browser-visit-tools')
+TAG_ROLE = ('bvl:role', 'sync-server')
+
+# Names of the (singleton) shared infra resources.
+SG_NAME = 'bvl-sync-server-sg'
+ROLE_NAME = 'bvl-sync-server-role'
+PROFILE_NAME = 'bvl-sync-server-profile'
+
+GRPC_PORT = 50443
+
+
+def resolve_region(arg_region):
+    """Region from explicit flag, else ``BVL_AWS_REGION``, else None
+    (let the ambient boto3 session decide)."""
+    return arg_region or os.environ.get('BVL_AWS_REGION') or None
+
+
+def client(service, region=None):
+    """Construct a boto3 client.  The one place the whole package
+    reaches AWS — unit tests monkeypatch this to hand back fakes."""
+    try:
+        import boto3
+    except ImportError:  # pragma: no cover - import-time environment guard
+        print("error: this tool requires boto3 (pip install boto3)",
+              file=sys.stderr)
+        sys.exit(2)
+    return boto3.client(service, region_name=region)
+
+
+def error_code(exc):
+    """AWS error code from a botocore ClientError-shaped exception, or
+    None.  Avoids importing botocore: we read the ``response`` dict that
+    every ClientError carries (and that the test fakes mimic)."""
+    resp = getattr(exc, 'response', None)
+    if isinstance(resp, dict):
+        return resp.get('Error', {}).get('Code')
+    return None
+
+
+# ---------------------------------------------------------------------------
+# state file (~/.browser-visit-logger/vm.json)
+# ---------------------------------------------------------------------------
+
+def state_path():
+    """Location of the persisted VM state.  ``BVL_VM_STATE_FILE`` wins
+    (the test-sandbox seam); otherwise it lives in the same config dir
+    ``install_laptop.sh`` already establishes."""
+    override = os.environ.get('BVL_VM_STATE_FILE')
+    if override:
+        return Path(override)
+    base = os.environ.get('BVL_CONFIG_DIR') or os.path.join(
+        os.path.expanduser('~'), '.browser-visit-logger')
+    return Path(base) / 'vm.json'
+
+
+def load_state():
+    """Return the parsed state dict, or ``{}`` if no file exists."""
+    p = state_path()
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text())
+
+
+def save_state(state):
+    """Persist ``state`` (a dict) atomically-ish, stamping updated_at."""
+    p = state_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    out = dict(state)
+    out['updated_at'] = datetime.datetime.now(
+        datetime.timezone.utc).isoformat()
+    p.write_text(json.dumps(out, indent=2, sort_keys=True) + '\n')
+    return out
+
+
+# ---------------------------------------------------------------------------
+# tag-based instance discovery
+# ---------------------------------------------------------------------------
+
+# Instance states we treat as "this VM still exists" — terminated and
+# shutting-down are deliberately excluded so a fresh create can proceed.
+LIVE_STATES = ('pending', 'running', 'stopping', 'stopped')
+
+
+def discover_instances(ec2):
+    """Every non-terminated instance carrying the sync-server role tag.
+    Returns a list of instance dicts (possibly empty)."""
+    resp = ec2.describe_instances(Filters=[
+        {'Name': f'tag:{TAG_ROLE[0]}', 'Values': [TAG_ROLE[1]]},
+        {'Name': 'instance-state-name', 'Values': list(LIVE_STATES)},
+    ])
+    instances = []
+    for res in resp.get('Reservations', []):
+        instances.extend(res.get('Instances', []))
+    return instances
+
+
+def resolve_instance_id(ec2, state):
+    """Find the managed instance id: trust ``state`` if its instance is
+    still live, else fall back to tag discovery.  Returns the id or
+    raises RuntimeError (none / ambiguous)."""
+    want = state.get('instance_id')
+    found = discover_instances(ec2)
+    by_id = {i['InstanceId']: i for i in found}
+    if want and want in by_id:
+        return want
+    if not found:
+        raise RuntimeError(
+            "no sync-server VM found (state file empty and no instance "
+            f"carries tag {TAG_ROLE[0]}={TAG_ROLE[1]}); run `create` first")
+    if len(found) > 1:
+        ids = ', '.join(sorted(by_id))
+        raise RuntimeError(
+            f"ambiguous: multiple sync-server instances found ({ids}); "
+            "terminate the extras or fix the state file")
+    return found[0]['InstanceId']
+
+
+# ---------------------------------------------------------------------------
+# SSM: wait-for-online + send-command-and-wait
+# ---------------------------------------------------------------------------
+
+RemoteResult = namedtuple('RemoteResult', 'status exit_code stdout stderr')
+
+_SSM_TERMINAL = ('Success', 'Cancelled', 'Failed', 'TimedOut')
+
+
+def wait_for_ssm_online(ssm, instance_id, timeout=180, interval=5,
+                        sleep=time.sleep, monotonic=time.monotonic):
+    """Block until the SSM agent on ``instance_id`` reports Online.
+
+    Commands sent before registration fail with InvalidInstanceId, so
+    every remote op calls this first.  Raises TimeoutError if the agent
+    doesn't come online within ``timeout`` seconds."""
+    deadline = monotonic() + timeout
+    while True:
+        resp = ssm.describe_instance_information(Filters=[
+            {'Key': 'InstanceIds', 'Values': [instance_id]}])
+        infos = resp.get('InstanceInformationList', [])
+        if infos and infos[0].get('PingStatus') == 'Online':
+            return
+        if monotonic() >= deadline:
+            raise TimeoutError(
+                f"SSM agent on {instance_id} not Online after {timeout}s")
+        sleep(interval)
+
+
+def run_remote(ssm, instance_id, commands, comment='', timeout=300,
+               interval=3, sleep=time.sleep, monotonic=time.monotonic):
+    """Send a RunShellScript command and block for its result.
+
+    ``commands`` is a list of shell lines.  Returns a RemoteResult.
+    Raises TimeoutError if the invocation never reaches a terminal
+    state within ``timeout`` seconds."""
+    sent = ssm.send_command(
+        InstanceIds=[instance_id],
+        DocumentName='AWS-RunShellScript',
+        Comment=comment[:100],
+        Parameters={'commands': list(commands)},
+    )
+    command_id = sent['Command']['CommandId']
+    deadline = monotonic() + timeout
+    while True:
+        inv = ssm.get_command_invocation(
+            CommandId=command_id, InstanceId=instance_id)
+        status = inv.get('Status')
+        if status in _SSM_TERMINAL:
+            return RemoteResult(
+                status=status,
+                exit_code=inv.get('ResponseCode', -1),
+                stdout=inv.get('StandardOutputContent', ''),
+                stderr=inv.get('StandardErrorContent', ''),
+            )
+        if monotonic() >= deadline:
+            raise TimeoutError(
+                f"SSM command {command_id} still {status} after {timeout}s")
+        sleep(interval)
+
+
+# ---------------------------------------------------------------------------
+# S3 staging bucket
+# ---------------------------------------------------------------------------
+
+def staging_bucket_name(sts, region):
+    """Deterministic per-account, per-region staging bucket name."""
+    account = sts.get_caller_identity()['Account']
+    return f'bvl-sync-deploy-{account}-{region}'
+
+
+def ensure_bucket(s3, name, region):
+    """Create the staging bucket if absent and attach a 7-day expiry
+    lifecycle rule.  Idempotent."""
+    try:
+        s3.head_bucket(Bucket=name)
+    except Exception as e:  # noqa: BLE001 - re-raised unless it's a 404
+        if error_code(e) not in ('404', 'NoSuchBucket', 'NotFound'):
+            raise
+        # us-east-1 rejects an explicit LocationConstraint; every other
+        # region requires it.
+        if region == 'us-east-1':
+            s3.create_bucket(Bucket=name)
+        else:
+            s3.create_bucket(
+                Bucket=name,
+                CreateBucketConfiguration={'LocationConstraint': region})
+    s3.put_bucket_lifecycle_configuration(
+        Bucket=name,
+        LifecycleConfiguration={'Rules': [{
+            'ID': 'bvl-expire-staging',
+            'Status': 'Enabled',
+            'Filter': {'Prefix': ''},
+            'Expiration': {'Days': 7},
+        }]})
+    return name
+
+
+def upload_file(s3, path, bucket, key, encrypt=False):
+    """Upload a local file to S3.  ``encrypt`` requests SSE (used for
+    the TLS material)."""
+    extra = {'ServerSideEncryption': 'AES256'} if encrypt else {}
+    s3.upload_file(str(path), bucket, key, ExtraArgs=extra)
+    return f's3://{bucket}/{key}'

--- a/browser-visit-tools/manage_sync_server.py
+++ b/browser-visit-tools/manage_sync_server.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""
+manage_sync_server.py — Remotely provision, deploy, and operate the
+browser-visit sync-server running on the EC2 VM, all over AWS SSM (no
+SSH, no inbound port 22).
+
+Subcommands
+-----------
+    provision  First-boot setup: create the bvlsync user + data dirs,
+               install the systemd unit and TLS material, enable the
+               service.  Idempotent; safe to re-run.
+    deploy     Cross-compiled binary → S3 → VM, install to
+               /usr/local/bin/sync-server, restart the service.
+    start      systemctl start sync-server
+    stop       systemctl stop sync-server
+    restart    systemctl restart sync-server
+    status     systemctl is-active + status
+    logs       journalctl snapshot (NOT a live tail — for follow, use
+               `aws ssm start-session`)
+    health     service active + gRPC port answers + disk ok
+
+The VM itself (and its AWS infra) is owned by the sibling
+``manage_vm.py``.  Build the binary first with
+``make -C ../browser-visit-sync-server build-linux GOARCH=<amd64|arm64>``.
+
+Exit codes: 0 success, 1 remote/AWS failure, 2 usage.
+"""
+
+import argparse
+import hashlib
+import sys
+from pathlib import Path
+
+import _bvl_aws as aws
+
+_HERE = Path(__file__).resolve().parent
+_UNIT_FILE = _HERE.parent / 'browser-visit-sync-server' / 'deploy' / \
+    'sync-server.service'
+
+# state ``arch`` → Go GOARCH token expected in the built binary's name.
+_GOARCH = {'x86_64': 'amd64', 'arm64': 'arm64'}
+
+_DATA_DIR = '/var/lib/browser-visit-sync'
+_ETC_DIR = '/etc/browser-visit-sync'
+
+
+def _surface(result):
+    """Print a RemoteResult's output; return a tool exit code."""
+    if result.stdout:
+        sys.stdout.write(result.stdout)
+        if not result.stdout.endswith('\n'):
+            sys.stdout.write('\n')
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+    if result.status == 'Success' and result.exit_code == 0:
+        return 0
+    print(f"remote command {result.status} (exit {result.exit_code})",
+          file=sys.stderr)
+    return 1
+
+
+def _ssm_target(args):
+    """Resolve the instance, build an SSM client, and wait for the agent
+    to be Online.  Returns (region, ssm, instance_id)."""
+    region = aws.resolve_region(args.region)
+    ec2 = aws.client('ec2', region)
+    instance_id = aws.resolve_instance_id(ec2, aws.load_state())
+    ssm = aws.client('ssm', region)
+    print(f"region={region or 'default'} instance={instance_id}")
+    aws.wait_for_ssm_online(ssm, instance_id)
+    return region, ssm, instance_id
+
+
+def _stage_clients(region):
+    """(s3, bucket) for the staging bucket, ensuring it exists."""
+    sts = aws.client('sts', region)
+    s3 = aws.client('s3', region)
+    bucket = aws.staging_bucket_name(sts, region)
+    aws.ensure_bucket(s3, bucket, region or 'us-east-1')
+    return s3, bucket
+
+
+def cmd_provision(args):
+    region, ssm, instance_id = _ssm_target(args)
+    s3, bucket = _stage_clients(region)
+    aws.upload_file(s3, _UNIT_FILE, bucket, 'deploy/sync-server.service')
+    aws.upload_file(s3, args.server_cert, bucket, 'tls/server.crt',
+                    encrypt=True)
+    aws.upload_file(s3, args.server_key, bucket, 'tls/server.key',
+                    encrypt=True)
+    aws.upload_file(s3, args.clients_ca, bucket, 'tls/clients-ca.crt',
+                    encrypt=True)
+    script = [
+        'set -euo pipefail',
+        'id -u bvlsync &>/dev/null || useradd --system --no-create-home '
+        '--shell /usr/sbin/nologin bvlsync',
+        f'mkdir -p {_DATA_DIR}/logs {_ETC_DIR}',
+        f'chown -R bvlsync:bvlsync {_DATA_DIR}',
+        f'chmod 750 {_ETC_DIR}',
+        f'aws s3 cp s3://{bucket}/deploy/sync-server.service '
+        '/etc/systemd/system/sync-server.service',
+        f'aws s3 cp s3://{bucket}/tls/server.crt {_ETC_DIR}/server.crt',
+        f'aws s3 cp s3://{bucket}/tls/server.key {_ETC_DIR}/server.key',
+        f'aws s3 cp s3://{bucket}/tls/clients-ca.crt '
+        f'{_ETC_DIR}/clients-ca.crt',
+        f'chown -R bvlsync:bvlsync {_ETC_DIR}',
+        f'chmod 600 {_ETC_DIR}/server.key',
+        'systemctl daemon-reload',
+        'systemctl enable sync-server',
+    ]
+    rc = _surface(aws.run_remote(ssm, instance_id, script,
+                                 comment='bvl provision'))
+    if rc == 0:
+        print("provisioned; run `deploy` to install the binary")
+    if rc == 0 and args.and_deploy:
+        return _deploy(region, ssm, instance_id, args)
+    return rc
+
+
+def _check_arch(binary):
+    """Warn/refuse if the binary's arch token doesn't match the VM's
+    recorded arch.  Returns an error string, or None if ok."""
+    arch = aws.load_state().get('arch')
+    if not arch:
+        return None
+    token = _GOARCH.get(arch)
+    if token and token not in Path(binary).name:
+        return (f"binary {Path(binary).name!r} does not look like a "
+                f"{token} build but the VM arch is {arch}; "
+                "rebuild with the matching GOARCH or pass --force")
+    return None
+
+
+def _deploy(region, ssm, instance_id, args):
+    s3, bucket = _stage_clients(region)
+    data = Path(args.binary).read_bytes()
+    digest = hashlib.sha256(data).hexdigest()
+    key = f'sync-server/{digest}'
+    aws.upload_file(s3, args.binary, bucket, key)
+    script = [
+        'set -euo pipefail',
+        f'aws s3 cp s3://{bucket}/{key} /tmp/sync-server.new',
+        'install -m 0755 /tmp/sync-server.new /usr/local/bin/sync-server',
+        'rm -f /tmp/sync-server.new',
+        'systemctl restart sync-server',
+    ]
+    print(f"deploying {Path(args.binary).name} ({digest[:12]}) ...")
+    return _surface(aws.run_remote(ssm, instance_id, script,
+                                   comment='bvl deploy'))
+
+
+def cmd_deploy(args):
+    if not Path(args.binary).is_file():
+        print(f"error: binary not found: {args.binary}", file=sys.stderr)
+        return 1
+    problem = _check_arch(args.binary)
+    if problem and not args.force:
+        print(f"error: {problem}", file=sys.stderr)
+        return 1
+    region, ssm, instance_id = _ssm_target(args)
+    return _deploy(region, ssm, instance_id, args)
+
+
+def _systemctl(args, action):
+    _region, ssm, instance_id = _ssm_target(args)
+    return _surface(aws.run_remote(
+        ssm, instance_id, [f'systemctl {action} sync-server'],
+        comment=f'bvl {action}'))
+
+
+def cmd_start(args):
+    return _systemctl(args, 'start')
+
+
+def cmd_stop(args):
+    return _systemctl(args, 'stop')
+
+
+def cmd_restart(args):
+    return _systemctl(args, 'restart')
+
+
+def cmd_status(args):
+    _region, ssm, instance_id = _ssm_target(args)
+    return _surface(aws.run_remote(ssm, instance_id, [
+        'systemctl is-active sync-server || true',
+        'systemctl status sync-server --no-pager || true',
+    ], comment='bvl status'))
+
+
+def cmd_logs(args):
+    _region, ssm, instance_id = _ssm_target(args)
+    cmd = f'journalctl -u sync-server -n {args.lines} --no-pager'
+    if args.since:
+        cmd += f' --since {args.since!r}'
+    return _surface(aws.run_remote(ssm, instance_id, [cmd],
+                                   comment='bvl logs'))
+
+
+def cmd_health(args):
+    _region, ssm, instance_id = _ssm_target(args)
+    script = [
+        'set -e',
+        'systemctl is-active --quiet sync-server && echo "service: active" '
+        '|| { echo "service: INACTIVE"; exit 1; }',
+        f'timeout 3 bash -c "</dev/tcp/127.0.0.1/{aws.GRPC_PORT}" '
+        f'&& echo "port {aws.GRPC_PORT}: open" '
+        f'|| {{ echo "port {aws.GRPC_PORT}: CLOSED"; exit 1; }}',
+        f'use=$(df --output=pcent {_DATA_DIR} | tail -1 | tr -dc "0-9"); '
+        'echo "disk: ${use}% used"; [ "$use" -lt 90 ] || '
+        '{ echo "disk: OVER 90%"; exit 1; }',
+    ]
+    return _surface(aws.run_remote(ssm, instance_id, script,
+                                   comment='bvl health'))
+
+
+_DISPATCH = {
+    'provision': cmd_provision, 'deploy': cmd_deploy, 'start': cmd_start,
+    'stop': cmd_stop, 'restart': cmd_restart, 'status': cmd_status,
+    'logs': cmd_logs, 'health': cmd_health,
+}
+
+
+def _build_parser():
+    p = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    sub = p.add_subparsers(dest='action', required=True)
+
+    def with_region(sp):
+        sp.add_argument('--region', help='AWS region (else BVL_AWS_REGION)')
+        return sp
+
+    pp = with_region(sub.add_parser('provision', help='first-boot setup'))
+    pp.add_argument('--server-cert', required=True, help='server cert PEM')
+    pp.add_argument('--server-key', required=True, help='server key PEM')
+    pp.add_argument('--clients-ca', required=True,
+                    help='CA bundle that signed the laptop client certs')
+    pp.add_argument('--and-deploy', action='store_true',
+                    help='chain a deploy after provisioning (needs --binary)')
+    pp.add_argument('--binary', help='binary to deploy when --and-deploy')
+    pp.add_argument('--force', action='store_true',
+                    help='skip the binary/VM arch check')
+
+    pd = with_region(sub.add_parser('deploy', help='install/update binary'))
+    pd.add_argument('--binary', required=True,
+                    help='path to the cross-compiled linux sync-server')
+    pd.add_argument('--force', action='store_true',
+                    help='skip the binary/VM arch check')
+
+    for name, helptext in (('start', 'start the service'),
+                           ('stop', 'stop the service'),
+                           ('restart', 'restart the service'),
+                           ('status', 'service status'),
+                           ('health', 'end-to-end health probe')):
+        with_region(sub.add_parser(name, help=helptext))
+
+    pl = with_region(sub.add_parser('logs', help='journalctl snapshot'))
+    pl.add_argument('--lines', type=int, default=100,
+                    help='number of log lines (default 100)')
+    pl.add_argument('--since', help="journalctl --since value, e.g. '1 hour ago'")
+    return p
+
+
+def main(argv):
+    args = _build_parser().parse_args(argv)
+    try:
+        return _DISPATCH[args.action](args)
+    except (RuntimeError, TimeoutError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == '__main__':  # pragma: no cover
+    sys.exit(main(sys.argv[1:]))

--- a/browser-visit-tools/manage_vm.py
+++ b/browser-visit-tools/manage_vm.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""
+manage_vm.py — Create and manage the EC2 VM that hosts the
+browser-visit sync-server.
+
+Subcommands
+-----------
+    create     Idempotently create the VM (and its security group + IAM
+               instance profile).  Re-running is a no-op if the tagged
+               instance already exists.
+    start      Start a stopped instance.
+    stop       Stop a running instance.
+    reboot     Reboot the instance.
+    status     Print instance id, state, and public address.
+    terminate  Terminate the instance (optionally purge shared infra).
+
+Remote management of the sync-server *process* lives in the sibling
+``manage_sync_server.py`` — this tool only owns the VM and its AWS
+infrastructure.
+
+Idempotency keys on the tags ``bvl:role=sync-server`` /
+``bvl:managed-by=browser-visit-tools``; ``create`` looks for an existing
+tagged, non-terminated instance before launching a new one.  AWS
+credentials come from the ambient boto3 chain (env / shared config /
+SSO).  See the README for the IAM permissions the operator needs
+(notably ``iam:PassRole``).
+
+Exit codes: 0 success, 1 AWS/operation failure, 2 usage.
+"""
+
+import argparse
+import json
+import sys
+
+import _bvl_aws as aws
+
+# AMI arch → (SSM public parameter suffix, default instance type).
+_ARCH = {
+    'x86_64': ('x86_64', 't3.small'),
+    'arm64': ('arm64', 't4g.small'),
+}
+
+_TRUST_POLICY = json.dumps({
+    'Version': '2012-10-17',
+    'Statement': [{
+        'Effect': 'Allow',
+        'Principal': {'Service': 'ec2.amazonaws.com'},
+        'Action': 'sts:AssumeRole',
+    }],
+})
+
+_SSM_CORE_POLICY = 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
+
+
+def _tag_spec(resource):
+    """A TagSpecification applying the managed-by + role tags."""
+    return {
+        'ResourceType': resource,
+        'Tags': [
+            {'Key': aws.TAG_MANAGED_BY[0], 'Value': aws.TAG_MANAGED_BY[1]},
+            {'Key': aws.TAG_ROLE[0], 'Value': aws.TAG_ROLE[1]},
+        ],
+    }
+
+
+def _resolve_ami(ssm, arch):
+    """Latest Amazon Linux 2023 AMI id for ``arch`` via the SSM public
+    parameter (so we never hardcode a region-specific id)."""
+    suffix = _ARCH[arch][0]
+    name = (f'/aws/service/ami-amazon-linux-latest/'
+            f'al2023-ami-kernel-default-{suffix}')
+    return ssm.get_parameter(Name=name)['Parameter']['Value']
+
+
+def _ensure_security_group(ec2, allow_cidrs):
+    """Find-or-create the sync-server security group; ensure ingress for
+    the gRPC port from each ``allow_cidrs`` entry.  Returns the sg id."""
+    resp = ec2.describe_security_groups(Filters=[
+        {'Name': 'group-name', 'Values': [aws.SG_NAME]}])
+    groups = resp.get('SecurityGroups', [])
+    if groups:
+        sg_id = groups[0]['GroupId']
+    else:
+        created = ec2.create_security_group(
+            GroupName=aws.SG_NAME,
+            Description='browser-visit sync-server gRPC ingress',
+            TagSpecifications=[_tag_spec('security-group')])
+        sg_id = created['GroupId']
+    for cidr in allow_cidrs:
+        try:
+            ec2.authorize_security_group_ingress(
+                GroupId=sg_id,
+                IpPermissions=[{
+                    'IpProtocol': 'tcp',
+                    'FromPort': aws.GRPC_PORT,
+                    'ToPort': aws.GRPC_PORT,
+                    'IpRanges': [{'CidrIp': cidr}],
+                }])
+        except Exception as e:  # noqa: BLE001
+            if aws.error_code(e) != 'InvalidPermission.Duplicate':
+                raise
+    return sg_id
+
+
+def _ensure_iam(iam, account, region):
+    """Find-or-create the instance role + profile.  Attaches the SSM
+    core managed policy and an inline policy letting the VM read the
+    deploy staging bucket.  Returns the instance-profile name."""
+    try:
+        iam.get_role(RoleName=aws.ROLE_NAME)
+    except Exception as e:  # noqa: BLE001
+        if aws.error_code(e) != 'NoSuchEntity':
+            raise
+        iam.create_role(RoleName=aws.ROLE_NAME,
+                        AssumeRolePolicyDocument=_TRUST_POLICY)
+    iam.attach_role_policy(RoleName=aws.ROLE_NAME, PolicyArn=_SSM_CORE_POLICY)
+    bucket = f'bvl-sync-deploy-{account}-{region}'
+    iam.put_role_policy(
+        RoleName=aws.ROLE_NAME,
+        PolicyName='bvl-deploy-bucket-read',
+        PolicyDocument=json.dumps({
+            'Version': '2012-10-17',
+            'Statement': [{
+                'Effect': 'Allow',
+                'Action': 's3:GetObject',
+                'Resource': f'arn:aws:s3:::{bucket}/*',
+            }],
+        }))
+    try:
+        iam.get_instance_profile(InstanceProfileName=aws.PROFILE_NAME)
+    except Exception as e:  # noqa: BLE001
+        if aws.error_code(e) != 'NoSuchEntity':
+            raise
+        iam.create_instance_profile(InstanceProfileName=aws.PROFILE_NAME)
+    try:
+        iam.add_role_to_instance_profile(
+            InstanceProfileName=aws.PROFILE_NAME, RoleName=aws.ROLE_NAME)
+    except Exception as e:  # noqa: BLE001
+        # LimitExceeded means the profile already carries its role.
+        if aws.error_code(e) != 'LimitExceeded':
+            raise
+    return aws.PROFILE_NAME
+
+
+def cmd_create(args):
+    region = aws.resolve_region(args.region)
+    ec2 = aws.client('ec2', region)
+    existing = aws.discover_instances(ec2)
+    if len(existing) > 1:
+        ids = ', '.join(sorted(i['InstanceId'] for i in existing))
+        print(f"error: multiple tagged instances already exist ({ids}); "
+              "refusing to create another", file=sys.stderr)
+        return 1
+    if len(existing) == 1:
+        inst = existing[0]
+        print(f"VM already exists: {inst['InstanceId']} "
+              f"({inst['State']['Name']}) — nothing to do")
+        aws.save_state({**aws.load_state(), 'region': region,
+                        'instance_id': inst['InstanceId'], 'arch': args.arch})
+        return 0
+
+    sts = aws.client('sts', region)
+    account = sts.get_caller_identity()['Account']
+    iam = aws.client('iam', region)
+    ssm = aws.client('ssm', region)
+
+    sg_id = _ensure_security_group(ec2, args.allow_cidr)
+    profile = _ensure_iam(iam, account, region)
+    ami = args.ami or _resolve_ami(ssm, args.arch)
+    instance_type = args.instance_type or _ARCH[args.arch][1]
+
+    print(f"launching {instance_type} ({args.arch}) from {ami} "
+          f"in {region or 'default region'} ...")
+    run = ec2.run_instances(
+        ImageId=ami,
+        InstanceType=instance_type,
+        MinCount=1, MaxCount=1,
+        SecurityGroupIds=[sg_id],
+        IamInstanceProfile={'Name': profile},
+        BlockDeviceMappings=[{
+            'DeviceName': '/dev/xvda',
+            'Ebs': {'VolumeSize': args.volume_size, 'VolumeType': 'gp3'},
+        }],
+        TagSpecifications=[_tag_spec('instance')],
+        ClientToken=f'bvl-sync-server-{region or "default"}',
+    )
+    instance_id = run['Instances'][0]['InstanceId']
+    aws.save_state({'region': region, 'instance_id': instance_id,
+                    'arch': args.arch, 'security_group_id': sg_id,
+                    'iam_instance_profile': profile})
+    print(f"created {instance_id}; run `manage_sync_server.py provision` "
+          "once it boots")
+    return 0
+
+
+def _resolve(args):
+    """Shared setup for the lifecycle subcommands: (ec2, instance_id)."""
+    region = aws.resolve_region(args.region)
+    ec2 = aws.client('ec2', region)
+    instance_id = aws.resolve_instance_id(ec2, aws.load_state())
+    print(f"region={region or 'default'} instance={instance_id}")
+    return ec2, instance_id
+
+
+def cmd_start(args):
+    ec2, instance_id = _resolve(args)
+    ec2.start_instances(InstanceIds=[instance_id])
+    print(f"starting {instance_id}")
+    return 0
+
+
+def cmd_stop(args):
+    ec2, instance_id = _resolve(args)
+    ec2.stop_instances(InstanceIds=[instance_id])
+    print(f"stopping {instance_id}")
+    return 0
+
+
+def cmd_reboot(args):
+    ec2, instance_id = _resolve(args)
+    ec2.reboot_instances(InstanceIds=[instance_id])
+    print(f"rebooting {instance_id}")
+    return 0
+
+
+def cmd_status(args):
+    ec2, instance_id = _resolve(args)
+    resp = ec2.describe_instances(InstanceIds=[instance_id])
+    inst = resp['Reservations'][0]['Instances'][0]
+    print(f"state:   {inst['State']['Name']}")
+    print(f"type:    {inst.get('InstanceType', '?')}")
+    print(f"public:  {inst.get('PublicDnsName') or '(none)'} "
+          f"{inst.get('PublicIpAddress') or ''}".rstrip())
+    return 0
+
+
+def _purge_infra(ec2, iam):
+    """Best-effort teardown of the shared SG / role / profile."""
+    try:
+        ec2.delete_security_group(GroupName=aws.SG_NAME)
+    except Exception as e:  # noqa: BLE001
+        print(f"warn: could not delete security group: {e}", file=sys.stderr)
+    try:
+        iam.remove_role_from_instance_profile(
+            InstanceProfileName=aws.PROFILE_NAME, RoleName=aws.ROLE_NAME)
+        iam.delete_instance_profile(InstanceProfileName=aws.PROFILE_NAME)
+        iam.delete_role_policy(RoleName=aws.ROLE_NAME,
+                               PolicyName='bvl-deploy-bucket-read')
+        iam.detach_role_policy(RoleName=aws.ROLE_NAME,
+                               PolicyArn=_SSM_CORE_POLICY)
+        iam.delete_role(RoleName=aws.ROLE_NAME)
+    except Exception as e:  # noqa: BLE001
+        print(f"warn: could not fully delete IAM role/profile: {e}",
+              file=sys.stderr)
+
+
+def cmd_terminate(args):
+    region = aws.resolve_region(args.region)
+    ec2 = aws.client('ec2', region)
+    instance_id = aws.resolve_instance_id(ec2, aws.load_state())
+    print(f"region={region or 'default'} instance={instance_id}")
+    ec2.terminate_instances(InstanceIds=[instance_id])
+    print(f"terminating {instance_id}")
+    if args.purge_infra:
+        _purge_infra(ec2, aws.client('iam', region))
+    return 0
+
+
+_DISPATCH = {
+    'create': cmd_create, 'start': cmd_start, 'stop': cmd_stop,
+    'reboot': cmd_reboot, 'status': cmd_status, 'terminate': cmd_terminate,
+}
+
+
+def _build_parser():
+    p = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    sub = p.add_subparsers(dest='action', required=True)
+
+    pc = sub.add_parser('create', help='idempotently create the VM')
+    pc.add_argument('--region', help='AWS region (else BVL_AWS_REGION)')
+    pc.add_argument('--allow-cidr', action='append', required=True,
+                    metavar='CIDR',
+                    help='CIDR allowed to reach the gRPC port (repeatable)')
+    pc.add_argument('--instance-type',
+                    help='override the arch default (t3.small / t4g.small)')
+    pc.add_argument('--volume-size', type=int, default=20,
+                    help='root EBS size in GiB (default 20)')
+    pc.add_argument('--arch', choices=sorted(_ARCH), default='x86_64',
+                    help='instance/AMI arch; must match the deployed binary')
+    pc.add_argument('--ami', help='override the resolved AL2023 AMI id')
+
+    for name, helptext in (('start', 'start a stopped VM'),
+                           ('stop', 'stop a running VM'),
+                           ('reboot', 'reboot the VM'),
+                           ('status', 'print VM state + address')):
+        sp = sub.add_parser(name, help=helptext)
+        sp.add_argument('--region', help='AWS region (else BVL_AWS_REGION)')
+
+    pt = sub.add_parser('terminate', help='terminate the VM')
+    pt.add_argument('--region', help='AWS region (else BVL_AWS_REGION)')
+    pt.add_argument('--purge-infra', action='store_true',
+                    help='also delete the shared security group + IAM role')
+    return p
+
+
+def main(argv):
+    args = _build_parser().parse_args(argv)
+    try:
+        return _DISPATCH[args.action](args)
+    except (RuntimeError, TimeoutError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == '__main__':  # pragma: no cover
+    sys.exit(main(sys.argv[1:]))

--- a/browser-visit-tools/tests/conftest.py
+++ b/browser-visit-tools/tests/conftest.py
@@ -28,6 +28,10 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 _SANDBOX = tempfile.mkdtemp(prefix='bvl-tools-test-sandbox-')
 os.environ.setdefault('BVL_DB_FILE', os.path.join(_SANDBOX, 'browser-visits.db'))
 os.environ.setdefault('BVL_OUTPUT_DIR', _SANDBOX)
+# manage_vm / manage_sync_server persist VM state to ~/.browser-visit-logger/
+# vm.json by default; pin it into the sandbox so tests never touch the real
+# file.  Individual tests override BVL_VM_STATE_FILE for their own scope.
+os.environ.setdefault('BVL_VM_STATE_FILE', os.path.join(_SANDBOX, 'vm.json'))
 
 os.environ['TZ'] = 'UTC'
 time.tzset()

--- a/browser-visit-tools/tests/test_bvl_aws.py
+++ b/browser-visit-tools/tests/test_bvl_aws.py
@@ -1,0 +1,330 @@
+"""Unit tests for _bvl_aws.py.
+
+boto3 isn't installed in the test venv, so a fake module is injected
+into sys.modules before importing the module under test (mirrors how
+test_fetch_vm_snapshot fakes grpc).  Every AWS interaction is exercised
+through hand-rolled fake clients — no network, no real boto3.
+"""
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Fake boto3 BEFORE importing the module (its `import boto3` is lazy, but
+# client() needs it to resolve for the success-path coverage).
+_fake_boto3 = types.ModuleType('boto3')
+_fake_boto3.client = lambda service, region_name=None: (
+    'client', service, region_name)
+sys.modules.setdefault('boto3', _fake_boto3)
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import _bvl_aws as aws  # noqa: E402
+
+
+class FakeError(Exception):
+    """A botocore ClientError look-alike (carries a .response)."""
+    def __init__(self, code):
+        super().__init__(code)
+        self.response = {'Error': {'Code': code}}
+
+
+# --------------------------------------------------------------------------
+# region / client / error_code
+# --------------------------------------------------------------------------
+
+def test_resolve_region_arg_wins(monkeypatch):
+    monkeypatch.setenv('BVL_AWS_REGION', 'eu-west-1')
+    assert aws.resolve_region('us-east-1') == 'us-east-1'
+
+
+def test_resolve_region_env(monkeypatch):
+    monkeypatch.setenv('BVL_AWS_REGION', 'eu-west-1')
+    assert aws.resolve_region(None) == 'eu-west-1'
+
+
+def test_resolve_region_none(monkeypatch):
+    monkeypatch.delenv('BVL_AWS_REGION', raising=False)
+    assert aws.resolve_region(None) is None
+
+
+def test_client_uses_boto3():
+    assert aws.client('ec2', 'us-east-1') == ('client', 'ec2', 'us-east-1')
+
+
+def test_error_code_present():
+    assert aws.error_code(FakeError('NoSuchEntity')) == 'NoSuchEntity'
+
+
+def test_error_code_absent():
+    assert aws.error_code(ValueError('plain')) is None
+
+
+# --------------------------------------------------------------------------
+# state file
+# --------------------------------------------------------------------------
+
+def test_state_path_override(monkeypatch, tmp_path):
+    monkeypatch.setenv('BVL_VM_STATE_FILE', str(tmp_path / 'x.json'))
+    assert aws.state_path() == tmp_path / 'x.json'
+
+
+def test_state_path_config_dir(monkeypatch, tmp_path):
+    monkeypatch.delenv('BVL_VM_STATE_FILE', raising=False)
+    monkeypatch.setenv('BVL_CONFIG_DIR', str(tmp_path))
+    assert aws.state_path() == tmp_path / 'vm.json'
+
+
+def test_state_path_home_default(monkeypatch):
+    monkeypatch.delenv('BVL_VM_STATE_FILE', raising=False)
+    monkeypatch.delenv('BVL_CONFIG_DIR', raising=False)
+    monkeypatch.setenv('HOME', '/home/tester')
+    assert aws.state_path() == Path('/home/tester/.browser-visit-logger/vm.json')
+
+
+def test_load_state_missing(monkeypatch, tmp_path):
+    monkeypatch.setenv('BVL_VM_STATE_FILE', str(tmp_path / 'absent.json'))
+    assert aws.load_state() == {}
+
+
+def test_save_then_load_roundtrip(monkeypatch, tmp_path):
+    target = tmp_path / 'sub' / 'vm.json'
+    monkeypatch.setenv('BVL_VM_STATE_FILE', str(target))
+    out = aws.save_state({'instance_id': 'i-1', 'region': 'us-east-1'})
+    assert out['instance_id'] == 'i-1'
+    assert 'updated_at' in out
+    loaded = aws.load_state()
+    assert loaded['instance_id'] == 'i-1'
+    assert loaded['region'] == 'us-east-1'
+
+
+# --------------------------------------------------------------------------
+# instance discovery
+# --------------------------------------------------------------------------
+
+class FakeEc2:
+    def __init__(self, instances=()):
+        self._instances = list(instances)
+        self.describe_filters = None
+
+    def describe_instances(self, Filters=None, **kw):
+        self.describe_filters = Filters
+        return {'Reservations': [
+            {'Instances': [i]} for i in self._instances]}
+
+
+def _inst(iid, state='running'):
+    return {'InstanceId': iid, 'State': {'Name': state}}
+
+
+def test_discover_instances_filters_and_flattens():
+    ec2 = FakeEc2([_inst('i-1'), _inst('i-2')])
+    found = aws.discover_instances(ec2)
+    assert [i['InstanceId'] for i in found] == ['i-1', 'i-2']
+    names = [f['Name'] for f in ec2.describe_filters]
+    assert 'tag:bvl:role' in names
+    assert 'instance-state-name' in names
+
+
+def test_resolve_instance_id_state_hit():
+    ec2 = FakeEc2([_inst('i-1'), _inst('i-2')])
+    assert aws.resolve_instance_id(ec2, {'instance_id': 'i-2'}) == 'i-2'
+
+
+def test_resolve_instance_id_fallback_single():
+    ec2 = FakeEc2([_inst('i-9')])
+    assert aws.resolve_instance_id(ec2, {}) == 'i-9'
+
+
+def test_resolve_instance_id_none():
+    with pytest.raises(RuntimeError, match='no sync-server VM'):
+        aws.resolve_instance_id(FakeEc2([]), {})
+
+
+def test_resolve_instance_id_ambiguous():
+    ec2 = FakeEc2([_inst('i-1'), _inst('i-2')])
+    with pytest.raises(RuntimeError, match='ambiguous'):
+        aws.resolve_instance_id(ec2, {})
+
+
+def test_resolve_instance_id_stale_state_falls_back():
+    # state names a now-terminated instance; discovery returns a different one
+    ec2 = FakeEc2([_inst('i-new')])
+    assert aws.resolve_instance_id(ec2, {'instance_id': 'i-old'}) == 'i-new'
+
+
+# --------------------------------------------------------------------------
+# SSM wait + run
+# --------------------------------------------------------------------------
+
+class FakeSSM:
+    def __init__(self, pings=(), invocations=()):
+        self._pings = list(pings)
+        self._invocations = list(invocations)
+        self.sent = None
+
+    def describe_instance_information(self, Filters=None, **kw):
+        self.info_filters = Filters
+        status = self._pings.pop(0)
+        infos = [] if status is None else [{'PingStatus': status}]
+        return {'InstanceInformationList': infos}
+
+    def send_command(self, **kw):
+        self.sent = kw
+        return {'Command': {'CommandId': 'cmd-1'}}
+
+    def get_command_invocation(self, **kw):
+        return self._invocations.pop(0)
+
+
+def _clock(values):
+    it = iter(values)
+    return lambda: next(it)
+
+
+def test_wait_for_ssm_online_immediate():
+    ssm = FakeSSM(pings=['Online'])
+    aws.wait_for_ssm_online(ssm, 'i-1', sleep=lambda _s: None,
+                            monotonic=_clock([0]))
+    # it polls for the specific instance, not all of them
+    assert ssm.info_filters == [{'Key': 'InstanceIds', 'Values': ['i-1']}]
+
+
+def test_wait_for_ssm_online_after_poll():
+    ssm = FakeSSM(pings=[None, 'Online'])
+    calls = []
+    aws.wait_for_ssm_online(ssm, 'i-1', interval=1,
+                            sleep=lambda s: calls.append(s),
+                            monotonic=_clock([0, 1]))
+    assert calls == [1]
+
+
+def test_wait_for_ssm_online_timeout():
+    ssm = FakeSSM(pings=['ConnectionLost'])
+    with pytest.raises(TimeoutError):
+        aws.wait_for_ssm_online(ssm, 'i-1', timeout=10,
+                                sleep=lambda _s: None,
+                                monotonic=_clock([0, 20]))
+
+
+def _inv(status, code=0, out='', err=''):
+    return {'Status': status, 'ResponseCode': code,
+            'StandardOutputContent': out, 'StandardErrorContent': err}
+
+
+def test_run_remote_success_immediate():
+    ssm = FakeSSM(invocations=[_inv('Success', 0, 'ok\n')])
+    res = aws.run_remote(ssm, 'i-1', ['echo hi'], comment='c',
+                         sleep=lambda _s: None, monotonic=_clock([0]))
+    assert res.status == 'Success'
+    assert res.exit_code == 0
+    assert res.stdout == 'ok\n'
+    # the command must run the shell document against the target instance
+    assert ssm.sent['DocumentName'] == 'AWS-RunShellScript'
+    assert ssm.sent['InstanceIds'] == ['i-1']
+    assert ssm.sent['Parameters'] == {'commands': ['echo hi']}
+
+
+def test_run_remote_comment_truncated():
+    # SSM caps the Comment field at 100 chars; run_remote must not exceed it.
+    ssm = FakeSSM(invocations=[_inv('Success', 0)])
+    aws.run_remote(ssm, 'i-1', ['x'], comment='c' * 250,
+                   sleep=lambda _s: None, monotonic=_clock([0]))
+    assert len(ssm.sent['Comment']) == 100
+
+
+def test_run_remote_surfaces_failure_output():
+    ssm = FakeSSM(invocations=[_inv('Failed', 7, 'partial', 'the error')])
+    res = aws.run_remote(ssm, 'i-1', ['x'],
+                         sleep=lambda _s: None, monotonic=_clock([0]))
+    assert res.status == 'Failed'
+    assert res.exit_code == 7
+    assert res.stderr == 'the error'
+
+
+def test_run_remote_polls_then_done():
+    ssm = FakeSSM(invocations=[_inv('InProgress'), _inv('Success', 0, 'x')])
+    res = aws.run_remote(ssm, 'i-1', ['c'], interval=2,
+                         sleep=lambda _s: None, monotonic=_clock([0, 1]))
+    assert res.stdout == 'x'
+
+
+def test_run_remote_timeout():
+    ssm = FakeSSM(invocations=[_inv('InProgress'), _inv('InProgress')])
+    with pytest.raises(TimeoutError):
+        aws.run_remote(ssm, 'i-1', ['c'], timeout=5,
+                       sleep=lambda _s: None, monotonic=_clock([0, 99]))
+
+
+# --------------------------------------------------------------------------
+# S3 staging
+# --------------------------------------------------------------------------
+
+class FakeSTS:
+    def get_caller_identity(self):
+        return {'Account': '123456789012'}
+
+
+class FakeS3:
+    def __init__(self, head_error=None):
+        self._head_error = head_error
+        self.created = None
+        self.lifecycle = None
+        self.uploads = []
+
+    def head_bucket(self, Bucket=None):
+        if self._head_error is not None:
+            raise self._head_error
+
+    def create_bucket(self, **kw):
+        self.created = kw
+
+    def put_bucket_lifecycle_configuration(self, **kw):
+        self.lifecycle = kw
+
+    def upload_file(self, path, bucket, key, ExtraArgs=None):
+        self.uploads.append((path, bucket, key, ExtraArgs))
+
+
+def test_staging_bucket_name():
+    assert aws.staging_bucket_name(FakeSTS(), 'us-east-1') == \
+        'bvl-sync-deploy-123456789012-us-east-1'
+
+
+def test_ensure_bucket_exists():
+    s3 = FakeS3(head_error=None)
+    aws.ensure_bucket(s3, 'b', 'us-west-2')
+    assert s3.created is None
+    assert s3.lifecycle is not None
+
+
+def test_ensure_bucket_create_us_east_1():
+    s3 = FakeS3(head_error=FakeError('404'))
+    aws.ensure_bucket(s3, 'b', 'us-east-1')
+    assert s3.created == {'Bucket': 'b'}
+
+
+def test_ensure_bucket_create_other_region():
+    s3 = FakeS3(head_error=FakeError('NoSuchBucket'))
+    aws.ensure_bucket(s3, 'b', 'eu-west-1')
+    assert s3.created['CreateBucketConfiguration'] == \
+        {'LocationConstraint': 'eu-west-1'}
+
+
+def test_ensure_bucket_other_error_reraises():
+    s3 = FakeS3(head_error=FakeError('AccessDenied'))
+    with pytest.raises(FakeError):
+        aws.ensure_bucket(s3, 'b', 'us-east-1')
+
+
+def test_upload_file_plain():
+    s3 = FakeS3()
+    uri = aws.upload_file(s3, '/tmp/x', 'b', 'k')
+    assert uri == 's3://b/k'
+    assert s3.uploads == [('/tmp/x', 'b', 'k', {})]
+
+
+def test_upload_file_encrypted():
+    s3 = FakeS3()
+    aws.upload_file(s3, '/tmp/x', 'b', 'k', encrypt=True)
+    assert s3.uploads[0][3] == {'ServerSideEncryption': 'AES256'}

--- a/browser-visit-tools/tests/test_manage_sync_server.py
+++ b/browser-visit-tools/tests/test_manage_sync_server.py
@@ -1,0 +1,313 @@
+"""Unit tests for manage_sync_server.py.
+
+All AWS plumbing is faked: _bvl_aws.client returns recording fakes, and
+the higher-level helpers (wait_for_ssm_online, run_remote, the S3
+staging trio) are monkeypatched so the suite never touches AWS and the
+~20 MB-binary path is exercised with a few dummy bytes.
+"""
+import argparse
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_fake_boto3 = types.ModuleType('boto3')
+_fake_boto3.client = lambda service, region_name=None: None
+sys.modules.setdefault('boto3', _fake_boto3)
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import _bvl_aws as aws  # noqa: E402
+import manage_sync_server as mss  # noqa: E402
+
+
+class Rec:
+    def __init__(self, returns=None):
+        self.calls = []
+        self._returns = returns or {}
+
+    def __getattr__(self, name):
+        def method(**kw):
+            self.calls.append((name, kw))
+            return self._returns.get(name)
+        return method
+
+
+class RunRec:
+    """Stand-in for aws.run_remote: records (instance_id, commands)."""
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    def __call__(self, ssm, instance_id, commands, comment='', **kw):
+        self.calls.append((instance_id, list(commands), comment))
+        return self.result
+
+    def last_commands(self):
+        return self.calls[-1][1]
+
+
+def _reservations(*instances):
+    return {'Reservations': [{'Instances': [i]} for i in instances]}
+
+
+def _inst(iid='i-1'):
+    return {'InstanceId': iid, 'State': {'Name': 'running'}}
+
+
+def _ok(out='ok\n', err=''):
+    return aws.RemoteResult('Success', 0, out, err)
+
+
+def _patch(monkeypatch, run_result=None, ec2=None):
+    services = {
+        'ec2': ec2 or Rec(returns={'describe_instances':
+                                   _reservations(_inst('i-1'))}),
+        'ssm': Rec(),
+        's3': Rec(),
+        'sts': Rec(returns={'get_caller_identity': {'Account': '1'}}),
+    }
+    monkeypatch.setattr(mss.aws, 'client',
+                        lambda service, region=None: services[service])
+    waited = []
+    monkeypatch.setattr(mss.aws, 'wait_for_ssm_online',
+                        lambda ssm, iid, *a, **k: waited.append(iid))
+    _patch.waited = waited
+    monkeypatch.setattr(mss.aws, 'staging_bucket_name',
+                        lambda sts, region: 'bvl-bucket')
+    monkeypatch.setattr(mss.aws, 'ensure_bucket', lambda *a, **k: 'bvl-bucket')
+    uploads = []
+
+    def _upload(s3, path, bucket, key, encrypt=False):
+        uploads.append((str(path), key, encrypt))
+        return f's3://{bucket}/{key}'
+    monkeypatch.setattr(mss.aws, 'upload_file', _upload)
+    runner = RunRec(run_result or _ok())
+    monkeypatch.setattr(mss.aws, 'run_remote', runner)
+    return runner, uploads
+
+
+# --------------------------------------------------------------------------
+# _surface
+# --------------------------------------------------------------------------
+
+def test_surface_success_adds_newline(capsys):
+    assert mss._surface(aws.RemoteResult('Success', 0, 'no-nl', '')) == 0
+    assert capsys.readouterr().out == 'no-nl\n'
+
+
+def test_surface_success_with_stderr(capsys):
+    assert mss._surface(aws.RemoteResult('Success', 0, 'out\n', 'warn')) == 0
+    cap = capsys.readouterr()
+    assert cap.out == 'out\n'
+    assert cap.err == 'warn'
+
+
+def test_surface_failure(capsys):
+    assert mss._surface(aws.RemoteResult('Failed', 2, '', 'boom')) == 1
+    assert 'remote command Failed' in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------
+# _check_arch
+# --------------------------------------------------------------------------
+
+def _write_state(monkeypatch, tmp_path, **state):
+    p = tmp_path / 'vm.json'
+    p.write_text(json.dumps(state))
+    monkeypatch.setenv('BVL_VM_STATE_FILE', str(p))
+    return p
+
+
+def test_check_arch_no_state(monkeypatch, tmp_path):
+    monkeypatch.setenv('BVL_VM_STATE_FILE', str(tmp_path / 'absent.json'))
+    assert mss._check_arch('sync-server-linux-amd64') is None
+
+
+def test_check_arch_match(monkeypatch, tmp_path):
+    _write_state(monkeypatch, tmp_path, arch='x86_64')
+    assert mss._check_arch('bin/sync-server-linux-amd64') is None
+
+
+def test_check_arch_mismatch(monkeypatch, tmp_path):
+    _write_state(monkeypatch, tmp_path, arch='arm64')
+    msg = mss._check_arch('sync-server-linux-amd64')
+    assert msg and 'arm64' in msg
+
+
+# --------------------------------------------------------------------------
+# provision
+# --------------------------------------------------------------------------
+
+def _provision_args(tmp_path, and_deploy=False, binary=None):
+    return argparse.Namespace(
+        action='provision', region=None,
+        server_cert=str(tmp_path / 'server.crt'),
+        server_key=str(tmp_path / 'server.key'),
+        clients_ca=str(tmp_path / 'clients-ca.crt'),
+        and_deploy=and_deploy, binary=binary, force=False)
+
+
+def test_provision_success(monkeypatch, tmp_path, capsys):
+    runner, uploads = _patch(monkeypatch)
+    assert mss.cmd_provision(_provision_args(tmp_path)) == 0
+    # unit file + 3 TLS files uploaded; the TLS ones (and ONLY those) are
+    # written with SSE.
+    keys = [u[1] for u in uploads]
+    assert 'deploy/sync-server.service' in keys
+    assert {'tls/server.crt', 'tls/server.key', 'tls/clients-ca.crt'} <= set(keys)
+    encrypted = {u[1] for u in uploads if u[2]}
+    assert encrypted == {'tls/server.crt', 'tls/server.key', 'tls/clients-ca.crt'}
+    # the remote shell creates the service account, confines ownership, and
+    # locks down the private key — the security-relevant steps.
+    cmds = '\n'.join(runner.last_commands())
+    assert 'useradd' in cmds and 'systemctl enable sync-server' in cmds
+    assert 'chown -R bvlsync:bvlsync /var/lib/browser-visit-sync' in cmds
+    assert 'chmod 600 /etc/browser-visit-sync/server.key' in cmds
+    assert 'provisioned' in capsys.readouterr().out
+
+
+def test_provision_failure_skips_deploy(monkeypatch, tmp_path):
+    runner, _ = _patch(monkeypatch,
+                       run_result=aws.RemoteResult('Failed', 1, '', 'x'))
+    args = _provision_args(tmp_path, and_deploy=True,
+                           binary=str(tmp_path / 'bin'))
+    assert mss.cmd_provision(args) == 1
+    # only the provision command ran; deploy never reached
+    assert len(runner.calls) == 1
+
+
+def test_provision_and_deploy(monkeypatch, tmp_path):
+    binary = tmp_path / 'sync-server-linux-amd64'
+    binary.write_bytes(b'ELF...')
+    runner, uploads = _patch(monkeypatch)
+    args = _provision_args(tmp_path, and_deploy=True, binary=str(binary))
+    assert mss.cmd_provision(args) == 0
+    # provision command + deploy command both ran
+    assert len(runner.calls) == 2
+    assert any(k.startswith('sync-server/') for _p, k, _e in uploads)
+
+
+# --------------------------------------------------------------------------
+# deploy
+# --------------------------------------------------------------------------
+
+def _deploy_args(binary, force=False):
+    return argparse.Namespace(action='deploy', region=None,
+                              binary=str(binary), force=force)
+
+
+def test_deploy_missing_binary(monkeypatch, capsys):
+    _patch(monkeypatch)
+    assert mss.cmd_deploy(_deploy_args('/no/such/binary')) == 1
+    assert 'binary not found' in capsys.readouterr().err
+
+
+def test_deploy_arch_mismatch_refused(monkeypatch, tmp_path, capsys):
+    _write_state(monkeypatch, tmp_path, arch='arm64')
+    binary = tmp_path / 'sync-server-linux-amd64'
+    binary.write_bytes(b'x')
+    _patch(monkeypatch)
+    assert mss.cmd_deploy(_deploy_args(binary)) == 1
+    assert 'does not look like' in capsys.readouterr().err
+
+
+def test_deploy_arch_mismatch_forced(monkeypatch, tmp_path):
+    _write_state(monkeypatch, tmp_path, arch='arm64')
+    binary = tmp_path / 'sync-server-linux-amd64'
+    binary.write_bytes(b'x')
+    runner, uploads = _patch(monkeypatch)
+    assert mss.cmd_deploy(_deploy_args(binary, force=True)) == 0
+    assert any(k.startswith('sync-server/') for _p, k, _e in uploads)
+
+
+def test_deploy_happy(monkeypatch, tmp_path):
+    import hashlib
+    monkeypatch.setenv('BVL_VM_STATE_FILE', str(tmp_path / 'absent.json'))
+    binary = tmp_path / 'sync-server-linux-amd64'
+    binary.write_bytes(b'binarydata')
+    runner, uploads = _patch(monkeypatch)
+    assert mss.cmd_deploy(_deploy_args(binary)) == 0
+    # the binary is staged under a content-addressed key (its sha256) ...
+    digest = hashlib.sha256(b'binarydata').hexdigest()
+    assert any(k == f'sync-server/{digest}' for _p, k, _e in uploads)
+    # ... and the remote shell pulls exactly that key, installs it 0755, and
+    # restarts the service.
+    cmds = '\n'.join(runner.last_commands())
+    assert f'sync-server/{digest}' in cmds
+    assert 'install -m 0755' in cmds and '/usr/local/bin/sync-server' in cmds
+    assert 'systemctl restart sync-server' in cmds
+
+
+# --------------------------------------------------------------------------
+# systemctl wrappers / status / logs / health
+# --------------------------------------------------------------------------
+
+def _args(action, **kw):
+    return argparse.Namespace(action=action, region=None, **kw)
+
+
+@pytest.mark.parametrize('action,fn', [
+    ('start', mss.cmd_start), ('stop', mss.cmd_stop),
+    ('restart', mss.cmd_restart)])
+def test_systemctl_wrappers(monkeypatch, action, fn):
+    runner, _ = _patch(monkeypatch)
+    assert fn(_args(action)) == 0
+    assert runner.last_commands() == [f'systemctl {action} sync-server']
+    # the SSM agent must be confirmed Online before the command is sent,
+    # else SendCommand fails with InvalidInstanceId.
+    assert _patch.waited == ['i-1']
+
+
+def test_cmd_status(monkeypatch):
+    runner, _ = _patch(monkeypatch)
+    assert mss.cmd_status(_args('status')) == 0
+    assert any('is-active' in c for c in runner.last_commands())
+
+
+def test_cmd_logs_default(monkeypatch):
+    runner, _ = _patch(monkeypatch)
+    assert mss.cmd_logs(_args('logs', lines=50, since=None)) == 0
+    assert '-n 50' in runner.last_commands()[0]
+    assert '--since' not in runner.last_commands()[0]
+
+
+def test_cmd_logs_since(monkeypatch):
+    runner, _ = _patch(monkeypatch)
+    assert mss.cmd_logs(_args('logs', lines=10, since='1 hour ago')) == 0
+    assert '--since' in runner.last_commands()[0]
+
+
+def test_cmd_health(monkeypatch):
+    runner, _ = _patch(monkeypatch)
+    assert mss.cmd_health(_args('health')) == 0
+    cmds = '\n'.join(runner.last_commands())
+    # all three probes present, each able to fail the script (exit 1) so a
+    # non-zero ResponseCode surfaces as a tool failure.
+    assert 'is-active --quiet sync-server' in cmds
+    assert '/dev/tcp/127.0.0.1/50443' in cmds
+    assert 'df --output=pcent' in cmds
+    assert cmds.count('exit 1') == 3
+    assert '-lt 90' in cmds  # disk threshold
+
+
+# --------------------------------------------------------------------------
+# main dispatch + error + parser
+# --------------------------------------------------------------------------
+
+def test_main_dispatch_start(monkeypatch):
+    _patch(monkeypatch)
+    assert mss.main(['start']) == 0
+
+
+def test_main_error_returns_1(monkeypatch, capsys):
+    ec2 = Rec(returns={'describe_instances': {'Reservations': []}})
+    _patch(monkeypatch, ec2=ec2)
+    assert mss.main(['status']) == 1
+    assert 'error:' in capsys.readouterr().err
+
+
+def test_parser_deploy_requires_binary():
+    with pytest.raises(SystemExit):
+        mss._build_parser().parse_args(['deploy'])

--- a/browser-visit-tools/tests/test_manage_vm.py
+++ b/browser-visit-tools/tests/test_manage_vm.py
@@ -1,0 +1,346 @@
+"""Unit tests for manage_vm.py.
+
+boto3 is faked (injected via test_bvl_aws's import side effect isn't
+guaranteed ordering-wise, so we inject here too) and every AWS client is
+a recording fake.  The single seam is _bvl_aws.client, monkeypatched to
+hand back per-service fakes.
+"""
+import argparse
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_fake_boto3 = types.ModuleType('boto3')
+_fake_boto3.client = lambda service, region_name=None: None
+sys.modules.setdefault('boto3', _fake_boto3)
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import manage_vm as mv  # noqa: E402
+
+
+class FakeError(Exception):
+    def __init__(self, code):
+        super().__init__(code)
+        self.response = {'Error': {'Code': code}}
+
+
+class Rec:
+    """Records every method call; returns canned values and/or raises
+    per-method on demand."""
+    def __init__(self, returns=None, raises=None):
+        self.calls = []
+        self._returns = returns or {}
+        self._raises = raises or {}
+
+    def __getattr__(self, name):
+        def method(**kw):
+            self.calls.append((name, kw))
+            if name in self._raises:
+                raise self._raises[name]
+            return self._returns.get(name)
+        return method
+
+    def names(self):
+        return [c[0] for c in self.calls]
+
+
+def _patch_clients(monkeypatch, **services):
+    monkeypatch.setattr(mv.aws, 'client',
+                        lambda service, region=None: services[service])
+
+
+def _reservations(*instances):
+    return {'Reservations': [{'Instances': [i]} for i in instances]}
+
+
+def _inst(iid='i-1', state='running', **extra):
+    return {'InstanceId': iid, 'State': {'Name': state}, **extra}
+
+
+# --------------------------------------------------------------------------
+# _resolve_ami / _ensure_security_group / _ensure_iam (helpers)
+# --------------------------------------------------------------------------
+
+def test_resolve_ami():
+    ssm = Rec(returns={'get_parameter': {'Parameter': {'Value': 'ami-9'}}})
+    assert mv._resolve_ami(ssm, 'arm64') == 'ami-9'
+    assert 'arm64' in ssm.calls[0][1]['Name']
+
+
+def test_ensure_sg_existing():
+    ec2 = Rec(returns={'describe_security_groups':
+                       {'SecurityGroups': [{'GroupId': 'sg-x'}]}})
+    assert mv._ensure_security_group(ec2, ['1.2.3.4/32']) == 'sg-x'
+    assert 'create_security_group' not in ec2.names()
+
+
+def test_ensure_sg_create():
+    ec2 = Rec(returns={'describe_security_groups': {'SecurityGroups': []},
+                       'create_security_group': {'GroupId': 'sg-new'}})
+    assert mv._ensure_security_group(ec2, ['1.2.3.4/32']) == 'sg-new'
+    # ingress must open exactly the gRPC port for the given CIDR — and
+    # nothing for SSH (22).
+    perm = [c for c in ec2.calls
+            if c[0] == 'authorize_security_group_ingress'][0][1]
+    rule = perm['IpPermissions'][0]
+    assert rule['FromPort'] == 50443 and rule['ToPort'] == 50443
+    assert rule['IpProtocol'] == 'tcp'
+    assert rule['IpRanges'][0]['CidrIp'] == '1.2.3.4/32'
+
+
+def test_ensure_sg_authorizes_every_cidr():
+    ec2 = Rec(returns={'describe_security_groups': {'SecurityGroups': []},
+                       'create_security_group': {'GroupId': 'sg-new'}})
+    mv._ensure_security_group(ec2, ['1.1.1.1/32', '2.2.2.2/32'])
+    cidrs = [c[1]['IpPermissions'][0]['IpRanges'][0]['CidrIp']
+             for c in ec2.calls if c[0] == 'authorize_security_group_ingress']
+    assert cidrs == ['1.1.1.1/32', '2.2.2.2/32']
+
+
+def test_ensure_sg_duplicate_ingress_ignored():
+    ec2 = Rec(returns={'describe_security_groups':
+                       {'SecurityGroups': [{'GroupId': 'sg-x'}]}},
+              raises={'authorize_security_group_ingress':
+                      FakeError('InvalidPermission.Duplicate')})
+    assert mv._ensure_security_group(ec2, ['1.2.3.4/32']) == 'sg-x'
+
+
+def test_ensure_sg_ingress_other_error_reraises():
+    ec2 = Rec(returns={'describe_security_groups':
+                       {'SecurityGroups': [{'GroupId': 'sg-x'}]}},
+              raises={'authorize_security_group_ingress':
+                      FakeError('RulesPerGroupLimitExceeded')})
+    with pytest.raises(FakeError):
+        mv._ensure_security_group(ec2, ['1.2.3.4/32'])
+
+
+def test_ensure_iam_all_exist():
+    iam = Rec()
+    assert mv._ensure_iam(iam, '123', 'us-east-1') == mv.aws.PROFILE_NAME
+    assert 'create_role' not in iam.names()
+    assert 'create_instance_profile' not in iam.names()
+
+
+def test_ensure_iam_creates_role_and_profile():
+    iam = Rec(raises={'get_role': FakeError('NoSuchEntity'),
+                      'get_instance_profile': FakeError('NoSuchEntity')})
+    mv._ensure_iam(iam, '123456789012', 'us-east-1')
+    calls = {c[0]: c[1] for c in iam.calls}
+    assert 'create_role' in calls and 'create_instance_profile' in calls
+    # the SSM-core managed policy is what makes the VM reachable over SSM
+    assert calls['attach_role_policy']['PolicyArn'].endswith(
+        'AmazonSSMManagedInstanceCore')
+    # the role is bound to the profile that RunInstances will pass
+    assert calls['add_role_to_instance_profile']['RoleName'] == mv.aws.ROLE_NAME
+    # inline policy lets the VM read its own deploy bucket
+    inline = calls['put_role_policy']['PolicyDocument']
+    assert 'bvl-sync-deploy-123456789012-us-east-1' in inline
+    assert 's3:GetObject' in inline
+
+
+def test_ensure_iam_get_role_other_error():
+    iam = Rec(raises={'get_role': FakeError('AccessDenied')})
+    with pytest.raises(FakeError):
+        mv._ensure_iam(iam, '123', 'us-east-1')
+
+
+def test_ensure_iam_get_profile_other_error():
+    iam = Rec(raises={'get_instance_profile': FakeError('Throttling')})
+    with pytest.raises(FakeError):
+        mv._ensure_iam(iam, '123', 'us-east-1')
+
+
+def test_ensure_iam_add_role_limit_exceeded_ignored():
+    iam = Rec(raises={'add_role_to_instance_profile':
+                      FakeError('LimitExceeded')})
+    assert mv._ensure_iam(iam, '123', 'us-east-1') == mv.aws.PROFILE_NAME
+
+
+def test_ensure_iam_add_role_other_error():
+    iam = Rec(raises={'add_role_to_instance_profile': FakeError('Boom')})
+    with pytest.raises(FakeError):
+        mv._ensure_iam(iam, '123', 'us-east-1')
+
+
+# --------------------------------------------------------------------------
+# cmd_create
+# --------------------------------------------------------------------------
+
+def _create_args(**kw):
+    base = dict(region='us-east-1', allow_cidr=['1.2.3.4/32'],
+                instance_type=None, volume_size=20, arch='x86_64', ami=None)
+    base.update(kw)
+    return argparse.Namespace(action='create', **base)
+
+
+def test_create_ambiguous_existing(monkeypatch, capsys):
+    ec2 = Rec(returns={'describe_instances': _reservations(_inst('i-1'),
+                                                           _inst('i-2'))})
+    _patch_clients(monkeypatch, ec2=ec2)
+    assert mv.cmd_create(_create_args()) == 1
+    assert 'multiple tagged instances' in capsys.readouterr().err
+
+
+def test_create_already_exists(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv('BVL_VM_STATE_FILE', str(tmp_path / 'vm.json'))
+    ec2 = Rec(returns={'describe_instances': _reservations(_inst('i-1'))})
+    _patch_clients(monkeypatch, ec2=ec2)
+    assert mv.cmd_create(_create_args()) == 0
+    assert 'already exists' in capsys.readouterr().out
+    assert mv.aws.load_state()['instance_id'] == 'i-1'
+
+
+def test_create_launches(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv('BVL_VM_STATE_FILE', str(tmp_path / 'vm.json'))
+    ec2 = Rec(returns={
+        'describe_instances': {'Reservations': []},
+        'describe_security_groups': {'SecurityGroups': []},
+        'create_security_group': {'GroupId': 'sg-new'},
+        'run_instances': {'Instances': [{'InstanceId': 'i-new'}]},
+    })
+    sts = Rec(returns={'get_caller_identity': {'Account': '123456789012'}})
+    iam = Rec()
+    ssm = Rec(returns={'get_parameter': {'Parameter': {'Value': 'ami-1'}}})
+    _patch_clients(monkeypatch, ec2=ec2, sts=sts, iam=iam, ssm=ssm)
+    assert mv.cmd_create(_create_args()) == 0
+    state = mv.aws.load_state()
+    assert state['instance_id'] == 'i-new'
+    # state captures enough to manage the VM later without re-discovery
+    assert state['security_group_id'] == 'sg-new'
+    assert state['iam_instance_profile'] == mv.aws.PROFILE_NAME
+    assert state['arch'] == 'x86_64'
+    run_kw = [c for c in ec2.calls if c[0] == 'run_instances'][0][1]
+    # default instance type for x86_64, the resolved AMI, the SG + profile,
+    # a gp3 root volume, and the discovery tags must all be wired up.
+    assert run_kw['InstanceType'] == 't3.small'
+    assert run_kw['ImageId'] == 'ami-1'
+    assert run_kw['SecurityGroupIds'] == ['sg-new']
+    assert run_kw['IamInstanceProfile'] == {'Name': mv.aws.PROFILE_NAME}
+    ebs = run_kw['BlockDeviceMappings'][0]['Ebs']
+    assert ebs['VolumeType'] == 'gp3' and ebs['VolumeSize'] == 20
+    tags = run_kw['TagSpecifications'][0]['Tags']
+    assert {'Key': 'bvl:role', 'Value': 'sync-server'} in tags
+    # deterministic ClientToken guards against a double-launch on retry
+    assert run_kw['ClientToken'] == 'bvl-sync-server-us-east-1'
+    assert 'created i-new' in capsys.readouterr().out
+
+
+def test_create_with_ami_and_type_override(monkeypatch, tmp_path):
+    monkeypatch.setenv('BVL_VM_STATE_FILE', str(tmp_path / 'vm.json'))
+    ec2 = Rec(returns={
+        'describe_instances': {'Reservations': []},
+        'describe_security_groups': {'SecurityGroups': [{'GroupId': 'sg-1'}]},
+        'run_instances': {'Instances': [{'InstanceId': 'i-z'}]},
+    })
+    sts = Rec(returns={'get_caller_identity': {'Account': '1'}})
+    iam = Rec()
+    ssm = Rec()  # get_parameter must NOT be called (ami provided)
+    _patch_clients(monkeypatch, ec2=ec2, sts=sts, iam=iam, ssm=ssm)
+    args = _create_args(ami='ami-custom', instance_type='c7g.large',
+                        arch='arm64')
+    assert mv.cmd_create(args) == 0
+    assert 'get_parameter' not in ssm.names()
+    run_kw = [c for c in ec2.calls if c[0] == 'run_instances'][0][1]
+    assert run_kw['InstanceType'] == 'c7g.large'
+    assert run_kw['ImageId'] == 'ami-custom'
+
+
+# --------------------------------------------------------------------------
+# lifecycle subcommands
+# --------------------------------------------------------------------------
+
+def _lifecycle_args(action, **kw):
+    return argparse.Namespace(action=action, region=None, **kw)
+
+
+def test_cmd_start(monkeypatch, capsys):
+    ec2 = Rec(returns={'describe_instances': _reservations(_inst('i-1'))})
+    _patch_clients(monkeypatch, ec2=ec2)
+    assert mv.cmd_start(_lifecycle_args('start')) == 0
+    assert 'start_instances' in ec2.names()
+    assert 'starting i-1' in capsys.readouterr().out
+
+
+def test_cmd_stop(monkeypatch):
+    ec2 = Rec(returns={'describe_instances': _reservations(_inst('i-1'))})
+    _patch_clients(monkeypatch, ec2=ec2)
+    assert mv.cmd_stop(_lifecycle_args('stop')) == 0
+    assert 'stop_instances' in ec2.names()
+
+
+def test_cmd_reboot(monkeypatch):
+    ec2 = Rec(returns={'describe_instances': _reservations(_inst('i-1'))})
+    _patch_clients(monkeypatch, ec2=ec2)
+    assert mv.cmd_reboot(_lifecycle_args('reboot')) == 0
+    assert 'reboot_instances' in ec2.names()
+
+
+def test_cmd_status_with_public(monkeypatch, capsys):
+    inst = _inst('i-1', InstanceType='t3.small',
+                 PublicDnsName='ec2.example.com', PublicIpAddress='1.2.3.4')
+    ec2 = Rec(returns={'describe_instances': _reservations(inst)})
+    _patch_clients(monkeypatch, ec2=ec2)
+    assert mv.cmd_status(_lifecycle_args('status')) == 0
+    out = capsys.readouterr().out
+    assert 'ec2.example.com' in out and '1.2.3.4' in out
+
+
+def test_cmd_status_no_public(monkeypatch, capsys):
+    ec2 = Rec(returns={'describe_instances': _reservations(_inst('i-1'))})
+    _patch_clients(monkeypatch, ec2=ec2)
+    assert mv.cmd_status(_lifecycle_args('status')) == 0
+    assert '(none)' in capsys.readouterr().out
+
+
+def test_cmd_terminate_plain(monkeypatch, capsys):
+    ec2 = Rec(returns={'describe_instances': _reservations(_inst('i-1'))})
+    _patch_clients(monkeypatch, ec2=ec2)
+    args = _lifecycle_args('terminate', purge_infra=False)
+    assert mv.cmd_terminate(args) == 0
+    assert 'terminate_instances' in ec2.names()
+    assert 'terminating i-1' in capsys.readouterr().out
+
+
+def test_cmd_terminate_with_purge(monkeypatch):
+    ec2 = Rec(returns={'describe_instances': _reservations(_inst('i-1'))})
+    iam = Rec()
+    _patch_clients(monkeypatch, ec2=ec2, iam=iam)
+    args = _lifecycle_args('terminate', purge_infra=True)
+    assert mv.cmd_terminate(args) == 0
+    assert 'delete_security_group' in ec2.names()
+    assert 'delete_role' in iam.names()
+
+
+def test_purge_infra_warns_on_failure(monkeypatch, capsys):
+    ec2 = Rec(raises={'delete_security_group': FakeError('DependencyViolation')})
+    iam = Rec(raises={'remove_role_from_instance_profile':
+                      FakeError('NoSuchEntity')})
+    mv._purge_infra(ec2, iam)
+    err = capsys.readouterr().err
+    assert 'could not delete security group' in err
+    assert 'could not fully delete IAM' in err
+
+
+# --------------------------------------------------------------------------
+# main dispatch + error surfacing + parser
+# --------------------------------------------------------------------------
+
+def test_main_runtime_error_returns_1(monkeypatch, capsys):
+    ec2 = Rec(returns={'describe_instances': {'Reservations': []}})
+    _patch_clients(monkeypatch, ec2=ec2)
+    assert mv.main(['status']) == 1
+    assert 'error:' in capsys.readouterr().err
+
+
+def test_main_dispatch_create(monkeypatch, tmp_path):
+    monkeypatch.setenv('BVL_VM_STATE_FILE', str(tmp_path / 'vm.json'))
+    ec2 = Rec(returns={'describe_instances': _reservations(_inst('i-1'))})
+    _patch_clients(monkeypatch, ec2=ec2)
+    assert mv.main(['create', '--allow-cidr', '1.2.3.4/32']) == 0
+
+
+def test_parser_requires_allow_cidr():
+    with pytest.raises(SystemExit):
+        mv._build_parser().parse_args(['create'])


### PR DESCRIPTION
## Summary

Adds idempotent creation and remote management of the EC2 VM that hosts the browser-visit sync-server. Previously the VM was assumed to exist (the systemd unit and README's "Run on EC2" section reference it) but there was no automation — this makes spin-up/update/operation a repeatable command.

Two new `boto3` CLI tools in `browser-visit-tools/`, following the repo's argparse + `main(argv)` + faked-I/O-test conventions:

- **`manage_vm.py`** — VM lifecycle: `create` (idempotent), `start`, `stop`, `reboot`, `status`, `terminate`. `create` keys on the `bvl:role=sync-server` / `bvl:managed-by` tags (looks before launching), and find-or-creates the security group (gRPC `50443` ingress only — **no SSH**) and an IAM instance profile with `AmazonSSMManagedInstanceCore`. AMI resolved from the AL2023 SSM public parameter.
- **`manage_sync_server.py`** — `provision`, `deploy`, `start`/`stop`/`restart`, `status`, `logs`, `health`, entirely over **AWS SSM** (no SSH, no open port 22). The ~20 MB binary + systemd unit + TLS material stage through a private per-account S3 bucket (SSE on TLS objects, 7-day expiry) that the VM pulls via its instance profile, since SSM's command-param cap can't carry the binary inline.
- **`_bvl_aws.py`** — shared boto3/SSM/S3 helpers behind a single `client()` seam.

## Supporting changes

- `browser-visit-sync-server/Makefile`: `build-linux` cross-compile target (`CGO_ENABLED=0`, `GOARCH` selectable) — pure-Go SQLite means no cgo.
- `browser-visit-tools/` Makefile + conftest: coverage for the new modules, `BVL_VM_STATE_FILE` sandboxed.
- Docs across all three READMEs: tool reference + IAM prerequisites (notably `iam:PassRole`), Run-on-EC2 pointer, top-level architecture note.

## Testing

`boto3` is faked in every test (all AWS calls route through `_bvl_aws.client`), so it stays out of `requirements-test.txt`. Tests assert behavior, not just coverage — port `50443` (not SSH), IAM profile/tags/gp3 on launch, SSE on TLS, `chmod 600` on the key, content-addressed deploy key, SSM-online-before-command ordering, health-probe failure semantics.

**167 tests, 100% line coverage** across `_bvl_aws.py`, `manage_vm.py`, `manage_sync_server.py`.

> [!NOTE]
> The full `make build-linux` compile needs the proto toolchain (`protoc-gen-go`) documented as one-time setup in the sync-server README — not installed in the dev environment here, so the target was verified via dry-run rather than a real build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)