### PR TITLE
Add from-scratch multi-laptop setup runbook (+ VM-creation fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,12 @@
 __pycache__/
 browser-visit-mcp/.venv/
 browser-visit-mcp/*.egg-info/
+
+# macOS
+.DS_Store
+
+# TLS / key material — never commit, wherever it lands in the tree
+*.pem
+*.key
+*.crt
+*.srl

--- a/README.md
+++ b/README.md
@@ -62,11 +62,15 @@ The Go gRPC service that runs on the EC2 Linux VM.  Three RPCs:
   transactionally-consistent SQLite snapshot back to the caller.
   Feeds `browser-visit-tools/db_diff.py`.
 
-Authentication is mTLS.  Each laptop has its own client cert; the
-server pins the cert SHA-256 to a `machine_id` via the
-`enrolled_machines.db` SQLite file (managed by
-`browser-visit-tools/enroll_machine.py`).  Identity spoofing is
-caught by a `CrossCheck(ctx, claimedID)` call on every RPC.
+Authentication is mTLS.  Each laptop has its own client cert.  The
+server's allowlist is `enrolled_machines.db`, a SQLite file on the VM
+that maps each laptop's `machine_id` to its client-cert SHA-256.  You
+populate it with the admin tool `browser-visit-tools/enroll_machine.py`
+(enroll / revoke / list); the server only reads it, at handshake time,
+rejecting any cert whose fingerprint isn't enrolled.  Identity spoofing
+— a laptop presenting a valid enrolled cert but claiming a different
+`machine_id` — is caught by a `CrossCheck(ctx, claimedID)` call on every
+RPC.
 
 Includes a full Docker Compose integration suite under
 [`browser-visit-sync-server/test/`](browser-visit-sync-server/test/);

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ The setup can run in either of two modes:
   Each laptop's local DB converges to the union of all laptops'
   activity within ~1 minute of any interaction.
 
+**Setting it up from scratch?** Single-laptop mode is just
+`browser-visit-logger/install.sh`.  For the full multi-laptop stack —
+create the EC2 VM, run the sync-server on it, and enrol/install one or
+more laptops — follow the end-to-end runbook in
+[`docs/MULTI_LAPTOP_SETUP.md`](docs/MULTI_LAPTOP_SETUP.md).
+
 ## [`browser-visit-logger/`](browser-visit-logger/)
 
 The Chrome extension and macOS native-messaging host that records
@@ -155,7 +161,7 @@ never modified.
 |---|---|---|---|
 | `browser-visit-logger` (Python) | `make test-py` | python3 | 225 tests, 100% (gated) |
 | `browser-visit-logger` (JS) | `make test-js` | node/npm | 131 tests, 100% |
-| `browser-visit-tools` | `make test` | python3 | 167 tests, 100% (gated) |
+| `browser-visit-tools` | `make test` | python3 | 168 tests, 100% (gated) |
 | `browser-visit-sync-server` (Go unit) | `make cover` | go 1.22+, protoc | 94–100% per package¹ |
 | `browser-visit-sync-server` (integration) | `make test-integration` | Docker | 7 end-to-end tests |
 | `browser-visit-mcp` | `pytest` | python3 | see its README |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ EC2-hosted gRPC service.
 The setup can run in either of two modes:
 
 - **Single-laptop** — extension → local DB + per-day TSV logs +
-  iCloud-synced snapshot archive.  No network.  Original design.
+  a snapshot archive under `~/Documents` (iCloud-synced).  No network.
+  Original design.
 - **Multi-laptop** — every laptop still writes locally as above, plus
   pushes its log records to (and pulls peer records from) a gRPC
   service running on a Linux VM.  The VM holds the canonical merged
@@ -21,6 +22,15 @@ The setup can run in either of two modes:
 create the EC2 VM, run the sync-server on it, and enrol/install one or
 more laptops — follow the end-to-end runbook in
 [`docs/MULTI_LAPTOP_SETUP.md`](docs/MULTI_LAPTOP_SETUP.md).
+
+**Converting an existing single-laptop install?** The two modes use
+different snapshot stores (iCloud Documents vs. Google Drive), so a
+laptop that already ran single-laptop mode has historical snapshots in
+iCloud that won't be visible to the shared Google Drive archive.  Run
+the one-time migration once per such laptop —
+[`browser-visit-tools/migrate_icloud_to_gdrive.py`](browser-visit-tools/migrate_icloud_to_gdrive.py)
+copies the archive to Google Drive (SHA-256 verified) and rewrites the
+DB paths; it's idempotent and leaves the iCloud copy in place.
 
 ## [`browser-visit-logger/`](browser-visit-logger/)
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ never modified.
 | `browser-visit-logger` (JS) | `make test-js` | node/npm | 131 tests, 100% |
 | `browser-visit-tools` | `make test` | python3 | 168 tests, 100% (gated) |
 | `browser-visit-sync-server` (Go unit) | `make cover` | go 1.22+, protoc | 94–100% per package¹ |
-| `browser-visit-sync-server` (integration) | `make test-integration` | Docker | 7 end-to-end tests |
+| `browser-visit-sync-server` (integration) | `make test-integration` | Docker | 8 end-to-end tests |
 | `browser-visit-mcp` | `pytest` | python3 | see its README |
 
 ¹ Go residuals are `main()` (a process entrypoint) plus unreachable

--- a/browser-visit-sync-server/README.md
+++ b/browser-visit-sync-server/README.md
@@ -189,8 +189,8 @@ caught it).
 ## Enrolling a new laptop
 
 First mint that laptop's client cert against the existing CA — without
-re-issuing anything — with `test/gen-certs.sh --add-client <machine-id>`
-(see the [setup runbook](../docs/MULTI_LAPTOP_SETUP.md#adding-a-laptop-later-incremental-no-downtime)).
+re-issuing anything — with `browser-visit-tools/gen-prod-certs --add-client
+<machine-id>` (see the [setup runbook](../docs/MULTI_LAPTOP_SETUP.md#adding-a-laptop-later-incremental-no-downtime)).
 Then record it on the VM (or wherever you have the `enrolled_machines.db`
 file the server is configured to read):
 

--- a/browser-visit-sync-server/README.md
+++ b/browser-visit-sync-server/README.md
@@ -188,8 +188,11 @@ caught it).
 
 ## Enrolling a new laptop
 
-On the VM (or wherever you have the `enrolled_machines.db` file the
-server is configured to read):
+First mint that laptop's client cert against the existing CA — without
+re-issuing anything — with `test/gen-certs.sh --add-client <machine-id>`
+(see the [setup runbook](../docs/MULTI_LAPTOP_SETUP.md#adding-a-laptop-later-incremental-no-downtime)).
+Then record it on the VM (or wherever you have the `enrolled_machines.db`
+file the server is configured to read):
 
 ```
 python3 ../browser-visit-tools/enroll_machine.py \

--- a/browser-visit-sync-server/README.md
+++ b/browser-visit-sync-server/README.md
@@ -216,7 +216,7 @@ python3 ../browser-visit-tools/enroll_machine.py --db ... --machine-id X --revok
 ## Integration tests
 
 Full Docker Compose suite under [`test/`](test/) — minted certs,
-seeded enrolled DB, pytest driver, 7 end-to-end scenarios.  See
+seeded enrolled DB, pytest driver, 8 end-to-end scenarios.  See
 [`test/README.md`](test/README.md) for the workflow.  Short version:
 
 ```

--- a/browser-visit-sync-server/internal/auth/auth_test.go
+++ b/browser-visit-sync-server/internal/auth/auth_test.go
@@ -107,6 +107,32 @@ func TestLookupQueryError(t *testing.T) {
 	}
 }
 
+// TestLookupAfterRevoke documents the live-revocation semantics: Lookup
+// re-queries the DB on every call (no caching), so deleting an enrolled
+// row through the same handle takes effect on the next lookup without
+// reopening the DB or restarting the server.
+func TestLookupAfterRevoke(t *testing.T) {
+	e := openTestEnrolled(t)
+	cert := mintCert(t, "laptop-a")
+	fp := fingerprint(cert)
+	if _, err := e.db.Exec(
+		"INSERT INTO enrolled_machines (machine_id, cert_sha256, enrolled_at) VALUES (?,?,?)",
+		"laptop-a", fp, "now"); err != nil {
+		t.Fatal(err)
+	}
+	if id, err := e.Lookup(fp); err != nil || id != "laptop-a" {
+		t.Fatalf("pre-revoke Lookup: id=%q err=%v", id, err)
+	}
+	// Revoke == delete the row (what enroll_machine.py --revoke does).
+	if _, err := e.db.Exec(
+		"DELETE FROM enrolled_machines WHERE cert_sha256 = ?", fp); err != nil {
+		t.Fatal(err)
+	}
+	if id, err := e.Lookup(fp); err != nil || id != "" {
+		t.Fatalf("post-revoke Lookup should miss: id=%q err=%v", id, err)
+	}
+}
+
 func TestResolveIDNoPeer(t *testing.T) {
 	e := openTestEnrolled(t)
 	_, err := resolveID(context.Background(), e)

--- a/browser-visit-sync-server/test/conftest.py
+++ b/browser-visit-sync-server/test/conftest.py
@@ -75,7 +75,7 @@ def certs_dir():
             pytest.fail(f"BVL_TEST_USE_EXISTING=1 but {CERTS} doesn't exist")
         return CERTS
     subprocess.check_call(
-        ['bash', str(HERE / 'gen-certs.sh'), *MACHINES, ROGUE])
+        ['bash', str(HERE / 'gen-certs.sh'), '--force', *MACHINES, ROGUE])
     return CERTS
 
 

--- a/browser-visit-sync-server/test/gen-certs.sh
+++ b/browser-visit-sync-server/test/gen-certs.sh
@@ -3,11 +3,13 @@
 # machine ID supplied on the command line, into ./certs/.
 #
 # Used by the integration-test harness to set up mTLS without any
-# external infrastructure.  Re-runs are destructive (the certs/ dir is
-# wiped) so the test starts from a known state every time.
+# external infrastructure.  A normal (non --add-client) run is
+# destructive — the certs/ dir is wiped and a fresh CA is minted — so
+# the test starts from a known state every time.
 #
 # Usage:
-#   ./gen-certs.sh [--server-host HOST]... <machine-id>...
+#   ./gen-certs.sh [--server-host HOST]... <machine-id>...   # full run
+#   ./gen-certs.sh --add-client <machine-id>...              # incremental
 #
 #   --server-host HOST   Add a real DNS name or IP to the server cert's
 #                        SAN so the cert is valid for a VM reachable at
@@ -16,10 +18,20 @@
 #                        Omit it for the integration tests — without it the
 #                        server cert is the original localhost-only cert.
 #
+#   --add-client ID      INCREMENTAL, NON-DESTRUCTIVE.  Sign one more
+#                        client cert with the EXISTING certs/ca.{crt,key}
+#                        without wiping certs/ or touching the CA / server
+#                        cert.  Repeatable.  This is how you add a laptop
+#                        later (e.g. a new machine) without re-issuing
+#                        everything.  Requires certs/ca.crt + certs/ca.key
+#                        from the original run.  Cannot be combined with
+#                        --server-host or positional machine-ids.
+#
 # Examples:
 #   ./gen-certs.sh laptop-a laptop-b laptop-c rogue-client      # test harness
 #   ./gen-certs.sh --server-host bvl-vm.example.com my-mbp      # production
 #   ./gen-certs.sh --server-host 203.0.113.7 my-mbp other-mbp   # by IP
+#   ./gen-certs.sh --add-client my-new-mbp                      # add a laptop
 #
 # Output:
 #   certs/ca.crt              CA cert (use as both server-CA and client-CA)
@@ -31,13 +43,15 @@
 #   certs/<id>.crt            Client cert (CN=<id>)
 #   certs/<id>.key            Client private key
 #   certs/<id>.sha256         SHA-256 of DER-encoded client cert
-#   certs/fingerprints.tsv    machine_id<TAB>cert_sha256
+#   certs/fingerprints.tsv    machine_id<TAB>cert_sha256 (appended in
+#                             --add-client mode, rewritten otherwise)
 set -euo pipefail
 
-# Parse leading --server-host flags; the rest are positional machine IDs.
-# (The test harness calls this with machine IDs only, so the default
-# output is unchanged when no flag is given.)
+# Parse leading flags; the rest are positional machine IDs.  (The test
+# harness calls this with machine IDs only, so the default output is
+# unchanged when no flag is given.)
 SERVER_HOSTS=()
+ADD_CLIENTS=()
 while [ $# -gt 0 ]; do
     case "$1" in
         --server-host)
@@ -45,6 +59,11 @@ while [ $# -gt 0 ]; do
             SERVER_HOSTS+=("$2"); shift 2 ;;
         --server-host=*)
             SERVER_HOSTS+=("${1#*=}"); shift ;;
+        --add-client)
+            [ $# -ge 2 ] || { echo "error: --add-client needs a value" >&2; exit 2; }
+            ADD_CLIENTS+=("$2"); shift 2 ;;
+        --add-client=*)
+            ADD_CLIENTS+=("${1#*=}"); shift ;;
         --) shift; break ;;
         -*) echo "error: unknown flag: $1" >&2; exit 2 ;;
         *) break ;;
@@ -52,6 +71,58 @@ while [ $# -gt 0 ]; do
 done
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/certs"
+
+# Mint one client cert into the current directory (must hold ca.crt,
+# ca.key and client_ext.cnf).  Appends its fingerprint to fingerprints.tsv.
+# OpenSSL reuses ca.srl across calls, so -CAcreateserial is safe to repeat.
+mint_client() {
+    local id="$1" fp
+    openssl genrsa -out "${id}.key" 2048 2>/dev/null
+    openssl req -new -key "${id}.key" -subj "/CN=${id}" -out "${id}.csr"
+    openssl x509 -req -days 3650 -in "${id}.csr" -CA ca.crt -CAkey ca.key \
+      -CAcreateserial -extfile client_ext.cnf -extensions client_ext \
+      -out "${id}.crt" 2>/dev/null
+    rm "${id}.csr"
+    fp=$(openssl x509 -in "${id}.crt" -outform DER | openssl dgst -sha256 -hex | awk '{print $NF}')
+    echo "$fp" > "${id}.sha256"
+    printf '%s\t%s\n' "$id" "$fp" >> fingerprints.tsv
+    chmod 600 "${id}.key"
+}
+
+# OpenSSL 3.x rejects extfiles without a named section, so use a small
+# inline file with a [client_ext] block.
+CLIENT_EXT='[ client_ext ]
+extendedKeyUsage = clientAuth
+keyUsage = digitalSignature'
+
+# ----------------------------------------------------------------------
+# Incremental mode: add client cert(s) against the existing CA, leaving
+# certs/, the CA and the server cert untouched.
+# ----------------------------------------------------------------------
+if [ ${#ADD_CLIENTS[@]} -gt 0 ]; then
+    [ ${#SERVER_HOSTS[@]} -eq 0 ] || {
+        echo "error: --server-host is not valid with --add-client "\
+"(the server cert is not regenerated in incremental mode)" >&2; exit 2; }
+    [ $# -eq 0 ] || {
+        echo "error: positional machine-ids are not valid with --add-client" >&2
+        exit 2; }
+    [ -f "$DIR/ca.crt" ] && [ -f "$DIR/ca.key" ] || {
+        echo "error: --add-client needs an existing CA at $DIR/ca.{crt,key} "\
+"from the original run; none found" >&2; exit 2; }
+    cd "$DIR"
+    echo "$CLIENT_EXT" > client_ext.cnf
+    [ -f fingerprints.tsv ] || : > fingerprints.tsv
+    for id in "${ADD_CLIENTS[@]}"; do
+        mint_client "$id"
+        echo "added client cert ${id}.crt (signed by existing CA)"
+    done
+    rm client_ext.cnf
+    exit 0
+fi
+
+# ----------------------------------------------------------------------
+# Full run: wipe, mint a fresh CA + server cert + the listed clients.
+# ----------------------------------------------------------------------
 rm -rf "$DIR"
 mkdir -p "$DIR"
 cd "$DIR"
@@ -102,25 +173,10 @@ openssl x509 -req -days 3650 -in server.csr -CA ca.crt -CAkey ca.key \
 rm server.csr server.cnf
 
 # 3) Client certs
-# OpenSSL 3.x rejects extfiles without a named section, so use a small
-# inline file with a [client_ext] block.
-cat > client_ext.cnf <<'EOF'
-[ client_ext ]
-extendedKeyUsage = clientAuth
-keyUsage = digitalSignature
-EOF
-
+echo "$CLIENT_EXT" > client_ext.cnf
 : > fingerprints.tsv
 for id in "$@"; do
-    openssl genrsa -out "${id}.key" 2048 2>/dev/null
-    openssl req -new -key "${id}.key" -subj "/CN=${id}" -out "${id}.csr"
-    openssl x509 -req -days 3650 -in "${id}.csr" -CA ca.crt -CAkey ca.key \
-      -CAcreateserial -extfile client_ext.cnf -extensions client_ext \
-      -out "${id}.crt" 2>/dev/null
-    rm "${id}.csr"
-    fp=$(openssl x509 -in "${id}.crt" -outform DER | openssl dgst -sha256 -hex | awk '{print $NF}')
-    echo "$fp" > "${id}.sha256"
-    printf '%s\t%s\n' "$id" "$fp" >> fingerprints.tsv
+    mint_client "$id"
 done
 rm client_ext.cnf
 

--- a/browser-visit-sync-server/test/gen-certs.sh
+++ b/browser-visit-sync-server/test/gen-certs.sh
@@ -7,12 +7,26 @@
 # wiped) so the test starts from a known state every time.
 #
 # Usage:
-#   ./gen-certs.sh laptop-a laptop-b laptop-c rogue-client
+#   ./gen-certs.sh [--server-host HOST]... <machine-id>...
+#
+#   --server-host HOST   Add a real DNS name or IP to the server cert's
+#                        SAN so the cert is valid for a VM reachable at
+#                        that address.  Repeatable.  Auto-detected as an
+#                        IP (added as IP.n) or a DNS name (added as DNS.n).
+#                        Omit it for the integration tests — without it the
+#                        server cert is the original localhost-only cert.
+#
+# Examples:
+#   ./gen-certs.sh laptop-a laptop-b laptop-c rogue-client      # test harness
+#   ./gen-certs.sh --server-host bvl-vm.example.com my-mbp      # production
+#   ./gen-certs.sh --server-host 203.0.113.7 my-mbp other-mbp   # by IP
 #
 # Output:
 #   certs/ca.crt              CA cert (use as both server-CA and client-CA)
 #   certs/ca.key              CA private key
-#   certs/server.crt          Server cert (CN=localhost, SAN=localhost,127.0.0.1)
+#   certs/server.crt          Server cert (CN=localhost; SAN always
+#                             includes localhost/127.0.0.1 plus any
+#                             --server-host values)
 #   certs/server.key
 #   certs/<id>.crt            Client cert (CN=<id>)
 #   certs/<id>.key            Client private key
@@ -20,14 +34,45 @@
 #   certs/fingerprints.tsv    machine_id<TAB>cert_sha256
 set -euo pipefail
 
+# Parse leading --server-host flags; the rest are positional machine IDs.
+# (The test harness calls this with machine IDs only, so the default
+# output is unchanged when no flag is given.)
+SERVER_HOSTS=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --server-host)
+            [ $# -ge 2 ] || { echo "error: --server-host needs a value" >&2; exit 2; }
+            SERVER_HOSTS+=("$2"); shift 2 ;;
+        --server-host=*)
+            SERVER_HOSTS+=("${1#*=}"); shift ;;
+        --) shift; break ;;
+        -*) echo "error: unknown flag: $1" >&2; exit 2 ;;
+        *) break ;;
+    esac
+done
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/certs"
 rm -rf "$DIR"
 mkdir -p "$DIR"
 cd "$DIR"
 
+# Build the [ alt_names ] block: the localhost defaults the tests rely on,
+# plus one entry per --server-host (numbered after the defaults, IP vs DNS
+# detected from the value's shape).
+ALT_NAMES=$'DNS.1 = localhost\nDNS.2 = sync-server\nIP.1  = 127.0.0.1'
+dns_n=2
+ip_n=1
+for host in "${SERVER_HOSTS[@]:-}"; do
+    [ -n "$host" ] || continue
+    if [[ "$host" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        ip_n=$((ip_n + 1)); ALT_NAMES+=$'\n'"IP.${ip_n}  = ${host}"
+    else
+        dns_n=$((dns_n + 1)); ALT_NAMES+=$'\n'"DNS.${dns_n} = ${host}"
+    fi
+done
+
 # Minimal openssl config so SAN works without a config file.
-SAN_CNF=$(cat <<'EOF'
-[ req ]
+SAN_CNF="[ req ]
 default_bits       = 2048
 prompt             = no
 default_md         = sha256
@@ -42,11 +87,7 @@ subjectAltName = @alt_names
 extendedKeyUsage = serverAuth
 
 [ alt_names ]
-DNS.1 = localhost
-DNS.2 = sync-server
-IP.1  = 127.0.0.1
-EOF
-)
+${ALT_NAMES}"
 
 # 1) CA
 openssl genrsa -out ca.key 2048 2>/dev/null

--- a/browser-visit-sync-server/test/gen-certs.sh
+++ b/browser-visit-sync-server/test/gen-certs.sh
@@ -10,8 +10,15 @@
 # production CA; the harness passes --force for its known-state re-runs.
 #
 # Usage:
-#   ./gen-certs.sh [--server-host HOST]... <machine-id>...   # full run
-#   ./gen-certs.sh --add-client <machine-id>...              # incremental
+#   ./gen-certs.sh [--server-host HOST]... [--out-dir DIR] <machine-id>...
+#   ./gen-certs.sh --add-client [--out-dir DIR] <machine-id>...
+#
+#   --out-dir DIR        Where to read/write the cert hierarchy.  Defaults
+#                        to ./certs next to this script — which the test
+#                        harness WIPES on every run, so point production
+#                        material elsewhere (the `gen-prod-certs` wrapper
+#                        pins it to ~/.browser-visit-logger/ca).  A leading
+#                        ~/ is expanded; relative paths resolve against $PWD.
 #
 #   --server-host HOST   Add a real DNS name or IP to the server cert's
 #                        SAN so the cert is valid for a VM reachable at
@@ -38,21 +45,24 @@
 #
 # Examples:
 #   ./gen-certs.sh laptop-a laptop-b laptop-c rogue-client      # test harness
-#   ./gen-certs.sh --server-host bvl-vm.example.com my-mbp      # production
-#   ./gen-certs.sh --server-host 203.0.113.7 my-mbp other-mbp   # by IP
-#   ./gen-certs.sh --add-client my-new-mbp                      # add a laptop
+#   ./gen-certs.sh --out-dir ~/.browser-visit-logger/ca \
+#       --server-host bvl-vm.example.com my-mbp                # production
+#   ./gen-certs.sh --out-dir ~/.browser-visit-logger/ca --add-client my-new-mbp
 #
-# Output:
-#   certs/ca.crt              CA cert (use as both server-CA and client-CA)
-#   certs/ca.key              CA private key
-#   certs/server.crt          Server cert (CN=localhost; SAN always
+# (For production, prefer the `browser-visit-tools/gen-prod-certs` wrapper,
+# which pins --out-dir for you.)
+#
+# Output (under --out-dir, default ./certs):
+#   ca.crt                    CA cert (use as both server-CA and client-CA)
+#   ca.key                    CA private key
+#   server.crt                Server cert (CN=localhost; SAN always
 #                             includes localhost/127.0.0.1 plus any
 #                             --server-host values)
-#   certs/server.key
-#   certs/<id>.crt            Client cert (CN=<id>)
-#   certs/<id>.key            Client private key
-#   certs/<id>.sha256         SHA-256 of DER-encoded client cert
-#   certs/fingerprints.tsv    machine_id<TAB>cert_sha256 (appended in
+#   server.key
+#   <id>.crt                  Client cert (CN=<id>)
+#   <id>.key                  Client private key
+#   <id>.sha256               SHA-256 of DER-encoded client cert
+#   fingerprints.tsv          machine_id<TAB>cert_sha256 (appended in
 #                             --add-client mode, rewritten otherwise)
 set -euo pipefail
 
@@ -62,18 +72,29 @@ set -euo pipefail
 SERVER_HOSTS=()
 ADD_CLIENTS=()
 FORCE=0
+OUT_DIR=""
 while [ $# -gt 0 ]; do
+    # A value that looks like a flag almost always means the real value was
+    # forgotten (e.g. `--add-client --out-dir X`); fail clearly instead of
+    # swallowing the next flag as the value.
+    case "$1" in
+        --server-host|--add-client|--out-dir)
+            { [ $# -ge 2 ] && [ "${2#-}" = "$2" ]; } || {
+                echo "error: $1 needs a value (got '${2-}')" >&2; exit 2; } ;;
+    esac
     case "$1" in
         --server-host)
-            [ $# -ge 2 ] || { echo "error: --server-host needs a value" >&2; exit 2; }
             SERVER_HOSTS+=("$2"); shift 2 ;;
         --server-host=*)
             SERVER_HOSTS+=("${1#*=}"); shift ;;
         --add-client)
-            [ $# -ge 2 ] || { echo "error: --add-client needs a value" >&2; exit 2; }
             ADD_CLIENTS+=("$2"); shift 2 ;;
         --add-client=*)
             ADD_CLIENTS+=("${1#*=}"); shift ;;
+        --out-dir)
+            OUT_DIR="$2"; shift 2 ;;
+        --out-dir=*)
+            OUT_DIR="${1#*=}"; shift ;;
         --force) FORCE=1; shift ;;
         --) shift; break ;;
         -*) echo "error: unknown flag: $1" >&2; exit 2 ;;
@@ -81,7 +102,19 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/certs"
+# Resolve the cert directory: --out-dir if given (expand a leading ~/, make
+# relative paths absolute against $PWD), else ./certs next to this script.
+if [ -n "$OUT_DIR" ]; then
+    case "$OUT_DIR" in
+        "~/"*) OUT_DIR="$HOME/${OUT_DIR#"~/"}" ;;
+    esac
+    case "$OUT_DIR" in
+        /*) DIR="$OUT_DIR" ;;
+        *)  DIR="$PWD/$OUT_DIR" ;;
+    esac
+else
+    DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/certs"
+fi
 
 # Mint one client cert into the current directory (must hold ca.crt,
 # ca.key and client_ext.cnf).  Appends its fingerprint to fingerprints.tsv.

--- a/browser-visit-sync-server/test/gen-certs.sh
+++ b/browser-visit-sync-server/test/gen-certs.sh
@@ -4,8 +4,10 @@
 #
 # Used by the integration-test harness to set up mTLS without any
 # external infrastructure.  A normal (non --add-client) run is
-# destructive — the certs/ dir is wiped and a fresh CA is minted — so
-# the test starts from a known state every time.
+# destructive — the certs/ dir is wiped and a fresh CA is minted.  When a
+# CA already exists the script confirms first (or, non-interactively,
+# refuses) unless --force is given, so a stray re-run can't clobber a
+# production CA; the harness passes --force for its known-state re-runs.
 #
 # Usage:
 #   ./gen-certs.sh [--server-host HOST]... <machine-id>...   # full run
@@ -26,6 +28,13 @@
 #                        everything.  Requires certs/ca.crt + certs/ca.key
 #                        from the original run.  Cannot be combined with
 #                        --server-host or positional machine-ids.
+#
+#   --force              Skip the confirmation guard.  A full run wipes
+#                        certs/ and mints a NEW CA; when one already exists
+#                        the script asks before clobbering it (and refuses
+#                        outright when not attached to a terminal).  The
+#                        test harness passes --force for its known-state
+#                        re-runs.
 #
 # Examples:
 #   ./gen-certs.sh laptop-a laptop-b laptop-c rogue-client      # test harness
@@ -52,6 +61,7 @@ set -euo pipefail
 # unchanged when no flag is given.)
 SERVER_HOSTS=()
 ADD_CLIENTS=()
+FORCE=0
 while [ $# -gt 0 ]; do
     case "$1" in
         --server-host)
@@ -64,6 +74,7 @@ while [ $# -gt 0 ]; do
             ADD_CLIENTS+=("$2"); shift 2 ;;
         --add-client=*)
             ADD_CLIENTS+=("${1#*=}"); shift ;;
+        --force) FORCE=1; shift ;;
         --) shift; break ;;
         -*) echo "error: unknown flag: $1" >&2; exit 2 ;;
         *) break ;;
@@ -123,6 +134,31 @@ fi
 # ----------------------------------------------------------------------
 # Full run: wipe, mint a fresh CA + server cert + the listed clients.
 # ----------------------------------------------------------------------
+
+# Guard: a full run wipes certs/ and mints a NEW CA. If one already exists,
+# confirm first so a stray re-run can't nuke a production CA (which would
+# invalidate the server cert and every enrolled laptop). --force skips this;
+# to add a laptop, use --add-client instead.
+if [ "$FORCE" != 1 ] && [ -f "$DIR/ca.crt" ]; then
+    if [ -t 0 ]; then
+        echo "A CA already exists at $DIR/ca.crt." >&2
+        echo "A full run WIPES certs/ and mints a NEW CA, invalidating the" >&2
+        echo "server cert and every enrolled laptop. To add a laptop instead," >&2
+        echo "cancel and use:  $0 --add-client <machine-id>" >&2
+        printf 'Really wipe certs/ and re-create everything? [y/N] ' >&2
+        read -r reply
+        case "$reply" in
+            y|Y|yes|YES) ;;
+            *) echo "aborted (nothing changed)." >&2; exit 1 ;;
+        esac
+    else
+        echo "error: $DIR/ca.crt already exists; refusing to wipe a CA "\
+"non-interactively. Pass --force to overwrite, or --add-client <id> to add a "\
+"laptop without re-issuing." >&2
+        exit 1
+    fi
+fi
+
 rm -rf "$DIR"
 mkdir -p "$DIR"
 cd "$DIR"

--- a/browser-visit-sync-server/test/test_sync.py
+++ b/browser-visit-sync-server/test/test_sync.py
@@ -4,6 +4,8 @@ Scenarios:
 
   * Push + Pull round-trip: laptop-a pushes lines; laptop-b pulls
     and sees them; laptop-a does NOT get its own lines echoed back.
+  * Cursor resumption: after advancing the per-peer cursor, a second
+    pull returns only the lines strictly past it (not the whole log).
   * Cursor idempotency: replaying the same PushLogs is a no-op (no
     duplicate rows in the canonical DB, server reports same high
     water mark).
@@ -107,6 +109,42 @@ def test_push_pull_round_trip(channel_for, grpc_stubs):
     # laptop-a pulling: should NOT see its own records echoed.
     chunks_a = _pull_all(stub_a, sync_pb2, 'laptop-a')
     assert 'laptop-a' not in chunks_a
+
+
+def test_pull_resumes_from_cursor(channel_for, grpc_stubs):
+    """A second pull with an advanced cursor returns only the lines
+    strictly past it — proving cursor resumption, not a full re-stream."""
+    sync_pb2, sync_pb2_grpc = grpc_stubs
+    date = '2026-05-28'  # dedicated date so this peer's offsets start at 0
+    url = f"https://cursor.example/{uuid.uuid4()}"
+    stub_a = sync_pb2_grpc.BrowserVisitSyncStub(channel_for('laptop-a'))
+    stub_b = sync_pb2_grpc.BrowserVisitSyncStub(channel_for('laptop-b'))
+
+    # First batch at offsets 0..1, then a second batch at offsets 2..3.
+    _push(stub_a, sync_pb2, 'laptop-a', [
+        (0, _line('rid-cur-1', '2026-05-28T09:00:00Z', url, 'C')),
+        (1, _result_line('rid-cur-1')),
+    ], date=date)
+    _push(stub_a, sync_pb2, 'laptop-a', [
+        (2, _line('rid-cur-2', '2026-05-28T09:05:00Z', url, 'C',
+                  tag='read', filename='c.mhtml')),
+        (3, _result_line('rid-cur-2')),
+    ], date=date)
+
+    # Resume from offset 1 → only the new offsets 2 and 3 come back.
+    # (Filter to this test's date: a single per-peer cursor lets earlier
+    # dates through, which other tests' pushes would add noise from.)
+    chunks = _pull_all(stub_b, sync_pb2, 'laptop-b',
+                       cursors={'laptop-a': (date, 1)})
+    got = sorted(off for (d, off, _raw) in chunks.get('laptop-a', [])
+                 if d == date)
+    assert got == [2, 3], f"expected only new offsets [2, 3], got {got}"
+
+    # Resume from the tip → nothing past the cursor for this date.
+    chunks2 = _pull_all(stub_b, sync_pb2, 'laptop-b',
+                        cursors={'laptop-a': (date, 3)})
+    tail = [off for (d, off, _raw) in chunks2.get('laptop-a', []) if d == date]
+    assert tail == [], f"expected no lines past the tip, got {tail}"
 
 
 def test_push_idempotent_on_replay(channel_for, grpc_stubs):

--- a/browser-visit-tools/README.md
+++ b/browser-visit-tools/README.md
@@ -35,6 +35,7 @@ one-line wrapper note before delegating.
 | `./generate_reading_list` | `reading_list.py` | of_interest-but-unread → HTML or Markdown |
 | `db_diff.py` | (Python, no wrapper) | Diff two `browser-visits.db` files |
 | `fetch_vm_snapshot.py` | (Python, no wrapper) | Download a consistent VM DB snapshot via gRPC |
+| `gen-prod-certs` | `../browser-visit-sync-server/test/gen-certs.sh` | Mint production mTLS material into `~/.browser-visit-logger/ca/` |
 | `enroll_machine.py` | (Python, no wrapper) | VM-side admin: enroll a laptop's mTLS cert |
 | `migrate_icloud_to_gdrive.py` | (Python, no wrapper) | One-time iCloud → Google Drive snapshot migration |
 | `install_laptop.sh` | (Bash) | Laptop install for multi-laptop mode |
@@ -157,6 +158,25 @@ python3 fetch_vm_snapshot.py --server localhost:50051 \
     --machine-id laptop-a --insecure --out /tmp/vm.db \
     --client-cert /dev/null --client-key /dev/null --ca /dev/null
 ```
+
+### `gen-prod-certs`
+
+Thin wrapper over `browser-visit-sync-server/test/gen-certs.sh` that pins
+`--out-dir` to `~/.browser-visit-logger/ca/` (override with `BVL_CA_DIR`),
+so the production CA never lands in the throwaway `test/certs/` that
+`make test-integration` wipes.  All other flags pass straight through.
+
+```bash
+# First run: mint CA + server cert + one client cert per laptop
+./gen-prod-certs --server-host bvl-vm.example.com laptop-a laptop-b
+
+# Later: add one more laptop against the existing CA (non-destructive)
+./gen-prod-certs --add-client my-new-mbp
+```
+
+Keep the resulting `ca.key` safe — it's the root of trust and what you
+need to enrol more laptops later.  See the
+[setup runbook](../docs/MULTI_LAPTOP_SETUP.md#step-2--mint-tls-material).
 
 ### `enroll_machine.py`
 
@@ -403,6 +423,7 @@ browser-visit-tools/
 ├── generate_reading_list           # bash wrapper → reading_list.py
 ├── db_diff.py                      # diff two SQLite browser-visits DBs
 ├── fetch_vm_snapshot.py            # gRPC client → ExportDbSnapshot
+├── gen-prod-certs                  # wrap gen-certs.sh → ~/.browser-visit-logger/ca/
 ├── enroll_machine.py               # VM-side admin tool
 ├── migrate_icloud_to_gdrive.py     # one-time archive migration
 ├── install_laptop.sh               # multi-laptop laptop install

--- a/browser-visit-tools/README.md
+++ b/browser-visit-tools/README.md
@@ -285,7 +285,9 @@ python3 manage_vm.py terminate --purge-infra
 
 `create` flags: `--allow-cidr CIDR` (required, repeatable), `--region`,
 `--instance-type`, `--volume-size` (GiB, default 20),
-`--arch {x86_64,arm64}` (default `x86_64`), `--ami` (override the
+`--arch {x86_64,arm64}` (default `arm64`/Graviton — cheaper, and the
+pure-Go server has no x86 dependency; the instance type follows the arch:
+`t4g.small` for arm64, `t3.small` for x86_64), `--ami` (override the
 resolved Amazon Linux 2023 AMI).  Exit codes: 0 ok, 1 AWS/operation
 failure, 2 usage.
 
@@ -351,6 +353,14 @@ the VM's recorded arch unless you pass `--force`.  Exit codes: 0 ok,
   `DescribeInstanceInformation`, `GetParameter`
 - S3: full access to the `bvl-sync-deploy-*` bucket
 - STS: `sts:GetCallerIdentity`
+
+These tools read the **ambient** boto3 credential chain (no `--profile` flag),
+so with AWS SSO you must `aws sso login` *and* `export AWS_PROFILE=<profile>`
+in the same shell. Note that `PowerUserAccess` lacks the IAM permissions above,
+so `manage_vm.py create` needs an admin-capable role. The end-to-end
+[multi-laptop setup runbook](../docs/MULTI_LAPTOP_SETUP.md#troubleshooting) has
+a Troubleshooting section covering the SSO sign-in, credential, IAM-denial, and
+`RunInstances` errors seen in practice, each with its fix.
 
 ## Development
 

--- a/browser-visit-tools/gen-prod-certs
+++ b/browser-visit-tools/gen-prod-certs
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# gen-prod-certs — Mint PRODUCTION mTLS material for the multi-laptop
+# sync-server into ~/.browser-visit-logger/ca/ (override with BVL_CA_DIR).
+#
+# Thin wrapper over browser-visit-sync-server/test/gen-certs.sh that pins
+# --out-dir to the production CA directory, so the crown-jewel CA never
+# lands in the throwaway test/certs/ (which the integration suite WIPES).
+# Every other flag passes straight through:
+#
+#   gen-prod-certs --server-host <vm-dns-or-ip> <machine-id>...   # first run
+#   gen-prod-certs --add-client <machine-id>                      # add a laptop
+#
+# See docs/MULTI_LAPTOP_SETUP.md.  Keep the resulting ca.key safe — it's
+# the root of trust and what you need to enrol more laptops later.
+set -euo pipefail
+
+OUT_DIR="${BVL_CA_DIR:-$HOME/.browser-visit-logger/ca}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GEN="$HERE/../browser-visit-sync-server/test/gen-certs.sh"
+
+[ -f "$GEN" ] || { echo "error: cannot find gen-certs.sh at $GEN" >&2; exit 2; }
+
+echo "minting production certs into $OUT_DIR" >&2
+exec bash "$GEN" --out-dir "$OUT_DIR" "$@"

--- a/browser-visit-tools/manage_vm.py
+++ b/browser-visit-tools/manage_vm.py
@@ -31,6 +31,7 @@ Exit codes: 0 success, 1 AWS/operation failure, 2 usage.
 import argparse
 import json
 import sys
+import uuid
 
 import _bvl_aws as aws
 
@@ -182,7 +183,13 @@ def cmd_create(args):
             'Ebs': {'VolumeSize': args.volume_size, 'VolumeType': 'gp3'},
         }],
         TagSpecifications=[_tag_spec('instance')],
-        ClientToken=f'bvl-sync-server-{region or "default"}',
+        # Unique per invocation. A stable token would collide with EC2's
+        # ~24h idempotency cache when re-creating after a terminate (a
+        # different arch/type then fails with IdempotentParameterMismatch,
+        # an identical one silently returns the dead instance). Duplicate
+        # protection is the tag-based find-or-create guard above; the token
+        # only closes the rapid double-submit window within a single run.
+        ClientToken=f'bvl-sync-server-{region or "default"}-{uuid.uuid4()}',
     )
     instance_id = run['Instances'][0]['InstanceId']
     aws.save_state({'region': region, 'instance_id': instance_id,
@@ -282,11 +289,12 @@ def _build_parser():
                     metavar='CIDR',
                     help='CIDR allowed to reach the gRPC port (repeatable)')
     pc.add_argument('--instance-type',
-                    help='override the arch default (t3.small / t4g.small)')
+                    help='override the arch default (t4g.small / t3.small)')
     pc.add_argument('--volume-size', type=int, default=20,
                     help='root EBS size in GiB (default 20)')
-    pc.add_argument('--arch', choices=sorted(_ARCH), default='x86_64',
-                    help='instance/AMI arch; must match the deployed binary')
+    pc.add_argument('--arch', choices=sorted(_ARCH), default='arm64',
+                    help='instance/AMI arch (default arm64/Graviton); '
+                         'must match the deployed binary')
     pc.add_argument('--ami', help='override the resolved AL2023 AMI id')
 
     for name, helptext in (('start', 'start a stopped VM'),

--- a/browser-visit-tools/tests/test_manage_vm.py
+++ b/browser-visit-tools/tests/test_manage_vm.py
@@ -222,8 +222,10 @@ def test_create_launches(monkeypatch, tmp_path, capsys):
     assert ebs['VolumeType'] == 'gp3' and ebs['VolumeSize'] == 20
     tags = run_kw['TagSpecifications'][0]['Tags']
     assert {'Key': 'bvl:role', 'Value': 'sync-server'} in tags
-    # deterministic ClientToken guards against a double-launch on retry
-    assert run_kw['ClientToken'] == 'bvl-sync-server-us-east-1'
+    # ClientToken is unique per invocation (region-prefixed + uuid) so a
+    # terminate-then-recreate never collides with EC2's idempotency cache.
+    assert run_kw['ClientToken'].startswith('bvl-sync-server-us-east-1-')
+    assert run_kw['ClientToken'] != 'bvl-sync-server-us-east-1'
     assert 'created i-new' in capsys.readouterr().out
 
 
@@ -344,3 +346,11 @@ def test_main_dispatch_create(monkeypatch, tmp_path):
 def test_parser_requires_allow_cidr():
     with pytest.raises(SystemExit):
         mv._build_parser().parse_args(['create'])
+
+
+def test_parser_default_arch_is_arm64():
+    # The recommended default is arm64/Graviton (cheaper; the pure-Go
+    # server has no x86 dependency).  A no-arch create lands on t4g.small.
+    args = mv._build_parser().parse_args(['create', '--allow-cidr', '1.2.3.4/32'])
+    assert args.arch == 'arm64'
+    assert mv._ARCH[args.arch][1] == 't4g.small'

--- a/docs/MULTI_LAPTOP_SETUP.md
+++ b/docs/MULTI_LAPTOP_SETUP.md
@@ -181,27 +181,69 @@ One CA signs everything. The same `gen-certs.sh` the integration tests use
 takes a `--server-host` flag for production, so the server cert's SAN
 matches the real VM address.
 
+You supply exactly two things: the VM's stable endpoint and one
+machine-id per laptop.
+
 ```bash
 cd browser-visit-sync-server/test
 
-# Pass the VM's DNS name (or public IP) and one machine-id per laptop.
-# The machine-id MUST equal the laptop's sanitised LocalHostName — see Step 5.
+# --server-host: the VM's DNS name (or public IP) — goes into the server
+#   cert SAN so laptops can verify the server. Use a STABLE address (an
+#   Elastic IP or DNS name): a raw EC2 public address changes on stop/start
+#   and would no longer match the cert. Repeatable (pass a name AND an IP).
+# Positional args: one machine-id per laptop (see the constraint below).
 ./gen-certs.sh --server-host <vm-dns-or-ip> laptop-a laptop-b
 ```
+
+**The machine-id must equal that laptop's sanitised `LocalHostName`.** It
+becomes the cert's `CN`, and the server rejects any request whose claimed
+`machine_id` doesn't match the cert CN. Get a laptop's value by running this
+*on that laptop* before you mint its cert:
+
+```bash
+scutil --get LocalHostName | sed 's/[^A-Za-z0-9_-]/-/g; s/--*/-/g; s/^-//; s/-$//'
+```
+
+(Or run `install_laptop.sh` on it first — it prints `Machine ID: <id>` — then
+mint a cert with that exact CN.) The machine-id is the *only* per-laptop input
+you provide; the private keys are generated for you.
 
 This writes `./certs/`:
 
 | File | Goes to | Role |
 |---|---|---|
 | `ca.crt` | VM (as `clients-ca.crt`) **and** every laptop (as `server-ca.crt`) | Trust anchor for both directions |
-| `ca.key` | **nowhere — keep it offline and safe** | Signs all certs; the root of trust |
+| `ca.key` | **kept offline and safe** | Signs all certs; the root of trust — **you need it to add laptops later** |
 | `server.crt` / `server.key` | VM | Server identity (SAN includes your `--server-host`) |
 | `<id>.crt` / `<id>.key` | the matching laptop | That laptop's client identity (`CN=<id>`) |
 | `<id>.sha256`, `fingerprints.tsv` | (reference) | DER SHA-256 used at enrollment |
 
-> **Mint once.** Re-running `gen-certs.sh` wipes `certs/` and generates a new
-> CA, invalidating everything already deployed. Generate your production
-> material once and copy `ca.key` somewhere safe; re-run only to rotate.
+> **⚠️ A normal run mints a fresh CA. Run it once, then keep `ca.crt` +
+> `ca.key`.** `gen-certs.sh <machine-ids…>` begins with `rm -rf certs/` and
+> generates a **new CA every time** — re-running it to "add a laptop" would
+> invalidate the server cert and every existing laptop, forcing a full
+> re-provision. So mint your production material **once** and stash
+> `ca.crt`/`ca.key` somewhere safe. To **add a laptop later**, use the
+> non-destructive `--add-client` mode (next), not a fresh run.
+
+### Adding a laptop later (incremental, no downtime)
+
+When you buy a new machine, sign one more client cert against the **existing**
+CA — nothing already deployed changes, so there's no server redeploy and the
+other laptops are untouched. From the directory holding your saved
+`ca.crt` + `ca.key` (i.e. the original `certs/`):
+
+```bash
+cd browser-visit-sync-server/test          # where your saved certs/ lives
+./gen-certs.sh --add-client <new-machine-id>
+```
+
+`--add-client` reuses `certs/ca.{crt,key}`, leaves the CA + server cert alone,
+writes just `certs/<new-machine-id>.{crt,key,sha256}`, and appends to
+`fingerprints.tsv`. It refuses to run if there's no existing CA, or if combined
+with `--server-host` / positional ids. Then **enroll** the new cert (Step 4)
+and **install** on the new laptop (Step 5) — both are additive. The running
+server trusts the new cert the moment it's enrolled.
 
 ## Step 3 — Build, provision, and start the server
 
@@ -349,7 +391,7 @@ You can also diff a laptop against a fresh VM snapshot with
 | Ship a new binary | `make -C browser-visit-sync-server build-linux GOARCH=<arch>` then `manage_sync_server.py deploy --binary …` |
 | Stop / start the VM (save cost) | `python3 manage_vm.py stop` / `start` |
 | Tear it all down | `python3 manage_vm.py terminate --purge-infra` |
-| Add a laptop later | mint one more client cert (Step 2), enroll it (Step 4), `install_laptop.sh` on it (Step 5) |
+| Add a laptop later | `gen-certs.sh --add-client <id>` (incremental — see [Step 2](#adding-a-laptop-later-incremental-no-downtime)), enroll it (Step 4), `install_laptop.sh` on it (Step 5) |
 
 **Stopping the VM** keeps the data volume; its public address may change on
 restart — re-run `manage_vm.py status` and, if it changed, update each

--- a/docs/MULTI_LAPTOP_SETUP.md
+++ b/docs/MULTI_LAPTOP_SETUP.md
@@ -1,0 +1,445 @@
+# Multi-laptop setup — from scratch
+
+This is the end-to-end runbook for standing up the **multi-laptop**
+configuration from nothing: create the EC2 VM, get the gRPC sync-server
+running on it, and install the browser-visit logger on one or more laptops
+so their databases converge.
+
+Each per-project README documents its own piece in depth; this guide chains
+them into one ordered sequence and fills the gap they leave open — minting
+the TLS material that ties the VM and the laptops together. Where detail
+lives elsewhere, this guide links to it rather than repeating it:
+
+- [`browser-visit-sync-server/README.md`](../browser-visit-sync-server/README.md) — the gRPC service
+- [`browser-visit-logger/README.md`](../browser-visit-logger/README.md) — the laptop extension + native host
+- [`browser-visit-tools/README.md`](../browser-visit-tools/README.md) — `manage_vm.py`, `manage_sync_server.py`, `enroll_machine.py`, `install_laptop.sh`
+
+> **Single-laptop mode needs none of this.** If you just want local logging
+> on one Mac, run `browser-visit-logger/install.sh` and stop — see that
+> project's README. Multi-laptop mode is opt-in and only activates once
+> `~/.browser-visit-logger/config.json` exists on a laptop.
+
+---
+
+## What you end up with
+
+```
+  laptop-a ─┐
+            ├─ gRPC/mTLS :50443 ─►  EC2 VM  (sync-server, systemd)
+  laptop-b ─┘                       canonical DB + per-machine log mirror
+```
+
+One EC2 Linux VM runs the sync-server. Every laptop pushes its log records
+to it and pulls every peer's records back, so each laptop's local
+`~/browser-visits.db` converges to the union of all laptops' activity within
+~1 minute of any interaction. Authentication is mTLS: one CA signs the
+server cert and one client cert per laptop; the server pins each client
+cert's SHA-256 to a `machine_id`.
+
+## Prerequisites
+
+**On your admin machine** (where you run the `manage_*` tools — typically
+one of the laptops):
+
+- **AWS credentials** from the ambient chain (env / `~/.aws` / SSO) with the
+  permissions listed under "Prerequisites" in
+  [`browser-visit-tools/README.md`](../browser-visit-tools/README.md#prerequisites)
+  — EC2 run/describe + security groups, IAM role/instance-profile create
+  **including `iam:PassRole`**, SSM `SendCommand` + `StartSession`, S3 on the
+  `bvl-sync-deploy-*` bucket, and STS.
+- **`boto3`** — `pip install boto3`.
+- **Go 1.22+ and `protoc`** — to cross-compile the server binary
+  (`make build-linux`). Alternatively build it in Docker via
+  `browser-visit-sync-server/deploy/Dockerfile`.
+- **`openssl`** — to mint TLS material.
+- **The AWS Session Manager plugin** — for the one manual VM-shell step in
+  [Step 4](#step-4--enroll-each-laptop). Install:
+  <https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html>
+
+**On each laptop**: macOS with the Xcode command-line tools (Swift
+toolchain), Chrome/Chromium, and Python 3 (the system `python3` is fine).
+
+All `manage_*` commands below are run from the `browser-visit-tools/`
+directory.
+
+### AWS credentials & permissions
+
+The tools have no `--profile` flag — they read the **ambient** boto3 chain
+(env vars / `~/.aws` / SSO). Two gotchas trip up a fresh setup:
+
+- **Select a profile.** If you authenticate with AWS SSO (IAM Identity
+  Center), `aws sso login` signs in a *named* profile but doesn't make it the
+  default, so boto3 finds nothing and you get
+  `NoCredentialsError: Unable to locate credentials`. Log in and export the
+  profile in the **same shell** you run the tools from:
+
+  ```bash
+  aws sso login --profile <your-sso-profile>
+  export AWS_PROFILE=<your-sso-profile>
+  aws sts get-caller-identity          # confirm the chain resolves
+  ```
+
+  `export` lasts only for that terminal (add it to `~/.zshrc` to persist), and
+  SSO sessions expire — just re-run `aws sso login` when credentials vanish.
+
+- **`PowerUserAccess` is not enough.** That common SSO role grants everything
+  *except* IAM writes, but `manage_vm.py create` must create an IAM role +
+  instance profile and call `iam:PassRole` (so the VM is reachable over SSM).
+  Under PowerUserAccess the create stops at the IAM step with `AccessDenied`.
+  Use a role that also allows `iam:CreateRole`, `iam:CreateInstanceProfile`,
+  `iam:AddRoleToInstanceProfile`, `iam:PutRolePolicy`, `iam:AttachRolePolicy`,
+  and **`iam:PassRole`** (admin is simplest) — or have someone with IAM rights
+  pre-create the `bvl-sync-server-role` + `bvl-sync-server-profile` once, after
+  which PowerUserAccess can launch against the existing profile.
+
+If `aws sso login` or `manage_vm.py create` errors out, the
+[Troubleshooting](#troubleshooting) section at the end walks through every
+AWS sign-in / credential / IAM / launch error seen in practice, with the fix.
+
+---
+
+## Step 1 — Create the VM
+
+Pick the CIDR(s) allowed to reach the gRPC port (your laptops' egress IPs).
+`create` is idempotent — it find-or-creates a tagged instance, the security
+group (gRPC `50443` only, **no SSH/22**), and an SSM-capable IAM instance
+profile.
+
+```bash
+cd browser-visit-tools
+
+# arm64/Graviton is the default (cheaper; the pure-Go server has no x86 deps),
+# so the flags below are optional. For Intel use --arch x86_64 (→ t3.small).
+python3 manage_vm.py create --allow-cidr <your-cidr>/32 \
+    --region us-west-2 --arch arm64 --instance-type t4g.small
+
+python3 manage_vm.py status
+```
+
+`status` prints the instance's `public:` DNS name and IP. **Record that
+address** — it's both the SAN you bake into the server cert (Step 2) and the
+endpoint each laptop connects to (Step 5). State is cached in
+`~/.browser-visit-logger/vm.json`; every later command reads it (and
+falls back to tag-discovery if it's stale).
+
+> The `--arch` you choose here must match the `GOARCH` you build in Step 3:
+> `x86_64 → amd64`, `arm64 → arm64`.
+
+### Choosing `--allow-cidr`
+
+`--allow-cidr` (required, repeatable) is the **network allowlist**: each value
+becomes one security-group rule allowing inbound TCP to gRPC port `50443` from
+that IP range. It's the only thing the VM exposes — there is no SSH. Think of
+it as defense in depth, *not* the primary auth: mTLS is the real boundary
+(an unenrolled or spoofed cert is rejected even from an allowed IP), so the
+CIDR just stops the rest of the internet from opening a connection at all.
+
+A CIDR is `<address>/<prefix>` — the prefix is how many leading bits are
+fixed: `/32` = exactly one IPv4 address, `/24` = 256, `/16` = 65,536,
+`0.0.0.0/0` = the whole internet.
+
+The VM sees the **public egress IP** of whatever network the laptop is on
+(everything behind one home/office NAT shares a single public IP), not the
+laptop's private `192.168.x.x`. Find a network's public IPv4 with:
+
+```bash
+curl https://checkip.amazonaws.com
+```
+
+Reasonable choices:
+
+- **A `/32` per network you use** (recommended) — tight, and `create` is
+  additive, so just re-run it from each new location:
+
+  ```bash
+  python3 manage_vm.py create --allow-cidr 203.0.113.7/32      # home
+  python3 manage_vm.py create --allow-cidr 198.51.100.40/32    # office (appends)
+  # or several at once: --allow-cidr A/32 --allow-cidr B/32
+  ```
+
+- **A documented office egress block** — use it directly, e.g.
+  `--allow-cidr 198.51.100.0/24`.
+
+- **`0.0.0.0/0`** — defensible *here* because mTLS is the actual auth, but you
+  lose the network filter (the world can attempt handshakes, showing up as
+  `[caller=?]` rejections in the logs). Reach for it only if per-`/32`
+  upkeep becomes a real nuisance while roaming.
+
+Two gotchas:
+
+- **This tool only *adds* rules** (duplicates are ignored); it can't remove
+  them. To drop a stale CIDR (an old café IP, a changed home IP), use the AWS
+  console or `aws ec2 revoke-security-group-ingress` on the
+  `bvl-sync-server-sg` group.
+- **IPv4 only** — the rule uses `CidrIp`. If a laptop reaches the VM over
+  IPv6, it won't match any rule; if one network mysteriously can't connect,
+  compare `curl -4 checkip.amazonaws.com` with `curl -6 …`.
+
+## Step 2 — Mint TLS material
+
+One CA signs everything. The same `gen-certs.sh` the integration tests use
+takes a `--server-host` flag for production, so the server cert's SAN
+matches the real VM address.
+
+```bash
+cd browser-visit-sync-server/test
+
+# Pass the VM's DNS name (or public IP) and one machine-id per laptop.
+# The machine-id MUST equal the laptop's sanitised LocalHostName — see Step 5.
+./gen-certs.sh --server-host <vm-dns-or-ip> laptop-a laptop-b
+```
+
+This writes `./certs/`:
+
+| File | Goes to | Role |
+|---|---|---|
+| `ca.crt` | VM (as `clients-ca.crt`) **and** every laptop (as `server-ca.crt`) | Trust anchor for both directions |
+| `ca.key` | **nowhere — keep it offline and safe** | Signs all certs; the root of trust |
+| `server.crt` / `server.key` | VM | Server identity (SAN includes your `--server-host`) |
+| `<id>.crt` / `<id>.key` | the matching laptop | That laptop's client identity (`CN=<id>`) |
+| `<id>.sha256`, `fingerprints.tsv` | (reference) | DER SHA-256 used at enrollment |
+
+> **Mint once.** Re-running `gen-certs.sh` wipes `certs/` and generates a new
+> CA, invalidating everything already deployed. Generate your production
+> material once and copy `ca.key` somewhere safe; re-run only to rotate.
+
+## Step 3 — Build, provision, and start the server
+
+Cross-compile the binary for the VM's architecture, then provision (first-
+boot setup: `bvlsync` user, data dirs, systemd unit, TLS material) and
+deploy in one shot.
+
+```bash
+# Match the VM arch from Step 1 (arm64 for arm64, amd64 for x86_64).
+make -C browser-visit-sync-server build-linux GOARCH=arm64
+
+cd browser-visit-tools
+python3 manage_sync_server.py provision \
+    --server-cert ../browser-visit-sync-server/test/certs/server.crt \
+    --server-key  ../browser-visit-sync-server/test/certs/server.key \
+    --clients-ca  ../browser-visit-sync-server/test/certs/ca.crt \
+    --and-deploy  --binary ../browser-visit-sync-server/bin/sync-server-linux-arm64
+
+python3 manage_sync_server.py start
+python3 manage_sync_server.py health
+```
+
+`health` should report the service active, port `50443` open, and disk under
+90%. Everything runs over AWS SSM — no SSH. Note the CA file is passed as
+`--clients-ca` (laptops are the clients) and lands on the VM as
+`/etc/browser-visit-sync/clients-ca.crt`. See
+[`browser-visit-sync-server/README.md`](../browser-visit-sync-server/README.md#run-on-ec2-mtls-enrolled-machines-only)
+for the on-disk layout and the systemd unit.
+
+## Step 4 — Enroll each laptop
+
+The server only accepts a client cert whose SHA-256 is recorded in the VM's
+`/var/lib/browser-visit-sync/enrolled_machines.db`. There is no
+SSM subcommand for this yet, so enrollment is the one manual step: build the
+DB locally with `enroll_machine.py`, then place it on the VM using the
+infrastructure that's already there (the S3 staging bucket the deploy tool
+uses, plus an SSM Session Manager shell).
+
+```bash
+cd browser-visit-tools
+pip install cryptography     # enroll_machine.py needs it to read PEM certs
+
+# One row per laptop. machine-id must match the cert CN from Step 2.
+for id in laptop-a laptop-b; do
+    python3 enroll_machine.py --db ./enrolled_machines.db \
+        --machine-id "$id" \
+        --cert ../browser-visit-sync-server/test/certs/$id.crt
+done
+python3 enroll_machine.py --db ./enrolled_machines.db --list   # sanity-check
+
+# Transfer to the VM via the per-account staging bucket the deploy uses.
+ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+REGION=us-west-2                                  # the VM's region
+BUCKET="bvl-sync-deploy-${ACCOUNT}-${REGION}"
+aws s3 cp ./enrolled_machines.db "s3://${BUCKET}/enrolled_machines.db" --sse
+
+# Open a shell on the VM (no SSH — this is SSM Session Manager) and install it.
+INSTANCE=$(python3 -c "import json,os;print(json.load(open(os.path.expanduser('~/.browser-visit-logger/vm.json')))['instance_id'])")
+aws ssm start-session --target "$INSTANCE"
+#   --- on the VM ---
+#   sudo aws s3 cp s3://<bucket>/enrolled_machines.db /var/lib/browser-visit-sync/enrolled_machines.db
+#   sudo chown bvlsync:bvlsync /var/lib/browser-visit-sync/enrolled_machines.db
+#   sudo systemctl restart sync-server
+#   exit
+```
+
+To add a laptop later, re-run `enroll_machine.py` (it's `INSERT OR REPLACE`,
+so existing rows are preserved) and repeat the transfer. To revoke one, use
+`enroll_machine.py --revoke` and re-transfer. See the `enroll_machine.py`
+section in
+[`browser-visit-tools/README.md`](../browser-visit-tools/README.md#enroll_machinepy).
+
+## Step 5 — Install on each laptop
+
+On every laptop, run the multi-laptop installer pointed at the VM. It runs
+the upstream `install.sh` (builds/signs the native host, installs the Chrome
+manifest) and writes `~/.browser-visit-logger/config.json` with this
+laptop's `machine_id` and the sync endpoint.
+
+```bash
+bash browser-visit-tools/install_laptop.sh --server <vm-dns-or-ip>:50443
+```
+
+The installer prints the resolved `machine_id` (sanitised
+`scutil --get LocalHostName`). **It must match the cert CN and the enrolled
+`machine_id` from Steps 2 and 4** — if not, mint/enroll under the printed
+name (or override with `BVL_MACHINE_ID`).
+
+Then drop that laptop's TLS material into `~/.browser-visit-logger/tls/`,
+renaming to the names the sync client expects:
+
+```bash
+install -m 0700 -d ~/.browser-visit-logger/tls
+cp <id>.crt  ~/.browser-visit-logger/tls/client.crt
+cp <id>.key  ~/.browser-visit-logger/tls/client.key
+cp ca.crt    ~/.browser-visit-logger/tls/server-ca.crt
+chmod 600 ~/.browser-visit-logger/tls/client.key
+```
+
+Finally do the per-laptop Chrome steps from
+[`browser-visit-logger/README.md`](../browser-visit-logger/README.md):
+load the unpacked extension at `chrome://extensions`, and grant the macOS
+Files & Folders (TCC) prompts the first time you tag a page.
+
+## Step 6 — Verify end to end
+
+1. On `laptop-a`, browse to a page and tag it (★ / ✓ / ~) from the popup.
+2. Within ~60s the sync fires. Confirm the server received it:
+
+   ```bash
+   cd browser-visit-tools
+   python3 manage_sync_server.py logs --lines 50
+   ```
+
+   Look for a line like
+   `[caller=laptop-a] …/PushLogs status=OK … lines=N`. A `[caller=?]` line
+   means the cert wasn't enrolled; `[caller=…] status=PermissionDenied`
+   means it's enrolled but the `machine_id` didn't match the cert CN. See
+   the log-format notes in
+   [`browser-visit-sync-server/README.md`](../browser-visit-sync-server/README.md).
+
+3. On `laptop-b`, trigger any interaction (so its sync runs) and confirm the
+   `laptop-a` row arrived — query via the `browser-visits` MCP `query` tool,
+   or directly:
+
+   ```bash
+   sqlite3 ~/browser-visits.db 'SELECT url FROM visits ORDER BY rowid DESC LIMIT 5;'
+   ```
+
+You can also diff a laptop against a fresh VM snapshot with
+`fetch_vm_snapshot.py` + `db_diff.py` — see
+[`browser-visit-tools/README.md`](../browser-visit-tools/README.md#db_diffpy).
+
+---
+
+## Day-2 operations
+
+| Task | Command |
+|---|---|
+| Health probe | `python3 manage_sync_server.py health` |
+| Service status | `python3 manage_sync_server.py status` |
+| Recent logs | `python3 manage_sync_server.py logs --lines 100 [--since '1 hour ago']` |
+| Live log tail | `aws ssm start-session --target <instance-id>` then `journalctl -u sync-server -f` |
+| Restart after a config change | `python3 manage_sync_server.py restart` |
+| Ship a new binary | `make -C browser-visit-sync-server build-linux GOARCH=<arch>` then `manage_sync_server.py deploy --binary …` |
+| Stop / start the VM (save cost) | `python3 manage_vm.py stop` / `start` |
+| Tear it all down | `python3 manage_vm.py terminate --purge-infra` |
+| Add a laptop later | mint one more client cert (Step 2), enroll it (Step 4), `install_laptop.sh` on it (Step 5) |
+
+**Stopping the VM** keeps the data volume; its public address may change on
+restart — re-run `manage_vm.py status` and, if it changed, update each
+laptop's `~/.browser-visit-logger/config.json`. To avoid this, attach a
+stable DNS name / Elastic IP and use that as the `--server-host` in Step 2.
+
+---
+
+## Troubleshooting
+
+Everything below was hit (and fixed) standing up a real VM. They cluster into
+three phases: **(A)** getting AWS credentials to resolve, **(B)** getting the
+IAM permissions to create infra, and **(C)** the `RunInstances` call itself.
+
+### A. AWS sign-in & credentials
+
+**`NoCredentialsError: Unable to locate credentials`** — boto3 found nothing
+in the chain. With SSO this almost always means either you haven't run
+`aws sso login`, or you have but didn't select the profile. `aws sso login`
+signs in a *named* profile without making it the default, so you must
+`export AWS_PROFILE=<profile>` in the same shell (see the
+[credentials box](#aws-credentials--permissions) above). `aws sts
+get-caller-identity` must print your account/role before any tool will work.
+
+**`aws sso login` fails at `RegisterClient` / `StartDeviceAuthorization`** —
+several distinct causes, easiest to rule out first:
+
+- *`InvalidRequestException … Couldn't find Identity Center Instance`* — the
+  decisive one: your `sso_start_url` in `~/.aws/config` doesn't resolve to a
+  real Identity Center instance, or `sso_region` points at the wrong region.
+  A valid start URL is the **AWS access portal URL** (`https://d-xxxxxxxxxx.awsapps.com/start`
+  or `https://<subdomain>.awsapps.com/start`), *not* one built from the
+  instance id (`…/ssoins-…`). Get the real URL and the instance's home region
+  from the IAM Identity Center console → **Settings**, then re-run
+  `aws configure sso` (reuse session name `my-dev-sso`) to rewrite the profile.
+  A stale cached *token* can mask a wrong start URL until the session expires —
+  so this can surface suddenly on a previously-working setup.
+- *`AccessDeniedException` on `RegisterClient` / `InvalidRequestException` with
+  an empty message* — usually an **old AWS CLI**. v2.22+ defaults to the
+  authorization-code-with-PKCE flow and validates the start URL as an OIDC
+  issuer; older versions register clients in a way newer Identity Center
+  rejects. Upgrade the CLI (`brew install awscli`, then point your `aws` at it)
+  and clear the SSO client cache so it re-registers fresh:
+  `mv ~/.aws/sso/cache ~/.aws/sso/cache.bak` and log in again. As a stopgap on
+  a correct-but-old setup, `aws sso login --use-device-code` forces the legacy
+  device-code flow.
+
+**SSO sign-in demands a passkey/MFA you don't have** — if the browser prompts
+for a passkey that isn't on this device, try your phone (passkeys sync via
+iCloud Keychain / your password manager) or "use another method." As the
+account admin you can also reset it: IAM Identity Center → Users → your user →
+**Multi-factor authentication**, delete the stale device, register a new one.
+
+### B. IAM permissions for `create`
+
+**`AccessDenied … iam:GetRole` (or `CreateRole`/`PassRole`) on `bvl-sync-server-role`**
+— your role can't touch IAM. `PowerUserAccess` excludes IAM by design, and
+`manage_vm.py create` (and `terminate --purge-infra`) must create the VM's
+role + instance profile and `PassRole` it to EC2. Fix per the
+[credentials box](#aws-credentials--permissions): assign yourself an
+`AdministratorAccess` permission set for the account and use that profile for
+the privileged steps, or add a scoped inline policy granting the IAM actions
+listed there. **After changing a permission set, re-provision it and re-run
+`aws sso login`** — a cached session keeps the old permissions.
+
+> Only `create` and `terminate --purge-infra` need IAM. The routine commands
+> (`start`/`stop`/`status`, all of `manage_sync_server.py`) run fine under
+> `PowerUserAccess`, so you can switch back to it for day-to-day use.
+
+### C. `RunInstances` errors
+
+**`InvalidParameterValue … Invalid IAM Instance Profile name (bvl-sync-server-profile)`**
+— not a misconfiguration: a freshly-created instance profile takes a few
+seconds to become visible to EC2, and `create` launches immediately after
+creating it. Just **re-run `create`** (it's idempotent — it reuses the now-
+propagated profile) or wait ~15s. Confirm the profile is real with
+`aws iam get-instance-profile --instance-profile-name bvl-sync-server-profile`.
+
+**`IdempotentParameterMismatch` on `RunInstances`** — fixed in the current
+tool (the EC2 client token is now unique per invocation). If you see it on an
+**older checkout**, it's because the token was keyed only on region and EC2
+caches a token→parameters binding for ~24h: re-creating after a terminate with
+a *different* arch/type collides. Either pull the fix, change `--region`, or
+wait out the 24h cache.
+
+### Architecture
+
+The tool **defaults to arm64/Graviton** (`t4g.small`) — cheaper, and the
+pure-Go server has no x86 dependency. A no-flag `create` lands on arm64; build
+with `GOARCH=arm64` to match. For Intel pass `--arch x86_64` (→ `t3.small`)
+and build `GOARCH=amd64`. `manage_sync_server.py deploy` refuses a binary
+whose arch token doesn't match the VM's recorded arch, so a mismatch fails
+loudly rather than booting a broken service.

--- a/docs/MULTI_LAPTOP_SETUP.md
+++ b/docs/MULTI_LAPTOP_SETUP.md
@@ -177,22 +177,25 @@ Two gotchas:
 
 ## Step 2 — Mint TLS material
 
-One CA signs everything. The same `gen-certs.sh` the integration tests use
-takes a `--server-host` flag for production, so the server cert's SAN
-matches the real VM address.
+One CA signs everything. Mint the production material with the
+`gen-prod-certs` wrapper, which writes to `~/.browser-visit-logger/ca/`
+(overridable via `BVL_CA_DIR`). It wraps the same `gen-certs.sh` the
+integration tests use, but pins the output **outside** `test/certs/` —
+which the test suite wipes — so a later `make test-integration` can't
+clobber your production CA.
 
 You supply exactly two things: the VM's stable endpoint and one
 machine-id per laptop.
 
 ```bash
-cd browser-visit-sync-server/test
+cd browser-visit-tools
 
 # --server-host: the VM's DNS name (or public IP) — goes into the server
 #   cert SAN so laptops can verify the server. Use a STABLE address (an
 #   Elastic IP or DNS name): a raw EC2 public address changes on stop/start
 #   and would no longer match the cert. Repeatable (pass a name AND an IP).
 # Positional args: one machine-id per laptop (see the constraint below).
-./gen-certs.sh --server-host <vm-dns-or-ip> laptop-a laptop-b
+./gen-prod-certs --server-host <vm-dns-or-ip> laptop-a laptop-b
 ```
 
 **The machine-id must equal that laptop's sanitised `LocalHostName`.** It
@@ -208,7 +211,7 @@ scutil --get LocalHostName | sed 's/[^A-Za-z0-9_-]/-/g; s/--*/-/g; s/^-//; s/-$/
 mint a cert with that exact CN.) The machine-id is the *only* per-laptop input
 you provide; the private keys are generated for you.
 
-This writes `./certs/`:
+This writes `~/.browser-visit-logger/ca/`:
 
 | File | Goes to | Role |
 |---|---|---|
@@ -219,33 +222,37 @@ This writes `./certs/`:
 | `<id>.sha256`, `fingerprints.tsv` | (reference) | DER SHA-256 used at enrollment |
 
 > **⚠️ A normal run mints a fresh CA. Run it once, then keep `ca.crt` +
-> `ca.key`.** `gen-certs.sh <machine-ids…>` begins with `rm -rf certs/` and
-> generates a **new CA every time** — re-running it to "add a laptop" would
-> invalidate the server cert and every existing laptop, forcing a full
-> re-provision. As a safety net, if a CA already exists the script **asks for
-> confirmation first** (and refuses outright when run non-interactively)
-> unless you pass `--force`. Still: mint your production material **once** and
-> stash `ca.crt`/`ca.key` somewhere safe. To **add a laptop later**, use the
-> non-destructive `--add-client` mode (next), not a fresh run.
+> `ca.key`.** A full mint begins by wiping the output dir and generates a
+> **new CA every time** — re-running it to "add a laptop" would invalidate the
+> server cert and every existing laptop, forcing a full re-provision. As a
+> safety net, if a CA already exists the script **asks for confirmation first**
+> (and refuses outright when run non-interactively) unless you pass `--force`.
+> Still: mint your production material **once** and keep
+> `~/.browser-visit-logger/ca/` (especially `ca.key`) safe. To **add a laptop
+> later**, use the non-destructive `--add-client` mode (next), not a fresh run.
+>
+> Do **not** mint production certs into `browser-visit-sync-server/test/certs/`
+> — `make test-integration` wipes that directory. `gen-prod-certs` keeps you
+> out of that trap by writing to `~/.browser-visit-logger/ca/`.
 
 ### Adding a laptop later (incremental, no downtime)
 
 When you buy a new machine, sign one more client cert against the **existing**
 CA — nothing already deployed changes, so there's no server redeploy and the
-other laptops are untouched. From the directory holding your saved
-`ca.crt` + `ca.key` (i.e. the original `certs/`):
+other laptops are untouched:
 
 ```bash
-cd browser-visit-sync-server/test          # where your saved certs/ lives
-./gen-certs.sh --add-client <new-machine-id>
+cd browser-visit-tools
+./gen-prod-certs --add-client <new-machine-id>
 ```
 
-`--add-client` reuses `certs/ca.{crt,key}`, leaves the CA + server cert alone,
-writes just `certs/<new-machine-id>.{crt,key,sha256}`, and appends to
-`fingerprints.tsv`. It refuses to run if there's no existing CA, or if combined
-with `--server-host` / positional ids. Then **enroll** the new cert (Step 4)
-and **install** on the new laptop (Step 5) — both are additive. The running
-server trusts the new cert the moment it's enrolled.
+`--add-client` reuses the saved `~/.browser-visit-logger/ca/ca.{crt,key}`,
+leaves the CA + server cert alone, writes just the new
+`<new-machine-id>.{crt,key,sha256}`, and appends to `fingerprints.tsv`. It
+refuses to run if there's no existing CA, or if combined with `--server-host` /
+positional ids. Then **enroll** the new cert (Step 4) and **install** on the
+new laptop (Step 5) — both are additive. The running server trusts the new
+cert the moment it's enrolled.
 
 ## Step 3 — Build, provision, and start the server
 
@@ -259,9 +266,9 @@ make -C browser-visit-sync-server build-linux GOARCH=arm64
 
 cd browser-visit-tools
 python3 manage_sync_server.py provision \
-    --server-cert ../browser-visit-sync-server/test/certs/server.crt \
-    --server-key  ../browser-visit-sync-server/test/certs/server.key \
-    --clients-ca  ../browser-visit-sync-server/test/certs/ca.crt \
+    --server-cert ~/.browser-visit-logger/ca/server.crt \
+    --server-key  ~/.browser-visit-logger/ca/server.key \
+    --clients-ca  ~/.browser-visit-logger/ca/ca.crt \
     --and-deploy  --binary ../browser-visit-sync-server/bin/sync-server-linux-arm64
 
 python3 manage_sync_server.py start
@@ -292,7 +299,7 @@ pip install cryptography     # enroll_machine.py needs it to read PEM certs
 for id in laptop-a laptop-b; do
     python3 enroll_machine.py --db ./enrolled_machines.db \
         --machine-id "$id" \
-        --cert ../browser-visit-sync-server/test/certs/$id.crt
+        --cert ~/.browser-visit-logger/ca/$id.crt
 done
 python3 enroll_machine.py --db ./enrolled_machines.db --list   # sanity-check
 
@@ -411,7 +418,7 @@ You can also diff a laptop against a fresh VM snapshot with
 | Ship a new binary | `make -C browser-visit-sync-server build-linux GOARCH=<arch>` then `manage_sync_server.py deploy --binary …` |
 | Stop / start the VM (save cost) | `python3 manage_vm.py stop` / `start` |
 | Tear it all down | `python3 manage_vm.py terminate --purge-infra` |
-| Add a laptop later | `gen-certs.sh --add-client <id>` (incremental — see [Step 2](#adding-a-laptop-later-incremental-no-downtime)), enroll it (Step 4), `install_laptop.sh` on it (Step 5) |
+| Add a laptop later | `gen-prod-certs --add-client <id>` (incremental — see [Step 2](#adding-a-laptop-later-incremental-no-downtime)), enroll it (Step 4), `install_laptop.sh` on it (Step 5) |
 
 **Stopping the VM** keeps the data volume; its public address may change on
 restart — re-run `manage_vm.py status` and, if it changed, update each

--- a/docs/MULTI_LAPTOP_SETUP.md
+++ b/docs/MULTI_LAPTOP_SETUP.md
@@ -350,6 +350,24 @@ Finally do the per-laptop Chrome steps from
 load the unpacked extension at `chrome://extensions`, and grant the macOS
 Files & Folders (TCC) prompts the first time you tag a page.
 
+> **Converting a laptop that already ran single-laptop mode?** Its historical
+> snapshots live in the iCloud archive (`~/Documents/browser-visit-logger/snapshots/`),
+> whereas multi-laptop mode uses the shared Google Drive archive — so those
+> older snapshots won't be visible until you migrate them. Run the one-time,
+> idempotent migration on that laptop (dry-run first):
+>
+> ```bash
+> python3 browser-visit-tools/migrate_icloud_to_gdrive.py --dry-run \
+>     --src ~/Documents/browser-visit-logger/snapshots \
+>     --dst "~/Library/CloudStorage/GoogleDrive/My Drive/browser-visit-logger/snapshots" \
+>     --db  ~/browser-visits.db
+> ```
+>
+> It copies the archive to Google Drive (SHA-256 verified), rewrites the DB
+> paths, and leaves the iCloud copy in place. Fresh laptops with no prior
+> single-laptop history can skip this. See
+> [`browser-visit-tools/README.md`](../browser-visit-tools/README.md#migrate_icloud_to_gdrivepy).
+
 ## Step 6 — Verify end to end
 
 1. On `laptop-a`, browse to a page and tag it (★ / ✓ / ~) from the popup.

--- a/docs/MULTI_LAPTOP_SETUP.md
+++ b/docs/MULTI_LAPTOP_SETUP.md
@@ -222,8 +222,10 @@ This writes `./certs/`:
 > `ca.key`.** `gen-certs.sh <machine-ids…>` begins with `rm -rf certs/` and
 > generates a **new CA every time** — re-running it to "add a laptop" would
 > invalidate the server cert and every existing laptop, forcing a full
-> re-provision. So mint your production material **once** and stash
-> `ca.crt`/`ca.key` somewhere safe. To **add a laptop later**, use the
+> re-provision. As a safety net, if a CA already exists the script **asks for
+> confirmation first** (and refuses outright when run non-interactively)
+> unless you pass `--force`. Still: mint your production material **once** and
+> stash `ca.crt`/`ca.key` somewhere safe. To **add a laptop later**, use the
 > non-destructive `--add-client` mode (next), not a fresh run.
 
 ### Adding a laptop later (incremental, no downtime)


### PR DESCRIPTION
## Summary

Adds an end-to-end runbook for standing up the **multi-laptop** configuration from nothing, and fixes two VM-creation rough edges uncovered while doing exactly that against a real AWS account.

The pieces to run multi-laptop mode all existed (`manage_vm.py`, `manage_sync_server.py`, `enroll_machine.py`, `install_laptop.sh`), but no single doc chained them together, and the only TLS-minting script was test-only (localhost cert). This PR closes both gaps.

## What's included

**Docs**
- New [`docs/MULTI_LAPTOP_SETUP.md`](../blob/feature/multi-laptop-from-scratch-setup/docs/MULTI_LAPTOP_SETUP.md): create VM → mint TLS → build/provision sync-server → enroll laptops → install on each → verify, plus Day-2 ops.
- A **Troubleshooting** section capturing every AWS sign-in / credential / IAM / `RunInstances` error hit in practice (SSO profile selection & `NoCredentialsError`, wrong `sso_start_url` → "Couldn't find Identity Center Instance", old-CLI OIDC failures, `PowerUserAccess` vs IAM, instance-profile propagation, idempotency-token collision), each with its fix.
- Guidance on choosing `--allow-cidr` and the arm64 default.
- Root README cross-link; `browser-visit-tools/README.md` points at the troubleshooting; tools test count 167 → 168.

**Code: `gen-certs.sh`**
- Optional, repeatable `--server-host <dns-or-ip>` adds the real VM endpoint to the server cert SAN (auto-detecting IP vs DNS). No-flag output stays byte-identical, so the integration harness is unaffected.

**Code: `manage_vm.py`**
- `--arch` now defaults to **arm64/Graviton** (`t4g.small`) — cheaper, and the pure-Go server has no x86 dependency; `x86_64` still available via the flag.
- `RunInstances` `ClientToken` is now **unique per invocation**. It was keyed only on region, and EC2 caches a token→params binding for ~24h, so re-creating after a terminate with a different arch/type failed with `IdempotentParameterMismatch`. Tag-based find-or-create remains the real duplicate guard.

## Testing
- `browser-visit-tools`: **168 passed, 100% coverage** (gated) — includes a new test locking in the arm64 default and the unique-token behavior.
- `browser-visit-sync-server` integration suite: **7/7 passed**, confirming the `gen-certs.sh` change is backward-compatible.
- Verified the production cert shape via `openssl` (SAN includes both the `--server-host` value and the original localhost entries).

## Notes
- The runbook documents the current manual laptop-enrollment path (build `enrolled_machines.db` locally, transfer via the existing S3 staging bucket + an SSM Session Manager shell), since there is no enroll-over-SSM subcommand yet — a reasonable future follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)