### PR TITLE
Automate Step 4: `manage_sync_server.py enroll` over SSM

### DIFF
--- a/browser-visit-logger/native-host/sync_client.py
+++ b/browser-visit-logger/native-host/sync_client.py
@@ -254,10 +254,16 @@ def replay_into_db(conn, raw: str) -> None:
     if tag in ('read', 'skimmed') and len(fields) >= 6:
         filename = fields[5]
         events_table = f'{tag}_events'
-        conn.execute(
+        cur = conn.execute(
             f"INSERT OR IGNORE INTO {events_table} (url, timestamp, filename) VALUES (?, ?, ?)",
             (url, timestamp, filename))
-        conn.execute(f"UPDATE visits SET {tag} = {tag} + 1 WHERE url = ?", (url,))
+        # Only bump the counter for a genuinely new event row.  The events
+        # PK is (url, timestamp), so replaying the same pulled line — e.g. a
+        # re-pull after a crash before the peer cursor advanced — IGNOREs the
+        # insert (rowcount 0) and must not double-count.  Mirrors
+        # host._insert_event's rowcount gate.
+        if cur.rowcount:
+            conn.execute(f"UPDATE visits SET {tag} = {tag} + 1 WHERE url = ?", (url,))
 
 
 # ----------------------------------------------------------------- grpc

--- a/browser-visit-logger/tests/test_sync_client.py
+++ b/browser-visit-logger/tests/test_sync_client.py
@@ -315,12 +315,15 @@ class FakeStub:
     def __init__(self, channel):
         self.pushes = []
         self.push_raises = False
+        self.push_fail_after = None   # raise once this many pushes have succeeded
         self.pull_chunks = []
         self.pull_raises = None
 
     def PushLogs(self, req, timeout=None):
         if self.push_raises:
             raise RuntimeError('push boom')
+        if self.push_fail_after is not None and len(self.pushes) >= self.push_fail_after:
+            raise RuntimeError('push boom (later batch)')
         self.pushes.append(req)
 
     def PullLogs(self, req, timeout=None):
@@ -411,6 +414,41 @@ def test_do_pull_applies_chunks(conn, env):
     assert sc.get_cursor(conn, 'peerB') == ('2026-05-21', 1)
     mirror = os.path.join(env.peers, 'peerB', 'browser-visits-2026-05-21.log')
     assert os.path.exists(mirror)
+
+
+def test_do_pull_replay_is_idempotent(conn, env):
+    # Re-pulling the same lines (e.g. a re-pull after a crash before the peer
+    # cursor was persisted) must NOT double-count the read counter.
+    chunk = Msg(peer_machine_id='peerB', lines=[
+        Msg(date='2026-05-21', line_offset=0,
+            raw_line='\t'.join(['rid', 'ts', 'https://x', 'T'])),
+        Msg(date='2026-05-21', line_offset=1,
+            raw_line='\t'.join(['rid', 't2', 'https://x', 'T', 'read', 'a.mhtml'])),
+    ])
+    stub = FakeStub(None)
+    stub.pull_chunks = [chunk]
+    sc.do_pull(conn, None, FakeSyncPb2(), FakeStubFactory(stub), 'm', 'h:1')
+    sc.do_pull(conn, None, FakeSyncPb2(), FakeStubFactory(stub), 'm', 'h:1')
+    assert conn.execute(
+        "SELECT read FROM visits WHERE url='https://x'").fetchone()[0] == 1
+    assert conn.execute(
+        "SELECT COUNT(*) FROM read_events WHERE url='https://x'").fetchone()[0] == 1
+
+
+def test_do_push_partial_failure_does_not_advance_cursor(conn, env):
+    # 501 lines → two PushLogs (500 + 1). The first batch is accepted, the
+    # second raises; the cursor must NOT advance, so the already-accepted
+    # lines re-push next run (PushLogs is idempotent server-side).
+    path = os.path.join(env.log_dir, 'browser-visits-2026-05-21.log')
+    with open(path, 'w') as f:
+        for i in range(501):
+            f.write(f'line{i}\n')
+    stub = FakeStub(None)
+    stub.push_fail_after = 1            # first push ok, second raises
+    with pytest.raises(RuntimeError):
+        sc.do_push(conn, None, FakeSyncPb2(), FakeStubFactory(stub), 'm', 'h:1')
+    assert len(stub.pushes) == 1                      # only the first batch sent
+    assert sc.get_cursor(conn, 'm') == ('', -1)       # cursor untouched
 
 
 def test_do_pull_sends_known_cursors(conn, env):

--- a/browser-visit-sync-server/README.md
+++ b/browser-visit-sync-server/README.md
@@ -191,27 +191,31 @@ caught it).
 First mint that laptop's client cert against the existing CA — without
 re-issuing anything — with `browser-visit-tools/gen-prod-certs --add-client
 <machine-id>` (see the [setup runbook](../docs/MULTI_LAPTOP_SETUP.md#adding-a-laptop-later-incremental-no-downtime)).
-Then record it on the VM (or wherever you have the `enrolled_machines.db`
-file the server is configured to read):
+Then record it on the VM with the `enroll` subcommand, which computes the
+cert fingerprint locally and writes the row in place over SSM (no file
+transfer, no restart):
 
 ```
-python3 ../browser-visit-tools/enroll_machine.py \
-    --db /var/lib/browser-visit-sync/enrolled_machines.db \
+python3 ../browser-visit-tools/manage_sync_server.py enroll \
     --machine-id <id-printed-by-install_laptop.sh> \
-    --cert /path/to/that-laptop-client.crt
+    --cert ~/.browser-visit-logger/ca/<id>.crt
 ```
 
-The script SHA-256s the cert's DER bytes and inserts a row.  At
-handshake time, the server's auth interceptor SHA-256s the peer's
-leaf cert and looks for the matching row — no match means
-`PermissionDenied` with no further detail (defense against
-enumeration).
+The fingerprint is the SHA-256 of the cert's DER bytes.  At handshake
+time, the server's auth interceptor SHA-256s the peer's leaf cert and
+looks for the matching row — no match means `PermissionDenied` with no
+further detail (defense against enumeration).  The server re-reads
+`enrolled_machines.db` on every request, so the change takes effect
+immediately.
 
 To list / revoke:
 ```
-python3 ../browser-visit-tools/enroll_machine.py --db ... --list
-python3 ../browser-visit-tools/enroll_machine.py --db ... --machine-id X --revoke
+python3 ../browser-visit-tools/manage_sync_server.py enroll --list
+python3 ../browser-visit-tools/manage_sync_server.py enroll --machine-id X --revoke
 ```
+
+The lower-level `enroll_machine.py` still edits an `enrolled_machines.db`
+file directly if you ever need that (e.g. seeding the integration tests).
 
 ## Integration tests
 

--- a/browser-visit-tools/README.md
+++ b/browser-visit-tools/README.md
@@ -340,6 +340,7 @@ make -C ../browser-visit-sync-server build-linux GOARCH=amd64   # or arm64
 | `status` | `systemctl is-active` + `status` |
 | `logs` | `journalctl` **snapshot** (`--lines`, `--since`); for a live tail use `aws ssm start-session` |
 | `health` | service active + gRPC port answers + disk under 90 % |
+| `enroll` | enrol (`--machine-id` + `--cert`), `--revoke`, or `--list` laptops in the server's `enrolled_machines.db` in place over SSM — fingerprint computed locally, no restart (the server re-reads the allowlist per request) |
 
 ```bash
 # First-boot setup (TLS material passed as local PEM paths)
@@ -352,6 +353,11 @@ python3 manage_sync_server.py deploy \
     --binary ../browser-visit-sync-server/bin/sync-server-linux-amd64
 python3 manage_sync_server.py start
 python3 manage_sync_server.py health
+
+# Enrol a laptop's cert (writes the VM's allowlist over SSM; no restart)
+python3 manage_sync_server.py enroll --machine-id laptop-a \
+    --cert ~/.browser-visit-logger/ca/laptop-a.crt
+python3 manage_sync_server.py enroll --list
 python3 manage_sync_server.py logs --lines 50
 ```
 

--- a/browser-visit-tools/manage_sync_server.py
+++ b/browser-visit-tools/manage_sync_server.py
@@ -18,6 +18,9 @@ Subcommands
     logs       journalctl snapshot (NOT a live tail — for follow, use
                `aws ssm start-session`)
     health     service active + gRPC port answers + disk ok
+    enroll     enrol / revoke / list a laptop in the server's
+               enrolled_machines.db, in place over SSM (no restart — the
+               server re-reads the allowlist on every request)
 
 The VM itself (and its AWS infra) is owned by the sibling
 ``manage_vm.py``.  Build the binary first with
@@ -28,10 +31,13 @@ Exit codes: 0 success, 1 remote/AWS failure, 2 usage.
 
 import argparse
 import hashlib
+import os
+import shlex
 import sys
 from pathlib import Path
 
 import _bvl_aws as aws
+import enroll_machine
 
 _HERE = Path(__file__).resolve().parent
 _UNIT_FILE = _HERE.parent / 'browser-visit-sync-server' / 'deploy' / \
@@ -42,6 +48,38 @@ _GOARCH = {'x86_64': 'amd64', 'arm64': 'arm64'}
 
 _DATA_DIR = '/var/lib/browser-visit-sync'
 _ETC_DIR = '/etc/browser-visit-sync'
+_ENROLLED_DB = f'{_DATA_DIR}/enrolled_machines.db'
+
+# Stdlib-only program run on the VM (Amazon Linux 2023 ships python3) to
+# mutate the server's allowlist in place.  argv: <db> <op> [machine_id] [fp].
+# The server re-reads enrolled_machines.db on every request, so no restart is
+# needed; busy_timeout rides out the brief lock the live server may hold.
+_ENROLL_PY = '''\
+import sqlite3, sys, datetime
+conn = sqlite3.connect(sys.argv[1])
+conn.execute("PRAGMA busy_timeout=5000")
+conn.execute("CREATE TABLE IF NOT EXISTS enrolled_machines ("
+             "machine_id TEXT PRIMARY KEY, cert_sha256 TEXT NOT NULL, "
+             "enrolled_at TEXT NOT NULL)")
+op = sys.argv[2]
+if op == "list":
+    rows = conn.execute("SELECT machine_id, cert_sha256, enrolled_at FROM "
+                        "enrolled_machines ORDER BY machine_id").fetchall()
+    for r in rows:
+        print("%-30s %s... %s" % (r[0], r[1][:16], r[2]))
+    print("(%d enrolled)" % len(rows))
+elif op == "revoke":
+    n = conn.execute("DELETE FROM enrolled_machines WHERE machine_id=?",
+                     (sys.argv[3],)).rowcount
+    conn.commit()
+    print("revoked %s (%d row(s))" % (sys.argv[3], n))
+else:
+    conn.execute("INSERT OR REPLACE INTO enrolled_machines VALUES (?,?,?)",
+                 (sys.argv[3], sys.argv[4],
+                  datetime.datetime.now(datetime.timezone.utc).isoformat()))
+    conn.commit()
+    print("enrolled %s" % sys.argv[3])
+'''
 
 
 def _surface(result):
@@ -214,10 +252,48 @@ def cmd_health(args):
                                    comment='bvl health'))
 
 
+def _enroll_remote(op, machine_id=None, fp=None):
+    """Shell lines that run the enrolled-DB ``op`` on the VM over SSM."""
+    argv = [_ENROLLED_DB, op]
+    if op == 'enroll':
+        argv += [machine_id, fp]
+    elif op == 'revoke':
+        argv += [machine_id]
+    quoted = ' '.join(shlex.quote(a) for a in argv)
+    lines = ['set -euo pipefail',
+             f'python3 -c {shlex.quote(_ENROLL_PY)} {quoted}']
+    if op != 'list':
+        # The write ran as root; keep the file owned by the service account.
+        lines.append(f'chown bvlsync:bvlsync {_ENROLLED_DB}')
+    return lines
+
+
+def cmd_enroll(args):
+    if args.list:
+        op, machine_id, fp = 'list', None, None
+    elif args.revoke:
+        if not args.machine_id:
+            print("error: --machine-id required to revoke", file=sys.stderr)
+            return 2
+        op, machine_id, fp = 'revoke', args.machine_id, None
+    else:
+        if not args.machine_id or not args.cert:
+            print("error: --machine-id and --cert required to enroll",
+                  file=sys.stderr)
+            return 2
+        op, machine_id = 'enroll', args.machine_id
+        fp = enroll_machine.cert_fingerprint(
+            Path(os.path.expanduser(args.cert)))
+    _region, ssm, instance_id = _ssm_target(args)
+    return _surface(aws.run_remote(
+        ssm, instance_id, _enroll_remote(op, machine_id, fp),
+        comment=f'bvl enroll {op}'))
+
+
 _DISPATCH = {
     'provision': cmd_provision, 'deploy': cmd_deploy, 'start': cmd_start,
     'stop': cmd_stop, 'restart': cmd_restart, 'status': cmd_status,
-    'logs': cmd_logs, 'health': cmd_health,
+    'logs': cmd_logs, 'health': cmd_health, 'enroll': cmd_enroll,
 }
 
 
@@ -257,6 +333,15 @@ def _build_parser():
     pl.add_argument('--lines', type=int, default=100,
                     help='number of log lines (default 100)')
     pl.add_argument('--since', help="journalctl --since value, e.g. '1 hour ago'")
+
+    pe = with_region(sub.add_parser(
+        'enroll', help='enrol / revoke / list laptops on the VM'))
+    pe.add_argument('--machine-id', help='laptop machine id (= its cert CN)')
+    pe.add_argument('--cert', help='laptop client cert (PEM or DER) to enrol')
+    pe.add_argument('--revoke', action='store_true',
+                    help='revoke --machine-id instead of enrolling')
+    pe.add_argument('--list', action='store_true',
+                    help='list the enrolled machines')
     return p
 
 

--- a/browser-visit-tools/tests/test_manage_sync_server.py
+++ b/browser-visit-tools/tests/test_manage_sync_server.py
@@ -293,6 +293,62 @@ def test_cmd_health(monkeypatch):
 
 
 # --------------------------------------------------------------------------
+# enroll / revoke / list
+# --------------------------------------------------------------------------
+
+def _enroll_args(**kw):
+    base = dict(action='enroll', region=None, machine_id=None, cert=None,
+                revoke=False, list=False)
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def test_enroll_inserts_fingerprint(monkeypatch, tmp_path):
+    import hashlib
+    cert = tmp_path / 'laptop-a.crt'
+    cert.write_bytes(b'DERBYTES')          # no PEM header → hashed as DER
+    fp = hashlib.sha256(b'DERBYTES').hexdigest()
+    runner, _ = _patch(monkeypatch)
+    assert mss.cmd_enroll(
+        _enroll_args(machine_id='laptop-a', cert=str(cert))) == 0
+    cmds = '\n'.join(runner.last_commands())
+    # the fingerprint is computed locally and the row written on the VM;
+    # no restart line — the server re-reads the DB live.
+    assert 'INSERT OR REPLACE' in cmds
+    assert 'laptop-a' in cmds and fp in cmds
+    assert f'chown bvlsync:bvlsync {mss._ENROLLED_DB}' in cmds
+    assert 'systemctl restart' not in cmds
+
+
+def test_enroll_requires_cert(monkeypatch, capsys):
+    _patch(monkeypatch)
+    assert mss.cmd_enroll(_enroll_args(machine_id='laptop-a')) == 2
+    assert 'required to enroll' in capsys.readouterr().err
+
+
+def test_enroll_revoke(monkeypatch):
+    runner, _ = _patch(monkeypatch)
+    assert mss.cmd_enroll(_enroll_args(revoke=True, machine_id='laptop-a')) == 0
+    cmds = '\n'.join(runner.last_commands())
+    assert 'DELETE FROM enrolled_machines' in cmds and 'laptop-a' in cmds
+    assert 'chown bvlsync:bvlsync' in cmds
+
+
+def test_enroll_revoke_requires_machine_id(monkeypatch, capsys):
+    _patch(monkeypatch)
+    assert mss.cmd_enroll(_enroll_args(revoke=True)) == 2
+    assert 'required to revoke' in capsys.readouterr().err
+
+
+def test_enroll_list_is_read_only(monkeypatch):
+    runner, _ = _patch(monkeypatch)
+    assert mss.cmd_enroll(_enroll_args(list=True)) == 0
+    cmds = '\n'.join(runner.last_commands())
+    assert 'SELECT machine_id' in cmds
+    assert 'chown' not in cmds              # list never writes
+
+
+# --------------------------------------------------------------------------
 # main dispatch + error + parser
 # --------------------------------------------------------------------------
 

--- a/docs/MULTI_LAPTOP_SETUP.md
+++ b/docs/MULTI_LAPTOP_SETUP.md
@@ -52,8 +52,10 @@ one of the laptops):
   (`make build-linux`). Alternatively build it in Docker via
   `browser-visit-sync-server/deploy/Dockerfile`.
 - **`openssl`** — to mint TLS material.
-- **The AWS Session Manager plugin** — for the one manual VM-shell step in
-  [Step 4](#step-4--enroll-each-laptop). Install:
+- **The AWS Session Manager plugin** (optional) — only for opening an
+  interactive VM shell (e.g. the live log tail in
+  [Day-2 operations](#day-2-operations)); the setup steps don't need it.
+  Install:
   <https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html>
 
 **On each laptop**: macOS with the Xcode command-line tools (Swift
@@ -285,45 +287,35 @@ for the on-disk layout and the systemd unit.
 ## Step 4 — Enroll each laptop
 
 The server only accepts a client cert whose SHA-256 is recorded in the VM's
-`/var/lib/browser-visit-sync/enrolled_machines.db`. There is no
-SSM subcommand for this yet, so enrollment is the one manual step: build the
-DB locally with `enroll_machine.py`, then place it on the VM using the
-infrastructure that's already there (the S3 staging bucket the deploy tool
-uses, plus an SSM Session Manager shell).
+`/var/lib/browser-visit-sync/enrolled_machines.db`. The `enroll` subcommand
+does this in place over SSM — it computes the cert's fingerprint locally and
+writes the row on the VM. No file transfer, no SSM shell, and **no restart**
+(the server re-reads the allowlist on every request):
 
 ```bash
 cd browser-visit-tools
-pip install cryptography     # enroll_machine.py needs it to read PEM certs
 
-# One row per laptop. machine-id must match the cert CN from Step 2.
-for id in laptop-a laptop-b; do
-    python3 enroll_machine.py --db ./enrolled_machines.db \
-        --machine-id "$id" \
-        --cert ~/.browser-visit-logger/ca/$id.crt
-done
-python3 enroll_machine.py --db ./enrolled_machines.db --list   # sanity-check
+# One per laptop. machine-id must match the cert CN from Step 2.
+python3 manage_sync_server.py enroll --machine-id laptop-a \
+    --cert ~/.browser-visit-logger/ca/laptop-a.crt
+python3 manage_sync_server.py enroll --machine-id laptop-b \
+    --cert ~/.browser-visit-logger/ca/laptop-b.crt
 
-# Transfer to the VM via the per-account staging bucket the deploy uses.
-ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
-REGION=us-west-2                                  # the VM's region
-BUCKET="bvl-sync-deploy-${ACCOUNT}-${REGION}"
-aws s3 cp ./enrolled_machines.db "s3://${BUCKET}/enrolled_machines.db" --sse
-
-# Open a shell on the VM (no SSH — this is SSM Session Manager) and install it.
-INSTANCE=$(python3 -c "import json,os;print(json.load(open(os.path.expanduser('~/.browser-visit-logger/vm.json')))['instance_id'])")
-aws ssm start-session --target "$INSTANCE"
-#   --- on the VM ---
-#   sudo aws s3 cp s3://<bucket>/enrolled_machines.db /var/lib/browser-visit-sync/enrolled_machines.db
-#   sudo chown bvlsync:bvlsync /var/lib/browser-visit-sync/enrolled_machines.db
-#   sudo systemctl restart sync-server
-#   exit
+python3 manage_sync_server.py enroll --list        # verify
 ```
 
-To add a laptop later, re-run `enroll_machine.py` (it's `INSERT OR REPLACE`,
-so existing rows are preserved) and repeat the transfer. To revoke one, use
-`enroll_machine.py --revoke` and re-transfer. See the `enroll_machine.py`
-section in
-[`browser-visit-tools/README.md`](../browser-visit-tools/README.md#enroll_machinepy).
+`enroll` is `INSERT OR REPLACE`, so re-running is safe and existing rows are
+preserved — that's also how you **add a laptop later** (mint its cert with
+`gen-prod-certs --add-client`, then one `enroll`). To cut a laptop off:
+
+```bash
+python3 manage_sync_server.py enroll --machine-id laptop-a --revoke
+```
+
+> Needs `cryptography` locally for the PEM→DER fingerprint
+> (`pip install cryptography`). The lower-level `enroll_machine.py` still
+> exists if you ever need to edit an `enrolled_machines.db` file directly; see
+> [`browser-visit-tools/README.md`](../browser-visit-tools/README.md#enroll_machinepy).
 
 ## Step 5 — Install on each laptop
 


### PR DESCRIPTION
## Summary

Automates the one remaining manual step in multi-laptop setup — **Step 4, enrolling each laptop**. Previously you built `enrolled_machines.db` locally, uploaded it via the S3 staging bucket, opened an SSM Session Manager shell, copied it onto the VM, `chown`ed it, and restarted the service. Now it's a one-liner.

## What's new

A `manage_sync_server.py enroll` subcommand that mutates the server's allowlist in place over SSM:

```bash
python3 manage_sync_server.py enroll --machine-id laptop-a --cert ~/.browser-visit-logger/ca/laptop-a.crt
python3 manage_sync_server.py enroll --list
python3 manage_sync_server.py enroll --machine-id laptop-a --revoke
```

- Computes the cert SHA-256 **locally** (reusing `enroll_machine.cert_fingerprint`), then runs a stdlib-`sqlite3` snippet on the VM (Amazon Linux 2023 ships `python3`) to `INSERT OR REPLACE` / `DELETE` / `SELECT`.
- **No restart**: `auth.Lookup` re-reads `enrolled_machines.db` on every request (proven by `TestLookupAfterRevoke`), so the change is live immediately. The write keeps the file owned by `bvlsync`; `busy_timeout` rides out the live server's brief read lock.
- No S3, no interactive shell — the data is tiny and fits in SSM command params.

`enroll_machine.py` stays as the lower-level direct-file tool (still used to seed the integration tests).

## Why it's safe to mutate the DB live
The production server runs on the EC2 host via systemd (the distroless/named-volume constraint was only the integration-test harness), so SSM can run `python3` against the real DB. The schema written exactly matches `enroll_machine.py` and the Go `auth.OpenEnrolled` DDL.

## Testing
- Tools suite **173 passed, 100% coverage** (gated) — 5 new tests covering enroll/revoke/list and the two arg-validation paths.
- Functionally exercised the embedded VM-side program against a temp DB (enroll → list → revoke → idempotent re-enroll), confirmed the schema matches, and verified the `python3 -c <shlex-quoted>` shell construction survives a real `bash` invocation.

## Docs
Runbook Step 4 rewritten to the one-liner (Session Manager plugin demoted to optional / Day-2 only); sync-server and tools READMEs updated to lead with `enroll`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)