### PR TITLE
Fix stale MCP schema test (add sync_state)

### DIFF
--- a/browser-visit-mcp/tests/test_server.py
+++ b/browser-visit-mcp/tests/test_server.py
@@ -132,7 +132,7 @@ def test_schema_lists_all_tables(seeded_db):
     out = server._do_schema(seeded_db)
     assert set(out['tables']) == {
         'visits', 'read_events', 'skimmed_events',
-        'snapshots', 'mover_errors',
+        'snapshots', 'mover_errors', 'sync_state',
     }
     assert 'CREATE TABLE' in out['ddl']
     assert 'visits' in out['ddl']


### PR DESCRIPTION
## Summary

`browser-visit-mcp`'s `test_schema_lists_all_tables` was **failing** — it asserted exactly five tables, but the canonical `browser-visit-logger/schema.sql` gained a `sync_state` table during the multi-laptop work and the test's expected set was never updated. (The MCP suite isn't in the routine dev loop, so it went unnoticed.)

This adds `sync_state` to the expected set. The test now passes and is *stronger* — it pins the full real schema, so a future table add/drop/rename is caught.

Found while auditing the repo's test suites. Unrelated to the in-flight multi-laptop / enroll work, hence a standalone PR.

## Testing
`pytest tests/ --cov=server` → **37 passed, server.py 100% coverage**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)