### PR TITLE
Fix IllegalLocationConstraintException: default region to vm.json

### DIFF
--- a/browser-visit-tools/manage_sync_server.py
+++ b/browser-visit-tools/manage_sync_server.py
@@ -100,9 +100,15 @@ def _surface(result):
 def _ssm_target(args):
     """Resolve the instance, build an SSM client, and wait for the agent
     to be Online.  Returns (region, ssm, instance_id)."""
-    region = aws.resolve_region(args.region)
+    state = aws.load_state()
+    # Fall back to the VM's recorded region so every client (ec2/ssm/s3)
+    # targets where the VM actually lives.  A region-less run otherwise
+    # leaves region=None, which poisons the staging-bucket name and makes
+    # CreateBucket fail with IllegalLocationConstraintException against the
+    # ambient (non-us-east-1) endpoint boto3 picks.
+    region = aws.resolve_region(args.region) or state.get('region')
     ec2 = aws.client('ec2', region)
-    instance_id = aws.resolve_instance_id(ec2, aws.load_state())
+    instance_id = aws.resolve_instance_id(ec2, state)
     ssm = aws.client('ssm', region)
     print(f"region={region or 'default'} instance={instance_id}")
     aws.wait_for_ssm_online(ssm, instance_id)

--- a/browser-visit-tools/tests/test_manage_sync_server.py
+++ b/browser-visit-tools/tests/test_manage_sync_server.py
@@ -352,6 +352,18 @@ def test_enroll_list_is_read_only(monkeypatch):
 # main dispatch + error + parser
 # --------------------------------------------------------------------------
 
+def test_region_defaults_to_vm_state(monkeypatch, tmp_path, capsys):
+    # No --region / BVL_AWS_REGION: fall back to the VM's recorded region so
+    # the ec2/ssm/s3 clients target where the VM lives.  Without it, region
+    # stays None and the staging bucket's CreateBucket fails with
+    # IllegalLocationConstraintException.
+    monkeypatch.delenv('BVL_AWS_REGION', raising=False)
+    _write_state(monkeypatch, tmp_path, region='us-west-2', instance_id='i-1')
+    _patch(monkeypatch)
+    assert mss.cmd_start(_args('start')) == 0
+    assert 'region=us-west-2' in capsys.readouterr().out
+
+
 def test_main_dispatch_start(monkeypatch):
     _patch(monkeypatch)
     assert mss.main(['start']) == 0


### PR DESCRIPTION
## Symptom
`manage_sync_server.py` (e.g. `provision`) fails with:
> `IllegalLocationConstraintException ... The unspecified location constraint is incompatible for the region specific endpoint this request was sent to` (on `CreateBucket`)

## Cause
Run without `--region` (and no `BVL_AWS_REGION`), `resolve_region` returns `None` — but boto3 still resolves the ambient region (e.g. `us-west-2`) for the real API calls. That `None` poisons the S3 staging step:
- the bucket name becomes `bvl-sync-deploy-<acct>-None`, and
- `_stage_clients` passes `region or 'us-east-1'` to `ensure_bucket`, so `CreateBucket` is sent **without** a `LocationConstraint` against the non-`us-east-1` endpoint → the error.

## Fix
`_ssm_target` now falls back to the region recorded in `vm.json` (written by `manage_vm.py create`), so every client (ec2/ssm/s3) targets where the VM actually lives and the bucket's `LocationConstraint` matches its endpoint. Explicit `--region` / `BVL_AWS_REGION` still take precedence. This also means you no longer need to pass `--region` at all for a VM created by this tooling.

## Testing
New `test_region_defaults_to_vm_state`; `browser-visit-tools` suite **174 passed, 100% coverage** (gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)