### PR TITLE
Fix InvocationDoesNotExist race in run_remote

### DIFF
--- a/browser-visit-tools/_bvl_aws.py
+++ b/browser-visit-tools/_bvl_aws.py
@@ -190,17 +190,26 @@ def run_remote(ssm, instance_id, commands, comment='', timeout=300,
     )
     command_id = sent['Command']['CommandId']
     deadline = monotonic() + timeout
+    status = 'pending'
     while True:
-        inv = ssm.get_command_invocation(
-            CommandId=command_id, InstanceId=instance_id)
-        status = inv.get('Status')
-        if status in _SSM_TERMINAL:
-            return RemoteResult(
-                status=status,
-                exit_code=inv.get('ResponseCode', -1),
-                stdout=inv.get('StandardOutputContent', ''),
-                stderr=inv.get('StandardErrorContent', ''),
-            )
+        try:
+            inv = ssm.get_command_invocation(
+                CommandId=command_id, InstanceId=instance_id)
+        except Exception as e:  # noqa: BLE001 - re-raised unless it's the race
+            # For a brief window after send_command the invocation isn't
+            # registered yet and SSM raises InvocationDoesNotExist; that's
+            # not a failure, so keep polling until it lands.
+            if error_code(e) != 'InvocationDoesNotExist':
+                raise
+        else:
+            status = inv.get('Status')
+            if status in _SSM_TERMINAL:
+                return RemoteResult(
+                    status=status,
+                    exit_code=inv.get('ResponseCode', -1),
+                    stdout=inv.get('StandardOutputContent', ''),
+                    stderr=inv.get('StandardErrorContent', ''),
+                )
         if monotonic() >= deadline:
             raise TimeoutError(
                 f"SSM command {command_id} still {status} after {timeout}s")

--- a/browser-visit-tools/tests/test_bvl_aws.py
+++ b/browser-visit-tools/tests/test_bvl_aws.py
@@ -174,7 +174,10 @@ class FakeSSM:
         return {'Command': {'CommandId': 'cmd-1'}}
 
     def get_command_invocation(self, **kw):
-        return self._invocations.pop(0)
+        item = self._invocations.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
 
 
 def _clock(values):
@@ -254,6 +257,25 @@ def test_run_remote_timeout():
     with pytest.raises(TimeoutError):
         aws.run_remote(ssm, 'i-1', ['c'], timeout=5,
                        sleep=lambda _s: None, monotonic=_clock([0, 99]))
+
+
+def test_run_remote_tolerates_invocation_not_yet_registered():
+    # Right after send_command, GetCommandInvocation raises
+    # InvocationDoesNotExist until the invocation lands — run_remote must
+    # keep polling, not crash.
+    ssm = FakeSSM(invocations=[
+        FakeError('InvocationDoesNotExist'), _inv('Success', 0, 'ok\n')])
+    res = aws.run_remote(ssm, 'i-1', ['c'],
+                         sleep=lambda _s: None, monotonic=_clock([0, 1]))
+    assert res.status == 'Success' and res.stdout == 'ok\n'
+
+
+def test_run_remote_reraises_other_invocation_error():
+    # Any other SSM error propagates (not swallowed as the registration race).
+    ssm = FakeSSM(invocations=[FakeError('AccessDeniedException')])
+    with pytest.raises(FakeError):
+        aws.run_remote(ssm, 'i-1', ['c'],
+                       sleep=lambda _s: None, monotonic=_clock([0]))
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Symptom
`manage_sync_server.py` (provision/deploy/enroll/…) fails with:
> `botocore.errorfactory.InvocationDoesNotExist ... when calling the GetCommandInvocation operation`

## Cause
`run_remote` polls `GetCommandInvocation` immediately after `SendCommand`. For a brief window the invocation isn't registered yet and SSM raises `InvocationDoesNotExist` — a well-known SSM race. The tool didn't catch it, so it propagated and aborted the op on first contact (and since the first poll is essentially always too fast, it fails ~every time, not intermittently).

## Fix
Catch `InvocationDoesNotExist` in the poll loop and keep polling until the invocation lands. Any other error still propagates immediately, and the existing timeout still bounds the wait (`status` defaults to `'pending'` for the timeout message if it never registers).

## Testing
Two regression tests — the retry-then-succeed path and the re-raise-other-errors path. `browser-visit-tools` suite **176 passed, 100% coverage** (gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)