### PR TITLE
docs(tools): pin AWS-tool runtime deps and document venv setup

### DIFF
--- a/browser-visit-tools/.gitignore
+++ b/browser-visit-tools/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 *.pyc
 .pytest_cache/
+.venv/
 .venv-test/
 .coverage
 coverage/

--- a/browser-visit-tools/README.md
+++ b/browser-visit-tools/README.md
@@ -19,6 +19,30 @@ into two groups:
   EC2 VM that hosts the sync-server, and remotely manage the server
   process over AWS SSM (no SSH).  Need `boto3` and AWS credentials.
 
+## Setup
+
+The read-only DB consumers (`reading_list.py`, `db_diff.py`) use only
+the standard library and need no install. The AWS tools (`manage_vm.py`,
+`manage_sync_server.py`) need `boto3`, and `enroll_machine.py`'s cert path
+needs `cryptography`. Both are listed in [`requirements.txt`](requirements.txt).
+
+Install them into a venv rather than the system Python:
+
+```bash
+python3 -m venv .venv
+.venv/bin/python -m pip install -r requirements.txt
+.venv/bin/python manage_sync_server.py health   # or: source .venv/bin/activate
+```
+
+A venv is recommended over `pip install --user`: Homebrew's `python3` is
+externally managed (PEP 668 blocks a plain `pip install`), and a `brew upgrade`
+that bumps the Python version wipes the global `site-packages`, silently
+removing previously-installed packages. The venv has its own `site-packages`
+that upgrades don't touch. `.venv/` is gitignored.
+
+(This is separate from the test venv under `.venv-test/`, which the `Makefile`
+manages — see [Development](#development).)
+
 ## CLI scripts
 
 All scripts live at the project root.  They share the same `BVL_*`
@@ -368,7 +392,8 @@ the VM's recorded arch unless you pass `--force`.  Exit codes: 0 ok,
 
 #### Prerequisites
 
-`boto3` (`pip install boto3`) and AWS credentials with, at minimum:
+`boto3` (see [Setup](#setup) — `pip install -r requirements.txt` into a venv)
+and AWS credentials with, at minimum:
 
 - EC2: `ec2:RunInstances`, `*Instances`, security-group create/authorize/delete,
   `ec2:DescribeImages`/`DescribeInstances`

--- a/browser-visit-tools/requirements.txt
+++ b/browser-visit-tools/requirements.txt
@@ -1,0 +1,9 @@
+# Runtime dependencies for the browser-visit-tools scripts.
+# Install into a venv (survives Homebrew Python upgrades):
+#   python3 -m venv .venv
+#   .venv/bin/python -m pip install -r requirements.txt
+#
+# boto3:        AWS SDK used by _bvl_aws.py (EC2/SSM control of the sync server).
+# cryptography: PEM/x509 handling in enroll_machine.py's cert path.
+boto3>=1.40
+cryptography>=42

--- a/docs/MULTI_LAPTOP_SETUP.md
+++ b/docs/MULTI_LAPTOP_SETUP.md
@@ -47,7 +47,18 @@ one of the laptops):
   — EC2 run/describe + security groups, IAM role/instance-profile create
   **including `iam:PassRole`**, SSM `SendCommand` + `StartSession`, S3 on the
   `bvl-sync-deploy-*` bucket, and STS.
-- **`boto3`** — `pip install boto3`.
+- **`boto3`** (and `cryptography`, for `enroll_machine.py`) — install into a
+  venv rather than the system Python. Homebrew's `python3` is externally
+  managed (PEP 668), and a `brew upgrade` that bumps the Python version wipes
+  the global `site-packages`, silently removing previously-installed packages:
+
+  ```bash
+  cd browser-visit-tools
+  python3 -m venv .venv
+  .venv/bin/python -m pip install -r requirements.txt
+  ```
+
+  See [Setup](../browser-visit-tools/README.md#setup) for details.
 - **Go 1.22+ and `protoc`** — to cross-compile the server binary
   (`make build-linux`). Alternatively build it in Docker via
   `browser-visit-sync-server/deploy/Dockerfile`.
@@ -62,7 +73,10 @@ one of the laptops):
 toolchain), Chrome/Chromium, and Python 3 (the system `python3` is fine).
 
 All `manage_*` commands below are run from the `browser-visit-tools/`
-directory.
+directory. They need the dependencies from the venv created above, so
+`python3` in every command means the venv's interpreter — either prefix the
+commands with `.venv/bin/` (e.g. `.venv/bin/python manage_vm.py status`) or
+run `source .venv/bin/activate` once and use `python3` as written.
 
 ### AWS credentials & permissions
 
@@ -312,8 +326,9 @@ preserved — that's also how you **add a laptop later** (mint its cert with
 python3 manage_sync_server.py enroll --machine-id laptop-a --revoke
 ```
 
-> Needs `cryptography` locally for the PEM→DER fingerprint
-> (`pip install cryptography`). The lower-level `enroll_machine.py` still
+> Needs `cryptography` locally for the PEM→DER fingerprint — already covered
+> by the venv install in [Prerequisites](#prerequisites)
+> (`requirements.txt`). The lower-level `enroll_machine.py` still
 > exists if you ever need to edit an `enrolled_machines.db` file directly; see
 > [`browser-visit-tools/README.md`](../browser-visit-tools/README.md#enroll_machinepy).
 
@@ -426,6 +441,13 @@ three phases: **(A)** getting AWS credentials to resolve, **(B)** getting the
 IAM permissions to create infra, and **(C)** the `RunInstances` call itself.
 
 ### A. AWS sign-in & credentials
+
+**`error: this tool requires boto3 (pip install boto3)`** (or
+`ModuleNotFoundError: No module named 'boto3'`) — you're running the tool with
+a Python that lacks the deps. Most often a `brew upgrade` bumped `python3` to a
+new version with an empty `site-packages`. Run it with the venv interpreter:
+`.venv/bin/python manage_sync_server.py …` (or `source .venv/bin/activate`
+first). Create the venv per [Prerequisites](#prerequisites) if you haven't.
 
 **`NoCredentialsError: Unable to locate credentials`** — boto3 found nothing
 in the chain. With SSO this almost always means either you haven't run


### PR DESCRIPTION
## Why

A Homebrew `brew upgrade` bumped the default `python3` to a new version and wiped its `site-packages`, dropping `boto3`. This broke `manage_sync_server.py health` (and the other AWS tools) with `error: this tool requires boto3`. The runtime deps were only ever installed ad-hoc, so nothing captured them and nothing documented how to install them durably.

## What

- **Add [`browser-visit-tools/requirements.txt`](../blob/docs/venv-setup-for-aws-tools/browser-visit-tools/requirements.txt)** capturing the runtime deps (`boto3`, `cryptography`) — previously only implicit (`requirements-test.txt` stays test-only).
- **Document a dedicated `.venv`** in the tools README with a new **Setup** section, explaining why a venv beats `pip install --user` (Homebrew Python is externally managed per PEP 668, and `brew upgrade` wipes the global `site-packages`).
- **Gitignore `.venv/`** (only `.venv-test/` was ignored).
- **`docs/MULTI_LAPTOP_SETUP.md`**: install deps into the venv, note that `python3` in the commands means the venv interpreter, point the `cryptography` step at the venv, and add a troubleshooting entry for the boto3-missing error.

Documentation and packaging only — no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)