### PR TITLE
fix(sync): make laptop multi-laptop sync actually run end to end

### DIFF
--- a/browser-visit-logger/README.md
+++ b/browser-visit-logger/README.md
@@ -623,9 +623,22 @@ activity within ~1 minute of any interaction.
 
 `BVLHost` (the Chrome native-messaging host) checks for
 `~/.browser-visit-logger/config.json` right after writing its
-response to Chrome.  If present, it `/bin/sh -c 'nohup python3
+response to Chrome.  If present, it `/bin/sh -c 'nohup <python>
 sync_client.py … &'` — fork+detach so Chrome isn't blocked on the
-network round-trip.  `sync_client.py` itself:
+network round-trip.  Two resolution details make this work without a
+source checkout on `PATH`:
+
+- **Script path** — `install.sh` bundles `sync_client.py` (and the
+  generated gRPC stubs) into the host `.app` under
+  `Contents/Resources/native-host/`, so `BVLHost` finds it via the
+  bundle; a dev fallback to the repo checkout is tried only if the
+  bundle copy is absent.
+- **Interpreter** (`resolveSyncPython`) — `BVL_PYTHON` if set, else the
+  grpcio venv at `~/.browser-visit-logger/sync-venv/bin/python` that
+  `install_laptop.sh` provisions, else bare `python3`.  The fallback
+  rarely has `grpcio`, so the venv is what actually lets sync connect.
+
+`sync_client.py` itself:
 
 1. Acquires `~/.browser-visit-logger/sync.lock` (flock) — drops out
    immediately if another sync is already running.

--- a/browser-visit-logger/install.sh
+++ b/browser-visit-logger/install.sh
@@ -219,6 +219,27 @@ if [[ "$OS" == "Darwin" ]]; then
     "$SWIFT_VERIFIER_BIN"
   HOST_BUNDLE_EXEC="$HOST_APP/Contents/MacOS/$HOST_APP_NAME"
   VERIFIER_BUNDLE_EXEC="$VERIFIER_APP/Contents/MacOS/$VERIFIER_APP_NAME"
+
+  # Bundle the multi-laptop sync client + its generated gRPC stubs into the
+  # host .app so BVLHost finds them via the bundle path — location-
+  # independent, with no dependency on a source checkout living at a
+  # guessed path.  Best-effort: the stubs only exist after `make proto-py`
+  # (install_laptop.sh runs it before this), so a plain single-laptop
+  # install simply bundles the client without stubs and never syncs.
+  HOST_RES_NATIVE="$HOST_APP/Contents/Resources/native-host"
+  mkdir -p "$HOST_RES_NATIVE"
+  cp "$NATIVE_DIR/sync_client.py" "$HOST_RES_NATIVE/"
+  STUBS_SRC="$SCRIPT_DIR/../browser-visit-sync-server/gen/syncpb_py"
+  if [[ -f "$STUBS_SRC/sync_pb2.py" ]]; then
+    mkdir -p "$HOST_RES_NATIVE/syncpb_py"
+    cp "$STUBS_SRC"/*.py "$HOST_RES_NATIVE/syncpb_py/"
+    info "Bundled sync_client.py + gRPC stubs into the host app."
+  else
+    info "No gRPC stubs at $STUBS_SRC — bundled sync_client.py without them (multi-laptop sync needs 'make proto-py')."
+  fi
+  # Adding Resources after build_app_bundle's codesign invalidates the
+  # signature; re-sign so the bundle keeps its TCC identity.
+  codesign --force --deep --sign - "$HOST_APP" 2>/dev/null
 else
   # On Linux there's no TCC, but the Swift port is macOS-only.  Linux
   # users would need to provide their own native-messaging host; for
@@ -326,7 +347,14 @@ if [[ "$OS" == "Darwin" ]]; then
   # ProgramArguments points at the verifier bundle's executable, not at
   # python3 directly, so launchd-spawned ticks attribute to the bundle's
   # TCC identity.
+  #
+  # Skipped when BVL_SKIP_VERIFIER=1 — set by install_laptop.sh for the
+  # multi-laptop architecture, where sealing/verification run on the EC2
+  # VM and the laptop must NOT carry its own verifier LaunchAgent.
   # ---------------------------------------------------------------------
+  if [[ "${BVL_SKIP_VERIFIER:-0}" == "1" ]]; then
+    info "BVL_SKIP_VERIFIER=1 — skipping verifier LaunchAgent (multi-laptop mode; verification runs on the VM)."
+  else
   VERIFIER_PLIST="$LAUNCHAGENTS_DIR/$VERIFIER_PLIST_LABEL.plist"
   mkdir -p "$LAUNCHAGENTS_DIR"
 
@@ -361,6 +389,7 @@ PYEOF
       2>/dev/null || true
     info "Kicked the verifier — accept the Files & Folders prompt if it appears."
   fi
+  fi  # end BVL_SKIP_VERIFIER guard
 else
   info "Verifier LaunchAgent is macOS-only; skipping on $OS."
 fi

--- a/browser-visit-logger/native-host/sync_client.py
+++ b/browser-visit-logger/native-host/sync_client.py
@@ -270,10 +270,20 @@ def replay_into_db(conn, raw: str) -> None:
 
 def _load_stubs():
     here = os.path.dirname(os.path.abspath(__file__))
-    gen = os.path.normpath(os.path.join(
-        here, '..', '..', 'browser-visit-sync-server', 'gen', 'syncpb_py'))
-    if gen not in sys.path:
-        sys.path.insert(0, gen)
+    # Candidate stub locations, in priority order:
+    #   1. colocated with this script — how install.sh bundles them into
+    #      the host .app (Resources/native-host/syncpb_py/), so the bundled
+    #      client is self-contained and location-independent.
+    #   2. the repo checkout's generated dir — dev / source runs after
+    #      `make proto-py`.
+    candidates = [
+        os.path.join(here, 'syncpb_py'),
+        os.path.normpath(os.path.join(
+            here, '..', '..', 'browser-visit-sync-server', 'gen', 'syncpb_py')),
+    ]
+    for gen in candidates:
+        if os.path.isdir(gen) and gen not in sys.path:
+            sys.path.insert(0, gen)
     import importlib
     try:
         sync_pb2 = importlib.import_module('sync_pb2')

--- a/browser-visit-logger/swift/Sources/BVLHost/main.swift
+++ b/browser-visit-logger/swift/Sources/BVLHost/main.swift
@@ -98,7 +98,7 @@ func maybeSpawnSync() {
         return
     }
 
-    let python = ProcessInfo.processInfo.environment["BVL_PYTHON"] ?? "python3"
+    let python = resolveSyncPython()
     let escaped = scriptPath.replacingOccurrences(of: "'", with: "'\\''")
     let cmd = "nohup \(python) '\(escaped)' >/dev/null 2>&1 &"
     let proc = Process()
@@ -114,6 +114,28 @@ func maybeSpawnSync() {
     } catch {
         log.error("Failed to spawn sync_client: \(error)")
     }
+}
+
+/// Pick the interpreter used to run `sync_client.py`.  `sync_client.py`
+/// needs the `grpcio` runtime, which the ambient `python3` (system or
+/// Homebrew) almost never has — so a bare `python3` fails at channel
+/// build and no sync ever reaches the server.  Resolution order:
+///   1. `BVL_PYTHON` override (tests / power users)
+///   2. the dedicated sync venv that `install_laptop.sh` provisions with
+///      grpcio at `~/.browser-visit-logger/sync-venv/bin/python`
+///   3. bare `python3` (last-resort; sync only works if grpcio happens to
+///      be importable there)
+func resolveSyncPython() -> String {
+    if let override = ProcessInfo.processInfo.environment["BVL_PYTHON"],
+       !override.isEmpty {
+        return override
+    }
+    let venvPython = (Paths.configDir as NSString)
+        .appendingPathComponent("sync-venv/bin/python")
+    if FileManager.default.fileExists(atPath: venvPython) {
+        return venvPython
+    }
+    return "python3"
 }
 
 /// Bundle layout (install.sh):

--- a/browser-visit-sync-server/Makefile
+++ b/browser-visit-sync-server/Makefile
@@ -1,7 +1,16 @@
-.PHONY: proto build build-linux test cover test-integration venv clean clean-venv
+.PHONY: proto proto-py build build-linux test cover test-integration venv clean clean-venv
 
-PROTO_DIR := proto
-GEN_DIR   := gen/syncpb
+PROTO_DIR  := proto
+GEN_DIR    := gen/syncpb
+GEN_PY_DIR := gen/syncpb_py
+
+# Interpreter used to build the Python-stub venv below.  Override if the
+# default python3 is too new for prebuilt grpcio-tools wheels (it would
+# otherwise fall back to a from-source build and fail), e.g.
+#   make proto-py PYTHON=python3.13
+PYTHON     ?= python3
+PROTO_VENV := gen/.venv-protoc
+PROTO_VPY  := $(PROTO_VENV)/bin/python
 
 # Python venv for the integration suite.  Lives inside test/ so it's
 # colocated with what uses it; gitignored.  Auto-created on first
@@ -20,6 +29,24 @@ proto:
 		--go_out=$(GEN_DIR) --go_opt=paths=source_relative \
 		--go-grpc_out=$(GEN_DIR) --go-grpc_opt=paths=source_relative \
 		$(PROTO_DIR)/sync.proto
+
+# Generate the *Python* gRPC stubs (sync_pb2, sync_pb2_grpc) that the
+# laptop sync client (browser-visit-logger/native-host/sync_client.py) and
+# browser-visit-tools/fetch_vm_snapshot.py import from gen/syncpb_py/.
+# Uses a dedicated, unpinned grpcio-tools venv so it picks up wheels for
+# the chosen PYTHON rather than the integration suite's pinned grpcio.
+proto-py: $(PROTO_VENV)/.installed
+	mkdir -p $(GEN_PY_DIR)
+	$(PROTO_VPY) -m grpc_tools.protoc \
+		-I $(PROTO_DIR) \
+		--python_out=$(GEN_PY_DIR) --grpc_python_out=$(GEN_PY_DIR) \
+		$(PROTO_DIR)/sync.proto
+
+$(PROTO_VENV)/.installed:
+	$(PYTHON) -m venv $(PROTO_VENV)
+	$(PROTO_VENV)/bin/pip install --upgrade pip
+	$(PROTO_VENV)/bin/pip install grpcio-tools
+	touch $(PROTO_VENV)/.installed
 
 build:
 	go build -o bin/sync-server ./cmd/sync-server

--- a/browser-visit-tools/install_laptop.sh
+++ b/browser-visit-tools/install_laptop.sh
@@ -5,12 +5,14 @@
 #   1. Run uninstall_laptop_legacy.sh first to remove the
 #      snapshot-verifier LaunchAgent (which now lives on the EC2 VM).
 #   2. Delegate to the existing browser-visit-logger/install.sh for
-#      the BVLHost + extension manifest.  install.sh has been updated
-#      to skip the verifier LaunchAgent on its own; we keep this
-#      wrapper to enforce the order and write the new sync config.
+#      the BVLHost + extension manifest, with BVL_SKIP_VERIFIER=1 so
+#      install.sh does not re-install the verifier LaunchAgent.
 #   3. Materialize ~/.browser-visit-logger/config.json with the
 #      machine_id (sanitized LocalHostName), and ensure mTLS material
 #      is in place under ~/.browser-visit-logger/tls/.
+#   4. Provision the sync runtime: a grpcio venv at
+#      ~/.browser-visit-logger/sync-venv (which BVLHost prefers when
+#      spawning sync_client.py) and the generated gRPC Python stubs.
 #
 # Usage:
 #   bash browser-visit-tools/install_laptop.sh
@@ -38,10 +40,50 @@ info() { echo "[install-laptop] $*"; }
 info "Step 1/3: removing legacy verifier LaunchAgent (if present)"
 bash "$SCRIPT_DIR/uninstall_laptop_legacy.sh"
 
-info "Step 2/3: running the upstream install.sh (BVLHost + extension)"
-bash "$REPO_ROOT/browser-visit-logger/install.sh"
+info "Step 2/4: provisioning the sync runtime (grpcio venv + gRPC stubs)"
+# sync_client.py needs the grpcio runtime plus generated Python stubs,
+# neither of which the ambient python3 provides.  Build a dedicated venv
+# the host prefers (see BVLHost.resolveSyncPython) and generate the stubs
+# the client imports.  Done BEFORE install.sh so install.sh can bundle the
+# stubs into the host .app.
+mkdir -p "$CONFIG_DIR"
+SYNC_VENV="$CONFIG_DIR/sync-venv"
+STUBS_DIR="$REPO_ROOT/browser-visit-sync-server/gen/syncpb_py"
 
-info "Step 3/3: writing machine config"
+# Pick an interpreter with prebuilt grpcio wheels.  A too-new python3
+# (e.g. 3.14) has no wheels yet and would trigger a failing source build,
+# so prefer a known-good minor.  Override with BVL_SYNC_PYTHON.
+pick_sync_python() {
+  if [[ -n "${BVL_SYNC_PYTHON:-}" ]]; then echo "$BVL_SYNC_PYTHON"; return; fi
+  for c in python3.13 python3.12 python3.11 python3; do
+    if command -v "$c" >/dev/null 2>&1; then echo "$c"; return; fi
+  done
+  echo python3
+}
+SYNC_PY_BOOT="$(pick_sync_python)"
+
+if [[ ! -x "$SYNC_VENV/bin/python" ]]; then
+  info "creating sync venv at $SYNC_VENV (using $SYNC_PY_BOOT)"
+  "$SYNC_PY_BOOT" -m venv "$SYNC_VENV"
+fi
+"$SYNC_VENV/bin/pip" install --quiet --upgrade pip
+"$SYNC_VENV/bin/pip" install --quiet grpcio grpcio-tools
+
+info "generating gRPC Python stubs into $STUBS_DIR"
+mkdir -p "$STUBS_DIR"
+"$SYNC_VENV/bin/python" -m grpc_tools.protoc \
+  -I "$REPO_ROOT/browser-visit-sync-server/proto" \
+  --python_out="$STUBS_DIR" --grpc_python_out="$STUBS_DIR" \
+  "$REPO_ROOT/browser-visit-sync-server/proto/sync.proto"
+info "sync runtime ready (interpreter: $SYNC_VENV/bin/python)"
+
+info "Step 3/4: running the upstream install.sh (BVLHost + extension)"
+# Multi-laptop mode runs sealing/verification on the EC2 VM, so the laptop
+# must not install its own verifier LaunchAgent.  install.sh also bundles
+# sync_client.py + the stubs generated above into the host .app.
+BVL_SKIP_VERIFIER=1 bash "$REPO_ROOT/browser-visit-logger/install.sh"
+
+info "Step 4/4: writing machine config"
 mkdir -p "$CONFIG_DIR" "$TLS_DIR"
 chmod 700 "$TLS_DIR"
 

--- a/docs/MULTI_LAPTOP_SETUP.md
+++ b/docs/MULTI_LAPTOP_SETUP.md
@@ -59,7 +59,13 @@ one of the laptops):
   <https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html>
 
 **On each laptop**: macOS with the Xcode command-line tools (Swift
-toolchain), Chrome/Chromium, and Python 3 (the system `python3` is fine).
+toolchain), Chrome/Chromium, and Python 3. The sync client needs a Python
+with prebuilt `grpcio` wheels — `install_laptop.sh` (Step 5) builds a
+dedicated venv for it and auto-picks a suitable interpreter
+(`python3.13` → `3.12` → `3.11`, else `python3`). The system `python3` is
+fine; a very new Homebrew `python3` (e.g. 3.14) may have no wheels yet and
+trigger a failing source build — override with
+`BVL_SYNC_PYTHON=/path/to/python3.13`.
 
 All `manage_*` commands below are run from the `browser-visit-tools/`
 directory.
@@ -319,10 +325,19 @@ python3 manage_sync_server.py enroll --machine-id laptop-a --revoke
 
 ## Step 5 — Install on each laptop
 
-On every laptop, run the multi-laptop installer pointed at the VM. It runs
-the upstream `install.sh` (builds/signs the native host, installs the Chrome
-manifest) and writes `~/.browser-visit-logger/config.json` with this
-laptop's `machine_id` and the sync endpoint.
+On every laptop, run the multi-laptop installer pointed at the VM. It:
+
+- **provisions the sync runtime** — a dedicated grpcio venv at
+  `~/.browser-visit-logger/sync-venv` and the generated gRPC Python stubs
+  (the bare `python3` the host would otherwise use lacks `grpcio`, so sync
+  would silently never connect);
+- **runs the upstream `install.sh`** (builds/signs the native host — which
+  now also bundles the sync client + stubs into the app so the host can
+  always find them — and installs the Chrome manifest), with the verifier
+  LaunchAgent **skipped** (`BVL_SKIP_VERIFIER=1`; sealing and verification
+  run on the VM in multi-laptop mode);
+- **writes `~/.browser-visit-logger/config.json`** with this laptop's
+  `machine_id` and the sync endpoint.
 
 ```bash
 bash browser-visit-tools/install_laptop.sh --server <vm-dns-or-ip>:50443
@@ -391,6 +406,28 @@ Files & Folders (TCC) prompts the first time you tag a page.
    ```bash
    sqlite3 ~/browser-visits.db 'SELECT url FROM visits ORDER BY rowid DESC LIMIT 5;'
    ```
+
+> **Telling whether the laptop side is actually syncing** — two local
+> signals, independent of any server/AWS access:
+>
+> ```bash
+> # The per-machine sync cursor: last_sync_success_at should advance and
+> # last_error stay empty within ~60s of an interaction.
+> sqlite3 ~/browser-visits.db \
+>   "SELECT machine_id, last_sync_success_at, last_error FROM sync_state;"
+>
+> # The host must actually spawn the client — this should NOT print
+> # "skipping spawn" (which means it can't find sync_client.py).
+> grep sync_client ~/browser-visits-host.log | tail -3
+> ```
+>
+> No `sync_state` table at all means the client has never run. To force a
+> sync by hand (look for `sync ok`):
+>
+> ```bash
+> ~/.browser-visit-logger/sync-venv/bin/python \
+>   browser-visit-logger/native-host/sync_client.py --force
+> ```
 
 You can also diff a laptop against a fresh VM snapshot with
 `fetch_vm_snapshot.py` + `db_diff.py` — see


### PR DESCRIPTION
## Summary

Multi-laptop sync never reached the EC2 sync-server on a freshly-installed laptop — the server log stayed empty because nothing ever connected. Root cause was **two independent bugs**, both upstream of the server:

1. **BVLHost never spawned `sync_client.py`.** The host `.app` bundle didn't carry the script, and the dev-fallback path (`~/projects/browser-visit-logger/native-host/…`) omitted the repo's extra nesting level — so every Chrome interaction logged `sync_client.py not found … skipping spawn`.
2. **Even when found, the client died at channel build.** The Python gRPC stubs were never generated (the advertised `make proto-py` target did not exist), and `grpcio` wasn't installed for any `python3` the host invokes.

Net effect: sync had never run on a laptop (no `sync_state` table in the local DB).

## Changes

- **`Makefile`** — add a real `proto-py` target that generates the Python gRPC stubs into `gen/syncpb_py` via a dedicated `grpcio-tools` venv (`PYTHON` overridable for interpreters lacking prebuilt wheels).
- **`sync_client.py`** — `_load_stubs` also looks for stubs colocated with the script, so a bundled copy is self-contained.
- **`main.swift`** — new `resolveSyncPython()` prefers the grpcio venv at `~/.browser-visit-logger/sync-venv` over the bare `python3` that lacks grpcio.
- **`install.sh`** — bundle `sync_client.py` + the generated stubs into the host `.app` (and re-sign), and honor `BVL_SKIP_VERIFIER=1` to skip installing the verifier LaunchAgent.
- **`install_laptop.sh`** — provision the grpcio venv and generate stubs **before** delegating to `install.sh` (so they get bundled), pass `BVL_SKIP_VERIFIER=1`, and remove the leftover verifier (multi-laptop verification runs on the VM).

## Verification

- `make proto-py` generates importable stubs; both shell scripts pass `bash -n`; `swift build` is clean.
- Re-ran `install_laptop.sh` on a real laptop: the host bundle now contains the client + stubs, the verifier LaunchAgent is gone, and the bundled client run with the venv interpreter reports `sync ok` (cursor advanced — server acked the backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)