### PR TITLE
VM Google Drive mount + account-qualified archive path (#47)

### DIFF
--- a/browser-visit-logger/README.md
+++ b/browser-visit-logger/README.md
@@ -799,7 +799,8 @@ env vars; env vars override defaults.
 | `BVL_VERIFIER_LOG` | `~/browser-visits-verifier.log` | reset (verifier writes via LaunchAgent stdout/stderr) |
 | `BVL_DB_FILE` | `~/browser-visits.db` | host, verifier, sealer, rebuilder, reset |
 | `BVL_DOWNLOADS_SNAPSHOTS_DIR` | `~/Downloads/browser-visit-snapshots` | host (synchronous archive source), verifier (sweep source), reset |
-| `BVL_GDRIVE_SNAPSHOTS_DIR` | `~/Library/CloudStorage/GoogleDrive/My Drive/browser-visit-logger/snapshots` | host (multi-laptop archive destination); preferred over the legacy name below |
+| `BVL_GDRIVE_SNAPSHOTS_DIR` | `~/Library/CloudStorage/GoogleDrive-<account>/My Drive/browser-visit-logger/snapshots` | host (multi-laptop archive destination); preferred over the legacy name below. `<account>` comes from `BVL_GDRIVE_ACCOUNT` or `gdrive_account` in `~/.browser-visit-logger/config.json` |
+| `BVL_GDRIVE_ACCOUNT` | (none) | host — the Google account that names the local `GoogleDrive-<account>` mount; recorded by `install_laptop.sh`. Only used to build the default above when `BVL_GDRIVE_SNAPSHOTS_DIR` is unset |
 | `BVL_ICLOUD_SNAPSHOTS_DIR` | (same default as above, when `BVL_GDRIVE_SNAPSHOTS_DIR` unset) | host, verifier, sealer, rebuilder — alias retained for backwards compat |
 | `BVL_MOVER_MIN_AGE_SECONDS` | `60` | verifier (sweep age threshold) |
 | `BVL_MOVER_ERROR_THRESHOLD` | `3` | verifier + sync_client (consecutive failures before persistent-error notification) |

--- a/browser-visit-logger/swift/Sources/BVLCore/Archive.swift
+++ b/browser-visit-logger/swift/Sources/BVLCore/Archive.swift
@@ -52,12 +52,16 @@ public enum Archive {
         _ db: Database, source: String, basename: String,
         dateStr: String, log: HostLog?
     ) {
-        let dateSubdir = (Paths.icloudSnapshotsDir as NSString)
-            .appendingPathComponent(dateStr)
-        let dest = (dateSubdir as NSString).appendingPathComponent(basename)
-
         do {
-            // (a) Ensure the date subdir exists.
+            // (a) Resolve the archive root and ensure the date subdir
+            //     exists.  archiveSnapshotsDir() throws when the Google
+            //     Drive mount is unconfigured/absent rather than naming a
+            //     local-only path — so an un-synced destination surfaces
+            //     as a recorded `move` error and the source is preserved
+            //     (the catch below skips the unlink at step (g)).
+            let dateSubdir = (try Paths.archiveSnapshotsDir() as NSString)
+                .appendingPathComponent(dateStr)
+            let dest = (dateSubdir as NSString).appendingPathComponent(basename)
             try FileManager.default.createDirectory(
                 atPath: dateSubdir, withIntermediateDirectories: true)
             // (b) Copy source → dest.  shutil.copy2 preserves mtime; we

--- a/browser-visit-logger/swift/Sources/BVLCore/OrphanLog.swift
+++ b/browser-visit-logger/swift/Sources/BVLCore/OrphanLog.swift
@@ -34,6 +34,14 @@ public enum OrphanLog {
     public static func mergePass(_ db: Database, log: HostLog?) {
         let dir = Paths.logDir
         guard FileManager.default.fileExists(atPath: dir) else { return }
+        let archiveRoot: String
+        do {
+            archiveRoot = try Paths.archiveSnapshotsDir()
+        } catch {
+            log?.error("orphan-log-merge: archive root unavailable: \(error); "
+                       + "skipping pass")
+            return
+        }
         let todayISO = todayUTCString()
 
         let entries: [String]
@@ -51,7 +59,7 @@ public enum OrphanLog {
                   dateISO < todayISO
             else { continue }
             let src = (dir as NSString).appendingPathComponent(entry)
-            let dateSubdir = (Paths.icloudSnapshotsDir as NSString)
+            let dateSubdir = (archiveRoot as NSString)
                 .appendingPathComponent(dateISO)
             let dst = (dateSubdir as NSString).appendingPathComponent(entry)
 

--- a/browser-visit-logger/swift/Sources/BVLCore/Paths.swift
+++ b/browser-visit-logger/swift/Sources/BVLCore/Paths.swift
@@ -45,26 +45,43 @@ public enum Paths {
     ///
     /// The default is built under the macOS Google Drive mount, which is
     /// named `GoogleDrive-<account>` (e.g.
-    /// `GoogleDrive-jane@gmail.com`) — NOT a bare `GoogleDrive`.  The
-    /// account is resolved via `gdriveAccount()`; if it is unknown we
-    /// fall back to the unqualified `GoogleDrive`, which will almost
-    /// certainly be wrong, so `install_laptop.sh` records the account in
-    /// the machine config at install time.
-    public static var archiveSnapshotsDir: String {
+    /// `GoogleDrive-jane@gmail.com`) — NOT a bare `GoogleDrive`.  We do
+    /// NOT fall back to the unqualified name when the account is unknown:
+    /// that directory isn't a Drive mount, so archiving into it would
+    /// strand snapshots in a local-only tree Google Drive never syncs
+    /// (and the mover would then delete the staged source — silent data
+    /// loss).  Instead this throws `PathsError.gdriveArchiveUnconfigured`
+    /// so callers fail safely: the mover records a `mover_errors` row and
+    /// leaves the source staged for the next pass; read/verify passes
+    /// skip.  The account is recorded by `install_laptop.sh` in the
+    /// machine config; `BVL_GDRIVE_ACCOUNT` overrides it.
+    ///
+    /// When the account-derived mount is required, its `.../My Drive`
+    /// base must already exist (Google Drive creates it) — we only ever
+    /// create subdirectories under it.  If it's absent (Drive signed
+    /// out, or a stale/wrong account) this also throws rather than
+    /// fabricating the tree.  An explicit `BVL_GDRIVE_SNAPSHOTS_DIR`
+    /// override is trusted as-is (tests, custom setups) and not checked.
+    public static func archiveSnapshotsDir() throws -> String {
         if let v = ProcessInfo.processInfo.environment["BVL_GDRIVE_SNAPSHOTS_DIR"] {
             return v
         }
         if let v = ProcessInfo.processInfo.environment["BVL_ICLOUD_SNAPSHOTS_DIR"] {
             return v
         }
-        let cloudDir: String
-        if let account = gdriveAccount(), !account.isEmpty {
-            cloudDir = "GoogleDrive-\(account)"
-        } else {
-            cloudDir = "GoogleDrive"
+        guard let account = gdriveAccount(), !account.isEmpty else {
+            throw PathsError.gdriveArchiveUnconfigured
         }
-        return (home as NSString).appendingPathComponent(
-            "Library/CloudStorage/\(cloudDir)/My Drive/browser-visit-logger/snapshots")
+        let mountBase = (home as NSString).appendingPathComponent(
+            "Library/CloudStorage/GoogleDrive-\(account)/My Drive")
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: mountBase, isDirectory: &isDir),
+              isDir.boolValue
+        else {
+            throw PathsError.gdriveMountMissing(mountBase)
+        }
+        return (mountBase as NSString)
+            .appendingPathComponent("browser-visit-logger/snapshots")
     }
 
     /// The user's Google account that names the local Drive mount
@@ -73,8 +90,7 @@ public enum Paths {
     ///   2. `gdrive_account` field in `machineConfigFile` — the durable
     ///      channel that reaches the Chrome-spawned host, which inherits
     ///      no BVL_* environment.
-    /// Returns nil when unknown (callers fall back to the unqualified
-    /// mount name).
+    /// Returns nil when unknown.
     public static func gdriveAccount() -> String? {
         if let env = ProcessInfo.processInfo.environment["BVL_GDRIVE_ACCOUNT"],
            !env.isEmpty {
@@ -92,10 +108,6 @@ public enum Paths {
         return account
     }
 
-    /// Deprecated alias; new code should call `archiveSnapshotsDir`.
-    /// Retained because external Swift callers may still reference it
-    /// during the transition.
-    public static var icloudSnapshotsDir: String { archiveSnapshotsDir }
 
     public static var moverErrorThreshold: Int {
         Int(env("BVL_MOVER_ERROR_THRESHOLD", "3")) ?? 3
@@ -220,5 +232,32 @@ public enum Paths {
     /// Marker file written when we can't reach Notification Center.
     public static var attentionFile: String {
         (home as NSString).appendingPathComponent("browser-visits-mover-needs-attention")
+    }
+}
+
+/// Raised by `Paths.archiveSnapshotsDir()` when it cannot resolve a real,
+/// cloud-synced Google Drive archive root.  Callers treat this as a
+/// recorded error (mover) or a skipped pass (verifier), never as a
+/// reason to fabricate a local-only directory.
+public enum PathsError: Error, CustomStringConvertible {
+    /// No `BVL_GDRIVE_SNAPSHOTS_DIR` override and no Google account to
+    /// build the `GoogleDrive-<account>` mount path from.
+    case gdriveArchiveUnconfigured
+    /// The account is known but its `.../My Drive` mount is absent
+    /// (Drive signed out, or a stale/wrong account).
+    case gdriveMountMissing(String)
+
+    public var description: String {
+        switch self {
+        case .gdriveArchiveUnconfigured:
+            return "Google Drive snapshot archive is not configured: set the "
+                + "account with `install_laptop.sh --gdrive-account <you>` "
+                + "(or the BVL_GDRIVE_ACCOUNT / BVL_GDRIVE_SNAPSHOTS_DIR env "
+                + "vars). Refusing to archive into a non-synced local path."
+        case .gdriveMountMissing(let base):
+            return "Google Drive mount \(base) does not exist: is Drive signed "
+                + "in for this account? Refusing to archive into a non-synced "
+                + "local path."
+        }
     }
 }

--- a/browser-visit-logger/swift/Sources/BVLCore/Paths.swift
+++ b/browser-visit-logger/swift/Sources/BVLCore/Paths.swift
@@ -42,6 +42,14 @@ public enum Paths {
     /// the preferred env var; `BVL_ICLOUD_SNAPSHOTS_DIR` is honored as
     /// an alias for backwards compatibility with existing installs and
     /// tests.
+    ///
+    /// The default is built under the macOS Google Drive mount, which is
+    /// named `GoogleDrive-<account>` (e.g.
+    /// `GoogleDrive-jane@gmail.com`) — NOT a bare `GoogleDrive`.  The
+    /// account is resolved via `gdriveAccount()`; if it is unknown we
+    /// fall back to the unqualified `GoogleDrive`, which will almost
+    /// certainly be wrong, so `install_laptop.sh` records the account in
+    /// the machine config at install time.
     public static var archiveSnapshotsDir: String {
         if let v = ProcessInfo.processInfo.environment["BVL_GDRIVE_SNAPSHOTS_DIR"] {
             return v
@@ -49,8 +57,39 @@ public enum Paths {
         if let v = ProcessInfo.processInfo.environment["BVL_ICLOUD_SNAPSHOTS_DIR"] {
             return v
         }
+        let cloudDir: String
+        if let account = gdriveAccount(), !account.isEmpty {
+            cloudDir = "GoogleDrive-\(account)"
+        } else {
+            cloudDir = "GoogleDrive"
+        }
         return (home as NSString).appendingPathComponent(
-            "Library/CloudStorage/GoogleDrive/My Drive/browser-visit-logger/snapshots")
+            "Library/CloudStorage/\(cloudDir)/My Drive/browser-visit-logger/snapshots")
+    }
+
+    /// The user's Google account that names the local Drive mount
+    /// (`GoogleDrive-<account>`).  Resolution order:
+    ///   1. `BVL_GDRIVE_ACCOUNT` env var (tests / recovery / overrides).
+    ///   2. `gdrive_account` field in `machineConfigFile` — the durable
+    ///      channel that reaches the Chrome-spawned host, which inherits
+    ///      no BVL_* environment.
+    /// Returns nil when unknown (callers fall back to the unqualified
+    /// mount name).
+    public static func gdriveAccount() -> String? {
+        if let env = ProcessInfo.processInfo.environment["BVL_GDRIVE_ACCOUNT"],
+           !env.isEmpty {
+            return env
+        }
+        return readGDriveAccountFromConfig()
+    }
+
+    private static func readGDriveAccountFromConfig() -> String? {
+        guard let data = FileManager.default.contents(atPath: machineConfigFile),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let account = obj["gdrive_account"] as? String,
+              !account.isEmpty
+        else { return nil }
+        return account
     }
 
     /// Deprecated alias; new code should call `archiveSnapshotsDir`.

--- a/browser-visit-logger/swift/Sources/BVLCore/Seal.swift
+++ b/browser-visit-logger/swift/Sources/BVLCore/Seal.swift
@@ -44,6 +44,13 @@ public enum Seal {
         _ db: Database, dryRun: Bool = false, log: HostLog?
     ) {
         let today = todayUTCString()
+        let archiveRoot: String
+        do {
+            archiveRoot = try Paths.archiveSnapshotsDir()
+        } catch {
+            log?.error("Seal: archive root unavailable: \(error); skipping pass")
+            return
+        }
         let dates: [String]
         do {
             dates = try db.queryAll("""
@@ -56,7 +63,7 @@ public enum Seal {
             return
         }
         for date in dates {
-            let subdir = (Paths.icloudSnapshotsDir as NSString)
+            let subdir = (archiveRoot as NSString)
                 .appendingPathComponent(date)
             // The seal pass tolerates a missing date subdir — covers
             // activity-only days (host-inserted snapshots row, no

--- a/browser-visit-logger/swift/Sources/BVLCore/Sweep.swift
+++ b/browser-visit-logger/swift/Sources/BVLCore/Sweep.swift
@@ -62,8 +62,10 @@ public enum Sweep {
             }
 
             if dryRun {
+                let root = (try? Paths.archiveSnapshotsDir())
+                    ?? "(archive unconfigured)"
                 log?.info("[dry-run] would move \(source) -> "
-                          + "\(Paths.icloudSnapshotsDir)/\(dateStr)/\(name)")
+                          + "\(root)/\(dateStr)/\(name)")
                 continue
             }
             Archive.moveOne(

--- a/browser-visit-logger/swift/Sources/BVLVerifier/main.swift
+++ b/browser-visit-logger/swift/Sources/BVLVerifier/main.swift
@@ -185,13 +185,15 @@ let log = HostLog(path: ProcessInfo.processInfo.environment["BVL_VERIFIER_LOG"]
                        ?? Paths.hostLog)
 
 func resolveTarget(_ arg: String) -> String {
-    // Bare 'YYYY-MM-DD' joins under ICLOUD_SNAPSHOTS_DIR; anything
-    // that looks like a path (absolute, or contains a separator) is
-    // used verbatim.
+    // Bare 'YYYY-MM-DD' joins under the archive root; anything that looks
+    // like a path (absolute, or contains a separator) is used verbatim.
     if (arg as NSString).isAbsolutePath || arg.contains("/") {
         return arg
     }
-    return (Paths.icloudSnapshotsDir as NSString).appendingPathComponent(arg)
+    // If the archive root is unconfigured, fall back to the bare arg so
+    // the caller reports a clear "No such directory" rather than crashing.
+    guard let root = try? Paths.archiveSnapshotsDir() else { return arg }
+    return (root as NSString).appendingPathComponent(arg)
 }
 
 func verifyOne(target: String, opts: CLIOptions) -> Int32 {
@@ -237,9 +239,16 @@ func verifyAllSealed(
         if !quiet { print("No sealed directories to verify.") }
         return true
     }
+    let archiveRoot: String
+    do {
+        archiveRoot = try Paths.archiveSnapshotsDir()
+    } catch {
+        log.error("verify-all: archive root unavailable: \(error)")
+        return false
+    }
     var anyFailed = false
     for date in dates {
-        let target = (Paths.icloudSnapshotsDir as NSString)
+        let target = (archiveRoot as NSString)
             .appendingPathComponent(date)
         if !FileManager.default.fileExists(atPath: target) {
             // Already covered by the seal pass's missing_directory error.
@@ -287,12 +296,16 @@ func printResult(target: String, result: VerifyResult, quiet: Bool) {
 
 func runTick(opts: CLIOptions) -> Int32 {
     do {
+        // Resolve the archive root first; archiveSnapshotsDir() throws
+        // when the Google Drive mount is unconfigured/absent, so we never
+        // create a local-only tree Drive won't sync.  We create only our
+        // own subdirectory under the (pre-existing) Drive mount.
+        let archiveRoot = try Paths.archiveSnapshotsDir()
         try FileManager.default.createDirectory(
-            atPath: Paths.icloudSnapshotsDir,
-            withIntermediateDirectories: true)
+            atPath: archiveRoot, withIntermediateDirectories: true)
     } catch {
         FileHandle.standardError.write(Data(
-            "Could not create iCloud snapshots dir \(Paths.icloudSnapshotsDir): \(error)\n".utf8))
+            "Could not prepare snapshots archive: \(error)\n".utf8))
         return 1
     }
     if !FileManager.default.fileExists(atPath: Paths.dbFile) {

--- a/browser-visit-sync-server/deploy/gdrive-snapshots.service
+++ b/browser-visit-sync-server/deploy/gdrive-snapshots.service
@@ -8,7 +8,10 @@ Wants=network-online.target
 # Type=notify: rclone signals readiness once the FUSE mount is live, so units
 # ordered After= this one (e.g. the snapshot verifier) don't race the mount.
 Type=notify
-ExecStart=/usr/bin/rclone mount gdrive:snapshots /mnt/gdrive-snapshots \
+# Mounts the remote root, which the rclone.conf pins to the shared `snapshots`
+# folder via root_folder_id.  Least privilege: the service account is shared
+# only that folder, so the mount can see nothing else in the user's Drive.
+ExecStart=/usr/bin/rclone mount gdrive: /mnt/gdrive-snapshots \
   --config /etc/browser-visit-sync/rclone.conf \
   --dir-cache-time 1m \
   --vfs-cache-mode writes \

--- a/browser-visit-sync-server/deploy/gdrive-snapshots.service
+++ b/browser-visit-sync-server/deploy/gdrive-snapshots.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=rclone mount of the Google Drive snapshot archive
+Documentation=https://github.com/theimer/browser-visit-logger/issues/47
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+# Type=notify: rclone signals readiness once the FUSE mount is live, so units
+# ordered After= this one (e.g. the snapshot verifier) don't race the mount.
+Type=notify
+ExecStart=/usr/bin/rclone mount gdrive:snapshots /mnt/gdrive-snapshots \
+  --config /etc/browser-visit-sync/rclone.conf \
+  --dir-cache-time 1m \
+  --vfs-cache-mode writes \
+  --umask 002
+ExecStop=/bin/fusermount3 -u /mnt/gdrive-snapshots
+Restart=on-failure
+RestartSec=10s
+# Runs as the same service account as sync-server so the mounted tree is owned
+# by (and readable/writable to) the account the verifier will run under. The
+# mountpoint itself is created and chowned to bvlsync by `provision-drive`.
+User=bvlsync
+Group=bvlsync
+
+[Install]
+WantedBy=multi-user.target

--- a/browser-visit-tools/README.md
+++ b/browser-visit-tools/README.md
@@ -241,13 +241,13 @@ it.
 # Dry run first to see what would happen
 python3 migrate_icloud_to_gdrive.py --dry-run \
     --src ~/Documents/browser-visit-logger/snapshots \
-    --dst "~/Library/CloudStorage/GoogleDrive/My Drive/browser-visit-logger/snapshots" \
+    --dst "~/Library/CloudStorage/GoogleDrive-<account>/My Drive/browser-visit-logger/snapshots" \
     --db  ~/browser-visits.db
 
 # Run for real
 python3 migrate_icloud_to_gdrive.py \
     --src ~/Documents/browser-visit-logger/snapshots \
-    --dst "~/Library/CloudStorage/GoogleDrive/My Drive/browser-visit-logger/snapshots" \
+    --dst "~/Library/CloudStorage/GoogleDrive-<account>/My Drive/browser-visit-logger/snapshots" \
     --db  ~/browser-visits.db
 ```
 

--- a/browser-visit-tools/README.md
+++ b/browser-visit-tools/README.md
@@ -365,6 +365,8 @@ make -C ../browser-visit-sync-server build-linux GOARCH=amd64   # or arm64
 | `logs` | `journalctl` **snapshot** (`--lines`, `--since`); for a live tail use `aws ssm start-session` |
 | `health` | service active + gRPC port answers + disk under 90 % |
 | `enroll` | enrol (`--machine-id` + `--cert`), `--revoke`, or `--list` laptops in the server's `enrolled_machines.db` in place over SSM — fingerprint computed locally, no restart (the server re-reads the allowlist per request) |
+| `provision-drive` | mount the Google Drive snapshot archive on the VM via `rclone` + a service-account key (`--service-account`, `--root-folder-id`); installs + enables the `gdrive-snapshots` systemd mount unit (idempotent). See [issue #47](https://github.com/theimer/browser-visit-logger/issues/47) |
+| `drive-status` | read-only diagnostic: is Drive mounted, is the mount service up, and does the canonical DB show snapshot rows |
 
 ```bash
 # First-boot setup (TLS material passed as local PEM paths)
@@ -383,6 +385,11 @@ python3 manage_sync_server.py enroll --machine-id laptop-a \
     --cert ~/.browser-visit-logger/ca/laptop-a.crt
 python3 manage_sync_server.py enroll --list
 python3 manage_sync_server.py logs --lines 50
+
+# Mount the Google Drive snapshot archive on the VM, then verify it
+python3 manage_sync_server.py provision-drive \
+    --service-account gdrive-sa.json --root-folder-id 1AbC...xyz
+python3 manage_sync_server.py drive-status
 ```
 
 `provision --and-deploy --binary <path>` chains a deploy after

--- a/browser-visit-tools/README.md
+++ b/browser-visit-tools/README.md
@@ -365,7 +365,7 @@ make -C ../browser-visit-sync-server build-linux GOARCH=amd64   # or arm64
 | `logs` | `journalctl` **snapshot** (`--lines`, `--since`); for a live tail use `aws ssm start-session` |
 | `health` | service active + gRPC port answers + disk under 90 % |
 | `enroll` | enrol (`--machine-id` + `--cert`), `--revoke`, or `--list` laptops in the server's `enrolled_machines.db` in place over SSM — fingerprint computed locally, no restart (the server re-reads the allowlist per request) |
-| `provision-drive` | mount the Google Drive snapshot archive on the VM via `rclone` + a service-account key (`--service-account`, `--root-folder-id`); installs + enables the `gdrive-snapshots` systemd mount unit (idempotent). See [issue #47](https://github.com/theimer/browser-visit-logger/issues/47) |
+| `provision-drive` | mount the Google Drive snapshot archive on the VM via `rclone` + a service-account key (`--service-account`, `--root-folder-id` — the shared `snapshots` folder id); installs + enables the `gdrive-snapshots` systemd mount unit (idempotent). See [Google Drive service-account setup](#google-drive-service-account-setup) and [issue #47](https://github.com/theimer/browser-visit-logger/issues/47) |
 | `drive-status` | read-only diagnostic: is Drive mounted, is the mount service up, and does the canonical DB show snapshot rows |
 
 ```bash
@@ -387,10 +387,46 @@ python3 manage_sync_server.py enroll --list
 python3 manage_sync_server.py logs --lines 50
 
 # Mount the Google Drive snapshot archive on the VM, then verify it
+# (--root-folder-id is the shared `snapshots` folder — see setup below)
 python3 manage_sync_server.py provision-drive \
     --service-account gdrive-sa.json --root-folder-id 1AbC...xyz
 python3 manage_sync_server.py drive-status
 ```
+
+#### Google Drive service-account setup
+
+`provision-drive` authenticates the VM to Drive with a **service
+account** — a separate Google identity that can reach *only* what you
+explicitly share with it.  Sharing just the `snapshots` folder means a
+compromised VM can touch nothing else in your Drive (unlike an OAuth
+token minted from your own account, which would expose all of it).
+
+One-time steps:
+
+1. **GCP project + Drive API.**  In the [Google Cloud
+   Console](https://console.cloud.google.com/), pick or create a
+   project, then **APIs & Services → Library → Google Drive API →
+   Enable**.
+2. **Create the service account.**  **APIs & Services → Credentials →
+   Create credentials → Service account.**  Name it (e.g.
+   `bvl-vm-drive`); no roles/permissions are needed (its Drive access
+   comes from sharing, not IAM).  Note its email
+   (`bvl-vm-drive@<project>.iam.gserviceaccount.com`).
+3. **Download a JSON key.**  Open the service account → **Keys → Add key
+   → Create new key → JSON.**  Save it locally (this is the
+   `--service-account` file); treat it as a secret.
+4. **Share the `snapshots` folder.**  In Drive, open
+   `My Drive/browser-visit-logger/`, right-click the **`snapshots`**
+   subfolder → **Share**, add the service-account email as **Editor**.
+   (Editor, not Viewer — the VM verifier writes `MANIFEST.tsv`.)
+5. **Get the folder id.**  Open that `snapshots` folder in the browser;
+   the id is the last path segment of the URL
+   (`drive.google.com/drive/folders/<THIS>`).  That is
+   `--root-folder-id`.
+
+Then run `provision-drive … && drive-status`.  The key is uploaded to
+the VM SSE-encrypted through S3 and stored `0400` as `bvlsync`; the VM
+never opens an inbound port for any of this (all over SSM).
 
 `provision --and-deploy --binary <path>` chains a deploy after
 provisioning.  `deploy` refuses a binary whose arch token doesn't match

--- a/browser-visit-tools/install_laptop.sh
+++ b/browser-visit-tools/install_laptop.sh
@@ -8,8 +8,9 @@
 #      the BVLHost + extension manifest, with BVL_SKIP_VERIFIER=1 so
 #      install.sh does not re-install the verifier LaunchAgent.
 #   3. Materialize ~/.browser-visit-logger/config.json with the
-#      machine_id (sanitized LocalHostName), and ensure mTLS material
-#      is in place under ~/.browser-visit-logger/tls/.
+#      machine_id (sanitized LocalHostName) and the Google account that
+#      names the local Drive mount (GoogleDrive-<account>), and ensure
+#      mTLS material is in place under ~/.browser-visit-logger/tls/.
 #   4. Provision the sync runtime: a grpcio venv at
 #      ~/.browser-visit-logger/sync-venv (which BVLHost prefers when
 #      spawning sync_client.py) and the generated gRPC Python stubs.
@@ -17,6 +18,10 @@
 # Usage:
 #   bash browser-visit-tools/install_laptop.sh
 #   bash browser-visit-tools/install_laptop.sh --server bvl-vm.example.com:50443
+#   bash browser-visit-tools/install_laptop.sh --gdrive-account jane@gmail.com
+#
+# When --gdrive-account is omitted the script prompts for it (the Google
+# account is needed to locate the GoogleDrive-<account> Drive mount).
 
 set -euo pipefail
 
@@ -27,15 +32,26 @@ CONFIG_FILE="$CONFIG_DIR/config.json"
 TLS_DIR="$CONFIG_DIR/tls"
 
 SERVER=""
+GDRIVE_ACCOUNT=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --server) SERVER="$2"; shift 2 ;;
+    --gdrive-account) GDRIVE_ACCOUNT="$2"; shift 2 ;;
     -h|--help) sed -n '1,/^set -euo/p' "$0" | sed '$d'; exit 0 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
 
 info() { echo "[install-laptop] $*"; }
+
+# The macOS Google Drive mount is named GoogleDrive-<account>, so we need
+# the user's Google account to locate the shared snapshot archive.  Ask
+# for it when it wasn't supplied on the command line and we have a
+# terminal; otherwise leave it blank (it can be added to config.json
+# later).
+if [[ -z "$GDRIVE_ACCOUNT" && -t 0 ]]; then
+  read -r -p "[install-laptop] Google account for your Google Drive (e.g. jane@gmail.com): " GDRIVE_ACCOUNT
+fi
 
 info "Step 1/3: removing legacy verifier LaunchAgent (if present)"
 bash "$SCRIPT_DIR/uninstall_laptop_legacy.sh"
@@ -97,6 +113,20 @@ fi
 
 if [[ -f "$CONFIG_FILE" ]]; then
   info "config already exists at $CONFIG_FILE — leaving machine_id unchanged"
+  # Backfill the Google account into an existing config if the user
+  # supplied one and it isn't already recorded, so upgrades pick up the
+  # correct GoogleDrive-<account> archive path without a reinstall.
+  if [[ -n "$GDRIVE_ACCOUNT" ]]; then
+    python3 - <<PY
+import json, pathlib
+p = pathlib.Path("$CONFIG_FILE")
+cfg = json.loads(p.read_text())
+if cfg.get("gdrive_account") != "$GDRIVE_ACCOUNT":
+    cfg["gdrive_account"] = "$GDRIVE_ACCOUNT"
+    p.write_text(json.dumps(cfg, indent=2, sort_keys=True) + "\n")
+    print("[install-laptop] set gdrive_account=$GDRIVE_ACCOUNT in $CONFIG_FILE")
+PY
+  fi
 else
   python3 - <<PY
 import json, datetime, pathlib
@@ -106,6 +136,8 @@ cfg = {
 }
 if "$SERVER":
     cfg["sync_server"] = "$SERVER"
+if "$GDRIVE_ACCOUNT":
+    cfg["gdrive_account"] = "$GDRIVE_ACCOUNT"
 pathlib.Path("$CONFIG_FILE").write_text(json.dumps(cfg, indent=2, sort_keys=True) + "\n")
 PY
   info "wrote $CONFIG_FILE with machine_id=$MACHINE_ID"

--- a/browser-visit-tools/manage_sync_server.py
+++ b/browser-visit-tools/manage_sync_server.py
@@ -257,15 +257,20 @@ def cmd_drive_status(args):
     """Diagnostic: is Drive mounted, is the mount service up, and does the
     canonical DB show snapshot rows?  Always prints; never mutates."""
     _region, ssm, instance_id = _ssm_target(args)
+    # The rclone FUSE mount is owner-only (no allow_other), so probe it AS the
+    # mount owner (bvlsync).  SSM runs this script as root, and root touching a
+    # non-allow_other FUSE mount gets EACCES — a plain `mountpoint`/`ls` would
+    # falsely report "NOT mounted" even when the mount is live for bvlsync
+    # (which is the account the verifier runs under, so owner-only is enough).
     script = [
-        f'mountpoint -q {_GDRIVE_MOUNT} '
+        f'runuser -u bvlsync -- mountpoint -q {_GDRIVE_MOUNT} '
         f'&& echo "mount: mounted at {_GDRIVE_MOUNT}" '
         '|| echo "mount: NOT mounted"',
         'echo "service: $(systemctl is-active gdrive-snapshots.service '
         '2>/dev/null || echo absent)"',
-        f'echo "recent snapshot days on Drive:"; '
-        f'ls -1 {_GDRIVE_MOUNT} 2>/dev/null | tail -5 '
-        '|| echo "  (none / unreadable)"',
+        'echo "recent snapshot days on Drive:"; '
+        f'days=$(runuser -u bvlsync -- ls -1 {_GDRIVE_MOUNT} 2>/dev/null '
+        '| tail -5); echo "${days:-  (none yet)}"',
         'echo "snapshot rows in canonical DB:"; '
         f'python3 -c {shlex.quote(_SNAPSHOT_SUMMARY_PY)} {_SNAPSHOTS_DB}',
     ]

--- a/browser-visit-tools/manage_sync_server.py
+++ b/browser-visit-tools/manage_sync_server.py
@@ -11,6 +11,13 @@ Subcommands
                service.  Idempotent; safe to re-run.
     deploy     Cross-compiled binary → S3 → VM, install to
                /usr/local/bin/sync-server, restart the service.
+    provision-drive
+               Mount the Google Drive snapshot archive on the VM via
+               rclone + a service-account key, and install the systemd
+               mount unit.  Idempotent.  (See issue #47.)
+    drive-status
+               Report whether Drive is mounted, the mount service is up,
+               and the canonical DB holds snapshot rows.  Read-only.
     start      systemctl start sync-server
     stop       systemctl stop sync-server
     restart    systemctl restart sync-server
@@ -40,8 +47,9 @@ import _bvl_aws as aws
 import enroll_machine
 
 _HERE = Path(__file__).resolve().parent
-_UNIT_FILE = _HERE.parent / 'browser-visit-sync-server' / 'deploy' / \
-    'sync-server.service'
+_DEPLOY = _HERE.parent / 'browser-visit-sync-server' / 'deploy'
+_UNIT_FILE = _DEPLOY / 'sync-server.service'
+_MOUNT_UNIT_FILE = _DEPLOY / 'gdrive-snapshots.service'
 
 # state ``arch`` → Go GOARCH token expected in the built binary's name.
 _GOARCH = {'x86_64': 'amd64', 'arm64': 'arm64'}
@@ -49,6 +57,40 @@ _GOARCH = {'x86_64': 'amd64', 'arm64': 'arm64'}
 _DATA_DIR = '/var/lib/browser-visit-sync'
 _ETC_DIR = '/etc/browser-visit-sync'
 _ENROLLED_DB = f'{_DATA_DIR}/enrolled_machines.db'
+_SNAPSHOTS_DB = f'{_DATA_DIR}/browser-visits.db'
+
+# Google Drive snapshot mount (see issue #47).  rclone reaches Drive with a
+# service-account key so the VM needs no interactive OAuth; the mounted tree is
+# where the (future) VM-side verifier seals days and writes MANIFEST.tsv.
+_GDRIVE_MOUNT = '/mnt/gdrive-snapshots'
+_GDRIVE_SA = f'{_ETC_DIR}/gdrive-sa.json'
+_RCLONE_CONF = f'{_ETC_DIR}/rclone.conf'
+
+# Read-only DB probe for `drive-status`.  Uses the sqlite3 module (guaranteed on
+# AL2023) rather than the sqlite3 CLI (not installed), mirroring _ENROLL_PY.
+# argv: <db>.  Opened read-only so a concurrent write never blocks the probe.
+_SNAPSHOT_SUMMARY_PY = '''\
+import sqlite3, sys
+try:
+    c = sqlite3.connect("file:%s?mode=ro" % sys.argv[1], uri=True)
+    rows = c.execute("SELECT date, sealed FROM snapshots "
+                     "ORDER BY date DESC LIMIT 5").fetchall()
+    if not rows:
+        print("  (snapshots table empty)")
+    for d, s in rows:
+        print("  %s  sealed=%s" % (d, s))
+except Exception as e:
+    print("  (query failed: %s)" % e)
+'''
+
+
+def _rclone_conf(root_folder_id):
+    """rclone.conf body for the Drive remote, keyed off the service account."""
+    return ('[gdrive]\n'
+            'type = drive\n'
+            'scope = drive\n'
+            f'service_account_file = {_GDRIVE_SA}\n'
+            f'root_folder_id = {root_folder_id}\n')
 
 # Stdlib-only program run on the VM (Amazon Linux 2023 ships python3) to
 # mutate the server's allowlist in place.  argv: <db> <op> [machine_id] [fp].
@@ -159,6 +201,66 @@ def cmd_provision(args):
     if rc == 0 and args.and_deploy:
         return _deploy(region, ssm, instance_id, args)
     return rc
+
+
+def cmd_provision_drive(args):
+    """Mount the Google Drive snapshot archive on the VM via rclone + a
+    service-account key, and install the systemd mount unit.  Idempotent."""
+    sa = Path(os.path.expanduser(args.service_account))
+    if not sa.is_file():
+        print(f"error: service account key not found: {sa}", file=sys.stderr)
+        return 1
+    region, ssm, instance_id = _ssm_target(args)
+    s3, bucket = _stage_clients(region)
+    aws.upload_file(s3, _MOUNT_UNIT_FILE, bucket,
+                    'deploy/gdrive-snapshots.service')
+    aws.upload_file(s3, sa, bucket, 'gdrive/gdrive-sa.json', encrypt=True)
+    conf = _rclone_conf(args.root_folder_id)
+    script = [
+        'set -euo pipefail',
+        'command -v rclone >/dev/null || dnf install -y rclone fuse3',
+        # The mountpoint is made by root and handed to the service account, so
+        # rclone (running as bvlsync) can mount onto a directory it owns.
+        f'mkdir -p {_GDRIVE_MOUNT}',
+        f'chown bvlsync:bvlsync {_GDRIVE_MOUNT}',
+        f'aws s3 cp s3://{bucket}/gdrive/gdrive-sa.json {_GDRIVE_SA}',
+        f'printf %s {shlex.quote(conf)} > {_RCLONE_CONF}',
+        f'aws s3 cp s3://{bucket}/deploy/gdrive-snapshots.service '
+        '/etc/systemd/system/gdrive-snapshots.service',
+        # The key and remote config are secrets: owned by the service account,
+        # unreadable to anyone else.
+        f'chown bvlsync:bvlsync {_GDRIVE_SA} {_RCLONE_CONF}',
+        f'chmod 400 {_GDRIVE_SA}',
+        f'chmod 600 {_RCLONE_CONF}',
+        'systemctl daemon-reload',
+        'systemctl enable --now gdrive-snapshots',
+    ]
+    rc = _surface(aws.run_remote(ssm, instance_id, script,
+                                 comment='bvl provision-drive'))
+    if rc == 0:
+        print(f"drive mount provisioned at {_GDRIVE_MOUNT}; "
+              "run `drive-status` to verify")
+    return rc
+
+
+def cmd_drive_status(args):
+    """Diagnostic: is Drive mounted, is the mount service up, and does the
+    canonical DB show snapshot rows?  Always prints; never mutates."""
+    _region, ssm, instance_id = _ssm_target(args)
+    script = [
+        f'mountpoint -q {_GDRIVE_MOUNT} '
+        f'&& echo "mount: mounted at {_GDRIVE_MOUNT}" '
+        '|| echo "mount: NOT mounted"',
+        'echo "service: $(systemctl is-active gdrive-snapshots.service '
+        '2>/dev/null || echo absent)"',
+        f'echo "recent snapshot days on Drive:"; '
+        f'ls -1 {_GDRIVE_MOUNT} 2>/dev/null | tail -5 '
+        '|| echo "  (none / unreadable)"',
+        'echo "snapshot rows in canonical DB:"; '
+        f'python3 -c {shlex.quote(_SNAPSHOT_SUMMARY_PY)} {_SNAPSHOTS_DB}',
+    ]
+    return _surface(aws.run_remote(ssm, instance_id, script,
+                                   comment='bvl drive-status'))
 
 
 def _check_arch(binary):
@@ -300,6 +402,7 @@ _DISPATCH = {
     'provision': cmd_provision, 'deploy': cmd_deploy, 'start': cmd_start,
     'stop': cmd_stop, 'restart': cmd_restart, 'status': cmd_status,
     'logs': cmd_logs, 'health': cmd_health, 'enroll': cmd_enroll,
+    'provision-drive': cmd_provision_drive, 'drive-status': cmd_drive_status,
 }
 
 
@@ -334,6 +437,18 @@ def _build_parser():
                            ('status', 'service status'),
                            ('health', 'end-to-end health probe')):
         with_region(sub.add_parser(name, help=helptext))
+
+    pdr = with_region(sub.add_parser(
+        'provision-drive',
+        help='mount the Google Drive snapshot archive on the VM (rclone)'))
+    pdr.add_argument('--service-account', required=True,
+                     help='path to the Google service-account JSON key')
+    pdr.add_argument('--root-folder-id', required=True,
+                     help='Drive folder id of the browser-visit-logger root')
+
+    with_region(sub.add_parser(
+        'drive-status',
+        help='report whether Drive is mounted and holds snapshot data'))
 
     pl = with_region(sub.add_parser('logs', help='journalctl snapshot'))
     pl.add_argument('--lines', type=int, default=100,

--- a/browser-visit-tools/manage_sync_server.py
+++ b/browser-visit-tools/manage_sync_server.py
@@ -85,7 +85,17 @@ except Exception as e:
 
 
 def _rclone_conf(root_folder_id):
-    """rclone.conf body for the Drive remote, keyed off the service account."""
+    """rclone.conf body for the Drive remote, keyed off the service account.
+
+    `scope = drive` is the token's capability (read/write), NOT which files
+    it can see: a service account can only reach items explicitly shared with
+    its address.  We share only the `snapshots` folder, so that is the whole
+    universe the VM can touch.  (The narrower `drive.file` scope is unusable
+    here — it restricts to files the app itself created, but the snapshots are
+    created by the laptop, a different identity.)  `root_folder_id` pins the
+    remote root to that shared folder so the mount lands directly on the
+    date-directory tree.
+    """
     return ('[gdrive]\n'
             'type = drive\n'
             'scope = drive\n'
@@ -444,7 +454,8 @@ def _build_parser():
     pdr.add_argument('--service-account', required=True,
                      help='path to the Google service-account JSON key')
     pdr.add_argument('--root-folder-id', required=True,
-                     help='Drive folder id of the browser-visit-logger root')
+                     help='Drive folder id of the shared `snapshots` folder '
+                          '(from its Drive URL)')
 
     with_region(sub.add_parser(
         'drive-status',

--- a/browser-visit-tools/migrate_icloud_to_gdrive.py
+++ b/browser-visit-tools/migrate_icloud_to_gdrive.py
@@ -21,7 +21,7 @@ Usage
 -----
     migrate_icloud_to_gdrive.py \\
         --src ~/Documents/browser-visit-logger/snapshots \\
-        --dst "~/Library/CloudStorage/GoogleDrive/My Drive/browser-visit-logger/snapshots" \\
+        --dst "~/Library/CloudStorage/GoogleDrive-<account>/My Drive/browser-visit-logger/snapshots" \\
         --db  ~/browser-visits.db
 
     # Dry run — print what would be copied / what SQL would be emitted

--- a/browser-visit-tools/tests/test_manage_sync_server.py
+++ b/browser-visit-tools/tests/test_manage_sync_server.py
@@ -232,6 +232,9 @@ def test_drive_status_is_read_only(monkeypatch):
     assert mss.cmd_drive_status(_args('drive-status')) == 0
     cmds = '\n'.join(runner.last_commands())
     assert f'mountpoint -q {mss._GDRIVE_MOUNT}' in cmds
+    # Probed as the mount owner, not root — a root-run mountpoint on an
+    # owner-only FUSE mount gets EACCES and falsely reports "NOT mounted".
+    assert 'runuser -u bvlsync -- mountpoint' in cmds
     assert 'is-active gdrive-snapshots.service' in cmds
     assert 'SELECT date, sealed FROM snapshots' in cmds
     # a diagnostic never mutates: no writes, no chown, no service control.

--- a/browser-visit-tools/tests/test_manage_sync_server.py
+++ b/browser-visit-tools/tests/test_manage_sync_server.py
@@ -190,6 +190,56 @@ def test_provision_and_deploy(monkeypatch, tmp_path):
 
 
 # --------------------------------------------------------------------------
+# provision-drive / drive-status  (issue #47)
+# --------------------------------------------------------------------------
+
+def _drive_args(service_account, root_folder_id='folder-123'):
+    return argparse.Namespace(
+        action='provision-drive', region=None,
+        service_account=str(service_account), root_folder_id=root_folder_id)
+
+
+def test_provision_drive_success(monkeypatch, tmp_path, capsys):
+    sa = tmp_path / 'gdrive-sa.json'
+    sa.write_text('{"type":"service_account"}')
+    runner, uploads = _patch(monkeypatch)
+    assert mss.cmd_provision_drive(_drive_args(sa)) == 0
+    # mount unit + service-account key uploaded; the KEY (and only it) is SSE'd.
+    keys = [u[1] for u in uploads]
+    assert 'deploy/gdrive-snapshots.service' in keys
+    assert 'gdrive/gdrive-sa.json' in keys
+    assert {u[1] for u in uploads if u[2]} == {'gdrive/gdrive-sa.json'}
+    cmds = '\n'.join(runner.last_commands())
+    # installs rclone, writes the remote config with the given folder id,
+    # locks down the secret, and brings the mount up now.
+    assert 'dnf install -y rclone' in cmds
+    assert 'folder-123' in cmds and mss._RCLONE_CONF in cmds
+    assert f'chmod 400 {mss._GDRIVE_SA}' in cmds
+    assert 'systemctl enable --now gdrive-snapshots' in cmds
+    assert 'drive-status' in capsys.readouterr().out
+
+
+def test_provision_drive_missing_key(monkeypatch, tmp_path, capsys):
+    _patch(monkeypatch)
+    assert mss.cmd_provision_drive(_drive_args(tmp_path / 'absent.json')) == 1
+    assert 'service account key not found' in capsys.readouterr().err
+    # bailed before touching AWS
+    assert _patch.waited == []
+
+
+def test_drive_status_is_read_only(monkeypatch):
+    runner, _ = _patch(monkeypatch)
+    assert mss.cmd_drive_status(_args('drive-status')) == 0
+    cmds = '\n'.join(runner.last_commands())
+    assert f'mountpoint -q {mss._GDRIVE_MOUNT}' in cmds
+    assert 'is-active gdrive-snapshots.service' in cmds
+    assert 'SELECT date, sealed FROM snapshots' in cmds
+    # a diagnostic never mutates: no writes, no chown, no service control.
+    assert 'chown' not in cmds
+    assert 'systemctl enable' not in cmds and 'systemctl restart' not in cmds
+
+
+# --------------------------------------------------------------------------
 # deploy
 # --------------------------------------------------------------------------
 

--- a/docs/MULTI_LAPTOP_SETUP.md
+++ b/docs/MULTI_LAPTOP_SETUP.md
@@ -388,7 +388,7 @@ Files & Folders (TCC) prompts the first time you tag a page.
 > ```bash
 > python3 browser-visit-tools/migrate_icloud_to_gdrive.py --dry-run \
 >     --src ~/Documents/browser-visit-logger/snapshots \
->     --dst "~/Library/CloudStorage/GoogleDrive/My Drive/browser-visit-logger/snapshots" \
+>     --dst "~/Library/CloudStorage/GoogleDrive-<account>/My Drive/browser-visit-logger/snapshots" \
 >     --db  ~/browser-visits.db
 > ```
 >


### PR DESCRIPTION
Addresses the mount + observability half of #47, and fixes a
silent-data-loss bug found along the way. The VM-side sealer/verifier
(the piece that makes the canonical DB's `snapshots` table non-empty) is
a follow-up on this same branch.

## What this does

**Puts the Google Drive snapshot archive on the VM.**
- `gdrive-snapshots.service`: an rclone FUSE mount (`Type=notify`, runs
  as `bvlsync`) of the shared Drive `snapshots` folder at
  `/mnt/gdrive-snapshots`.
- `manage_sync_server.py provision-drive`: installs rclone, pushes a
  service-account key (SSE'd through S3) + a generated `rclone.conf`,
  installs and enables the mount unit. Idempotent, all over SSM.
- `manage_sync_server.py drive-status`: read-only diagnostic — is Drive
  mounted, is the mount service up, which day-folders are visible, and
  does the canonical DB show `snapshots` rows. Probes as `bvlsync` (the
  owner-only FUSE mount is invisible to a root-run `mountpoint`).

**Least-privilege auth:** a Google service account shared *only* the
`snapshots` folder, so a compromised VM can reach nothing else in the
user's Drive (vs. an OAuth token minted from the user's own account,
which would expose all of it). README documents the click-by-click
setup.

**Fixes the archive-path bug (`GoogleDrive-<account>`).** The macOS
Drive client mounts at `~/Library/CloudStorage/GoogleDrive-<account>/My
Drive`, not a bare `GoogleDrive/My Drive`. The old hardcoded default
pointed at a directory that isn't a Drive mount:
- `Paths.archiveSnapshotsDir()` now builds the account-qualified path
  from `BVL_GDRIVE_ACCOUNT` / `gdrive_account` in the machine config
  (the durable channel that reaches the Chrome-spawned host).
- It **throws** instead of falling back to the unqualified name: that
  fallback would `createDirectory()` a local-only tree Drive never
  syncs, copy the snapshot in, then unlink the staged source — silent
  loss. Callers now fail safely (mover records a `move` error and leaves
  the source staged; verify/seal passes skip).
- `install_laptop.sh` grows `--gdrive-account` (prompts when a TTY is
  present) and records it in `config.json`.

## Verified on a live VM

`provision-drive` + `drive-status` against the real instance now report
`mount: mounted`, `service: active`, and list day-folders visible on
Drive — including folders created *after* the laptop-side fix, proving
the end-to-end path (laptop → Drive → VM mount) works.

Tools suite 179 passed, logger suite 227 passed; Swift builds clean.

## Not in this PR (follow-up)

The VM-side sealer/verifier timer that reads `/mnt/gdrive-snapshots`,
seals completed UTC days, writes `MANIFEST.tsv`, and populates
`snapshots.sealed`. Until it lands, `drive-status`'s DB line stays
`(snapshots table empty)` — the mount has the files, nothing consumes
them yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
