### PR TITLE
Fix sealer: drop host dependency + honest seal count

### DIFF
--- a/browser-visit-logger/tests/test_snapshot_mover.py
+++ b/browser-visit-logger/tests/test_snapshot_mover.py
@@ -1,9 +1,9 @@
 """
-Unit tests for the Python helpers in native-host/snapshot_mover.py.
+Unit tests for the Python helpers in browser-visit-snapshot-lib/snapshot_mover.py.
 
-After the Swift port these helpers are imported only by
-snapshot_sealer.py and visits_rebuilder.py.  This module covers them
-in three layers:
+After the Swift port these helpers are imported by the laptop tools
+snapshot_sealer.py and visits_rebuilder.py, and by the VM seal pass
+seal_completed_days.py.  This module covers them in three layers:
 
   1. Bare schema / utility tests (TestTodayUtc, TestSnapshotsTable
      Schema, TestMoverErrorsSchema) for in-memory smoke coverage.
@@ -22,6 +22,7 @@ import datetime
 import errno
 import os
 import sqlite3
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -54,6 +55,36 @@ class TestTodayUtc(unittest.TestCase):
 
     def test_returns_a_date_object(self):
         self.assertIsInstance(snapshot_mover._today_utc(), datetime.date)
+
+
+# ---------------------------------------------------------------------------
+# The ensure-table helpers must not depend on host.py (the VM has no host);
+# reproduces the deploy bug where they lazily `import host`.
+# ---------------------------------------------------------------------------
+class TestEnsureTablesHostIndependent(unittest.TestCase):
+
+    def test_ensure_tables_without_host_importable(self):
+        import builtins
+        real_import = builtins.__import__
+
+        def blocked(name, *a, **k):
+            if name == 'host':
+                raise ModuleNotFoundError("host blocked (simulating the VM)")
+            return real_import(name, *a, **k)
+
+        saved = sys.modules.pop('host', None)
+        builtins.__import__ = blocked
+        try:
+            conn = sqlite3.connect(':memory:')
+            snapshot_mover._ensure_snapshots_table(conn)
+            snapshot_mover._ensure_mover_errors_table(conn)
+            tables = {r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'")}
+            self.assertLessEqual({'snapshots', 'mover_errors'}, tables)
+        finally:
+            builtins.__import__ = real_import
+            if saved is not None:
+                sys.modules['host'] = saved
 
 
 # ---------------------------------------------------------------------------

--- a/browser-visit-snapshot-lib/snapshot_mover.py
+++ b/browser-visit-snapshot-lib/snapshot_mover.py
@@ -108,32 +108,47 @@ _LOG_FILENAME_RE = re.compile(r'^browser-visits-(\d{4}-\d{2}-\d{2})\.log$')
 
 
 # ---------------------------------------------------------------------------
-# Schema for the `snapshots` table — co-owned by host.py (Python) and
-# the Swift production code.  Sealer needs to ensure it exists before
-# upserting.
+# DDL for the two tables the sealer manages.  Kept self-contained (no
+# dependency on host.py / schema.sql) so this shared library works wherever
+# it runs — including the VM, which has neither.  These mirror the canonical
+# definitions in browser-visit-logger/schema.sql (and, for snapshots, the
+# sync-server's store.go); all three are trivial and stable.  IF NOT EXISTS
+# makes them idempotent and harmless where the table already exists (e.g. the
+# VM, where the sync-server creates `snapshots`).
 # ---------------------------------------------------------------------------
 
-def _ensure_snapshots_table(conn: sqlite3.Connection) -> None:
-    """Create the snapshots table if absent.
+_SNAPSHOTS_DDL = """\
+CREATE TABLE IF NOT EXISTS snapshots (
+    date   TEXT PRIMARY KEY,
+    sealed INTEGER NOT NULL DEFAULT 0
+);"""
 
-    DDL lives in schema.sql; we just exec it via host._load_schema_sql.
-    Idempotent because every CREATE there uses IF NOT EXISTS.
-    """
-    import host
-    conn.executescript(host._load_schema_sql())
+_MOVER_ERRORS_DDL = """\
+CREATE TABLE IF NOT EXISTS mover_errors (
+    key        TEXT PRIMARY KEY,
+    operation  TEXT NOT NULL,
+    target     TEXT NOT NULL,
+    message    TEXT NOT NULL,
+    first_seen TEXT NOT NULL,
+    last_seen  TEXT NOT NULL,
+    attempts   INTEGER NOT NULL DEFAULT 1,
+    notified   INTEGER NOT NULL DEFAULT 0,
+    immediate  INTEGER NOT NULL DEFAULT 0
+);"""
+
+
+def _ensure_snapshots_table(conn: sqlite3.Connection) -> None:
+    """Create the snapshots table if absent.  Idempotent."""
+    conn.executescript(_SNAPSHOTS_DDL)
     conn.commit()
 
 
-# ---------------------------------------------------------------------------
-# Schema for the `mover_errors` table — tracks unresolved failures.
 # Reached transitively from `_build_manifest_rows` via `_try_record_error`,
-# so the sealer needs the table present before sealing a dir that has
-# any non-conforming filenames or orphan files.  DDL lives in schema.sql.
-# ---------------------------------------------------------------------------
-
+# so the sealer needs this table present before sealing a dir that has any
+# non-conforming filenames or orphan files.
 def _ensure_mover_errors_table(conn: sqlite3.Connection) -> None:
-    import host
-    conn.executescript(host._load_schema_sql())
+    """Create the mover_errors table if absent.  Idempotent."""
+    conn.executescript(_MOVER_ERRORS_DDL)
     conn.commit()
 
 

--- a/browser-visit-sync-server/sealer/seal_completed_days.py
+++ b/browser-visit-sync-server/sealer/seal_completed_days.py
@@ -121,16 +121,29 @@ def cli(argv=None):
         return 0
 
     conn = sqlite3.connect(snapshot_mover.DB_FILE)
+    sealed = 0
     try:
         snapshot_mover._ensure_snapshots_table(conn)
         snapshot_mover._ensure_mover_errors_table(conn)
         for name, subdir in candidates:
             snapshot_mover._seal_directory(conn, subdir, date_key=name)
+            # _seal_directory swallows errors into mover_errors; the
+            # snapshots row flips to sealed=1 only on success, so count that
+            # rather than the number attempted.
+            row = conn.execute(
+                "SELECT sealed FROM snapshots WHERE date = ?", (name,)
+            ).fetchone()
+            if row and row[0] == 1:
+                sealed += 1
     finally:
         conn.close()
-    print(f'sealed {len(candidates)} director'
-          f'{"y" if len(candidates) == 1 else "ies"}')
-    return 0
+    failed = len(candidates) - sealed
+    msg = f'sealed {sealed} of {len(candidates)} director' \
+          f'{"y" if len(candidates) == 1 else "ies"}'
+    if failed:
+        msg += f' ({failed} failed — see mover_errors)'
+    print(msg)
+    return 1 if failed else 0
 
 
 if __name__ == '__main__':  # pragma: no cover


### PR DESCRIPTION
Found by deploying the VM sealer.

**1. Shared lib depended on host.py.** `_ensure_snapshots_table` / `_ensure_mover_errors_table` lazily `import host` and ran the full schema via `host._load_schema_sql()` — needing host.py + schema.sql, neither on the VM. Replaced with self-contained DDL for the two sealer-owned tables (trivial, sentinel-free, mirror schema.sql). Fully severs the shared lib from the laptop `host` module. Regression test blocks `import host` to reproduce the VM.

**2. Misleading count.** `seal_completed_days` printed 'sealed N' for directories *attempted*; `_seal_directory` swallows failures into `mover_errors`. Now counts rows that actually reached `sealed=1`, reports 'sealed X of N (Y failed)', and exits non-zero on failure.

Logger suite 234 + regression, all green. Separately, deploying surfaced that the **service account cannot write to a personal My Drive** (Google 403 storageQuotaExceeded) — an auth-model decision tracked outside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)